### PR TITLE
Lcc fix

### DIFF
--- a/src/readers/read-lcc.ts
+++ b/src/readers/read-lcc.ts
@@ -445,7 +445,7 @@ const readLcc = async (fileHandle: FileHandle, sourceName: string, options: Opti
             return true;
         }
 
-        // check attributes to determine whether SH is present or not
+        // before version 4 sh seems to have always been present, but we test for shcoef attribute anyway
         return lccJson.attributes.findIndex((attr: any) => attr.name === 'shcoef') !== -1;
     };
 


### PR DESCRIPTION
This PR fixes the older versions of lcc format. It seems before version 4, lcc never had "fileType" member.

It seems like earlier versions:
- spherical harmonics was always present
- the environment attribute bounds (color, sh, scale) were shared with the main bounds

It would be nice to confirm these assumptions, but at least with this change we can also convert the older example LCC files.