### PR TITLE
Add library exports for programmatic usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,15 @@
     "typescript"
   ],
   "license": "MIT",
+  "main": "./dist/lib.mjs",
+  "module": "./dist/lib.mjs",
+  "types": "./dist/lib.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/lib.d.ts",
+      "import": "./dist/lib.mjs"
+    }
+  },
   "bin": {
     "splat-transform": "bin/cli.mjs"
   },

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -19,6 +19,28 @@ const application = {
     cache: false
 };
 
+const library = {
+    input: 'src/lib.ts',
+    output: {
+        dir: 'dist',
+        format: 'esm',
+        sourcemap: true,
+        entryFileNames: '[name].mjs'
+    },
+    external: ['webgpu'],
+    plugins: [
+        typescript({
+            tsconfig: './tsconfig.json',
+            declaration: true,
+            declarationDir: './dist'
+        }),
+        resolve(),
+        json()
+    ],
+    cache: false
+};
+
 export default [
-    application
+    application,
+    library
 ];

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,0 +1,28 @@
+/**
+ * Library exports for programmatic use of @playcanvas/splat-transform
+ */
+
+export { Column, DataTable } from './data-table';
+export type { TypedArray } from './data-table';
+
+export { transform } from './transform';
+export { generateOrdering } from './ordering';
+
+export { readPly } from './readers/read-ply';
+export type { PlyData } from './readers/read-ply';
+export { writePly } from './writers/write-ply';
+
+export { readKsplat } from './readers/read-ksplat';
+export { readLcc } from './readers/read-lcc';
+export { readMjs } from './readers/read-mjs';
+export { readSog } from './readers/read-sog';
+export { readSplat } from './readers/read-splat';
+export { readSpz } from './readers/read-spz';
+export { isCompressedPly, decompressPly } from './readers/decompress-ply';
+
+export { writeCsv } from './writers/write-csv';
+export { writeHtml } from './writers/write-html';
+export { writeLod } from './writers/write-lod';
+export { writeSog } from './writers/write-sog';
+export { writeCompressedPly } from './writers/write-compressed-ply';
+export { CompressedChunk } from './writers/compressed-chunk';


### PR DESCRIPTION
Add library entry point (src/lib.ts) that exports utilities for programmatic consumption. This allows using splat-transform as a library, not just as a CLI tool.

Changes:
- Add src/lib.ts with exports for DataTable, Column, readers, writers
- Update rollup.config.mjs to build library bundle to lib/
- Update package.json with main, module, types, and exports fields
- Add lib/ to .gitignore to exclude build artifacts

Related to https://github.com/playcanvas/splat-transform/issues/71

- [x] I confirm I have read the [contributing guidelines](https://github.com/splat-transform/splat-transform/blob/main/.github/CONTRIBUTING.md)
