### PR TITLE
Add configurable WASM URL for browser bundler compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     ".": {
       "import": "./dist/index.mjs",
       "types": "./dist/lib/index.d.ts"
-    }
+    },
+    "./lib/*": "./lib/*"
   },
   "bin": {
     "splat-transform": "bin/cli.mjs"

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -46,3 +46,6 @@ export type { Options, Param } from './types';
 // Logger
 export { logger } from './utils/logger';
 export type { Logger } from './utils/logger';
+
+// WebP codec (for browser WASM configuration)
+export { WebPCodec } from './utils/webp-codec';

--- a/src/lib/utils/webp-codec.ts
+++ b/src/lib/utils/webp-codec.ts
@@ -1,16 +1,27 @@
 import createModule from '../../../lib/webp.mjs';
 
 class WebPCodec {
+    /**
+     * URL to the webp.wasm file. Set this before any SOG read/write operations
+     * in browser environments where the default path resolution doesn't work.
+     *
+     * @example
+     * import { WebPCodec } from '@playcanvas/splat-transform';
+     * import wasmUrl from '@playcanvas/splat-transform/lib/webp.wasm?url';
+     * WebPCodec.wasmUrl = wasmUrl;
+     */
+    static wasmUrl: string | null = null;
+
     Module: any;
 
     static async create() {
         const instance = new WebPCodec();
         instance.Module = await createModule({
             locateFile: (path: string) => {
-                if (path.endsWith('.wasm')) {
-                    return new URL(`../lib/${path}`, import.meta.url).toString();
+                if (path.endsWith('.wasm') && WebPCodec.wasmUrl) {
+                    return WebPCodec.wasmUrl;
                 }
-                return path;
+                return new URL(`../lib/${path}`, import.meta.url).toString();
             }
         });
         return instance;


### PR DESCRIPTION
## Add configurable WASM URL for browser bundler compatibility

This PR enables browser-based bundlers (Vite, Webpack, etc.) to properly locate and bundle the WebP WASM file by:

- Exporting the `WebPCodec` class from the public API
- Adding a static `wasmUrl` property to configure the WASM file path
- Adding a package export for the `lib/` directory to allow direct WASM imports

### Changes

- **WebPCodec.wasmUrl**: New static property to configure the WASM file URL before SOG read/write operations
- **Package exports**: Added `./lib/*` export mapping for direct access to `webp.wasm`

### Usage

For bundlers that require explicit WASM URL handling:

```typescript
import { WebPCodec } from '@playcanvas/splat-transform';
import wasmUrl from '@playcanvas/splat-transform/lib/webp.wasm?url';

WebPCodec.wasmUrl = wasmUrl;
````

This should be called once at application startup, before any SOG file operations.
