### PR TITLE
Remove Node.js Buffer dependency in favor of Uint8Array

### DIFF
--- a/src/lib/utils/webp-codec.ts
+++ b/src/lib/utils/webp-codec.ts
@@ -37,7 +37,7 @@ class WebPCodec {
         Module._webp_free(outPtr);
         Module._free(inPtr); Module._free(outPtrPtr); Module._free(outSizePtr);
 
-        return Buffer.from(bytes);
+        return bytes;
     }
 
     decodeRGBA(webp: Uint8Array): { rgba: Uint8Array, width: number, height: number } {


### PR DESCRIPTION
## Remove Node.js Buffer dependency in favor of Uint8Array

This PR refactors the library to use the standard `Uint8Array` API instead of Node.js-specific `Buffer` methods, improving browser compatibility.

### Changes

- **webp-codec.ts**: Return the raw `Uint8Array` from `encodeRGBA()` instead of wrapping it in a `Buffer`
- **write-ply.ts**: Replace `Buffer` operations with `Uint8Array` equivalents:
  - `Buffer.from()` → `new Uint8Array(buffer, byteOffset, byteLength)`
  - `Buffer.alloc()` → `new Uint8Array(size)`
  - `buffer.copy()` → `typedArray.set()` with `subarray()`

### Why

`Uint8Array` is part of the standard JavaScript API and works in both Node.js and browser environments. `Buffer` is Node.js-specific and requires polyfills in browsers. This change makes the library more portable without requiring `Buffer` polyfills.