### PR TITLE
Fix for generators on windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@playcanvas/supersplat-viewer": "^1.5.0",
-        "webgpu": "^0.3.6"
+        "webgpu": "^0.3.5"
       },
       "bin": {
         "splat-transform": "bin/cli.mjs"
@@ -1374,9 +1374,9 @@
       ]
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.65",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.65.tgz",
-      "integrity": "sha512-cYrHab4d6wuVvDW5tdsfI6/o6vcLMDe6w2Citd1oS51Xxu2ycLCnVo4fqwujfKWijrZMInTJIKcXxteoy21nVA==",
+      "version": "0.1.64",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.64.tgz",
+      "integrity": "sha512-84kRIAGV46LJTlJZWxShiOrNL30A+9KokD7RB3dRCIqODFjodS5tCD5yyiZ8kIReGVZSDfA3XkkwyyOIF6K62A==",
       "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
@@ -5337,13 +5337,13 @@
       "optional": true
     },
     "node_modules/webgpu": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/webgpu/-/webgpu-0.3.6.tgz",
-      "integrity": "sha512-9vWmCwcIpvshJyVVQ75+nnFj4aTDpqtOMZJG9lGy0bdUeGmbvbrNabCprsZUkJZm86ez8010awOrMnNokpqpLQ==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/webgpu/-/webgpu-0.3.5.tgz",
+      "integrity": "sha512-9nGMfGHEoMpAI5s8ZTMpaTF/Hk2vdUB6SJOuHtPp0PUXQgaBtJVs/oQqfI7BfVts4Tbrk01atU13EiLn1a/ayA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@webgpu/types": "^0.1.65",
+        "@webgpu/types": "^0.1.61",
         "debug": "^4.4.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@playcanvas/supersplat-viewer": "^1.5.0",
-        "webgpu": "^0.3.5"
+        "webgpu": "^0.3.0"
       },
       "bin": {
         "splat-transform": "bin/cli.mjs"
@@ -1886,6 +1886,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3853,6 +3854,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/napi-build-utils": {
@@ -5337,14 +5339,12 @@
       "optional": true
     },
     "node_modules/webgpu": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/webgpu/-/webgpu-0.3.5.tgz",
-      "integrity": "sha512-9nGMfGHEoMpAI5s8ZTMpaTF/Hk2vdUB6SJOuHtPp0PUXQgaBtJVs/oQqfI7BfVts4Tbrk01atU13EiLn1a/ayA==",
-      "hasInstallScript": true,
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/webgpu/-/webgpu-0.3.0.tgz",
+      "integrity": "sha512-oDhJlZFFwCxgkHpVVfJn1+S0qsEJSZX9eDCjQCswCkXF2FYklApU974DybGAdBQSpS32XXUtbo31i7HJSYCJow==",
       "license": "MIT",
       "dependencies": {
-        "@webgpu/types": "^0.1.61",
-        "debug": "^4.4.0"
+        "@webgpu/types": "^0.1.61"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@playcanvas/supersplat-viewer": "^1.5.0",
-    "webgpu": "^0.3.5"
+    "webgpu": "^0.3.0"
   },
   "scripts": {
     "build": "rollup -c",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@playcanvas/supersplat-viewer": "^1.5.0",
-    "webgpu": "^0.3.6"
+    "webgpu": "^0.3.5"
   },
   "scripts": {
     "build": "rollup -c",

--- a/src/gpu/gpu-device.ts
+++ b/src/gpu/gpu-device.ts
@@ -119,7 +119,7 @@ const createDevice = async () => {
 
     const graphicsDevice = new WebgpuGraphicsDevice(canvas, {
         antialias: false,
-        depth: true,
+        depth: false,
         stencil: false
     });
 

--- a/src/gpu/gpu-device.ts
+++ b/src/gpu/gpu-device.ts
@@ -119,7 +119,7 @@ const createDevice = async () => {
 
     const graphicsDevice = new WebgpuGraphicsDevice(canvas, {
         antialias: false,
-        depth: false,
+        depth: true,
         stencil: false
     });
 

--- a/src/readers/read-mjs.ts
+++ b/src/readers/read-mjs.ts
@@ -20,7 +20,7 @@ type Generator = {
 };
 
 const readMjs = async (filename: string, params: Param[]): Promise<SplatData> => {
-    const module = await import(filename);
+    const module = await import(`file://${filename}`);
     if (!module) {
         throw new Error(`Failed to load module: ${filename}`);
     }


### PR DESCRIPTION
Windows requires file urls be specified with `file://`.

(Also revert back to webgpu 0.3.0 since the latest doesn't work on windows, see [here](https://github.com/dawn-gpu/node-webgpu/issues/10)).