### PR TITLE
Fix type error on early termination of kmeans for very small datasets.

### DIFF
--- a/src/utils/k-means.ts
+++ b/src/utils/k-means.ts
@@ -138,7 +138,10 @@ const kmeans = async (points: DataTable, k: number, iterations: number, device?:
     if (points.numRows < k) {
         return {
             centroids: points.clone(),
-            labels: new Array(points.numRows).fill(0).map((_, i) => i)
+            // use a typed array here so downstream code can rely on
+            // labels supporting subarray(), even in this early-return
+            // path used for very small datasets.
+            labels: new Uint32Array(points.numRows).map((_, i) => i)
         };
     }
 


### PR DESCRIPTION
Fixes #
Updating the k-means early-exit path to always return a TypedArray for labels, avoiding `labels.subarray` TypeError.

This PR fixes a runtime error:

> `TypeError: labels.subarray is not a function`

by ensuring that `kmeans` consistently returns a `Uint32Array` for `labels`, even in the early-return case when `points.numRows < k`.

Previously, the early-exit path returned a plain JavaScript array:

```ts
return {
  centroids: points.clone(),
  labels: new Array(points.numRows).fill(0).map((_, i) => i)
};
```

Downstream code assumes `labels` is a typed array and calls methods like `subarray()`. This worked for the normal path (where `labels` is created as `new Uint32Array(points.numRows)`), but failed for very small datasets that hit the early return.

The code now uses a `Uint32Array` in that branch as well:

```ts
return {
  centroids: points.clone(),
  // use a typed array here so downstream code can rely on
  // labels supporting subarray(), even in this early-return
  // path used for very small datasets.
  labels: new Uint32Array(points.numRows).map((_, i) => i)
};
```

This makes the return type of `labels` consistent across all code paths and prevents the `labels.subarray` TypeError for small datasets.

- [x] I confirm I have read the [contributing guidelines](https://github.com/splat-transform/splat-transform/blob/main/.github/CONTRIBUTING.md)