### PR TITLE
Restore Publint for Publishing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "eslint-import-resolver-typescript": "4.4.4",
         "pathe": "^2.0.3",
         "playcanvas": "2.14.4",
+        "publint": "0.3.16",
         "rollup": "4.54.0",
         "tslib": "2.8.1",
         "typescript": "5.9.3"
@@ -324,6 +325,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@publint/pack": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@publint/pack/-/pack-0.1.2.tgz",
+      "integrity": "sha512-S+9ANAvUmjutrshV4jZjaiG8XQyuJIZ8a4utWmN/vW1sgQ9IfBnPndwkmQYw53QmouOIytT874u65HEmu6H5jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://bjornlu.com/sponsor"
       }
     },
     "node_modules/@rollup/plugin-json": {
@@ -3287,6 +3301,16 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "license": "MIT"
@@ -3488,6 +3512,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "dev": true,
@@ -3539,6 +3570,13 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.3",
@@ -3606,6 +3644,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/publint": {
+      "version": "0.3.16",
+      "resolved": "https://registry.npmjs.org/publint/-/publint-0.3.16.tgz",
+      "integrity": "sha512-MFqyfRLAExPVZdTQFwkAQELzA8idyXzROVOytg6nEJ/GEypXBUmMGrVaID8cTuzRS1U5L8yTOdOJtMXgFUJAeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@publint/pack": "^0.1.2",
+        "package-manager-detector": "^1.6.0",
+        "picocolors": "^1.1.1",
+        "sade": "^1.8.1"
+      },
+      "bin": {
+        "publint": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://bjornlu.com/sponsor"
       }
     },
     "node_modules/pump": {
@@ -3801,6 +3861,19 @@
         "@rollup/rollup-win32-x64-gnu": "4.54.0",
         "@rollup/rollup-win32-x64-msvc": "4.54.0",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/safe-array-concat": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "types": "dist/lib/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "types": "./dist/lib/index.d.ts"
+      "types": "./dist/lib/index.d.ts",
+      "import": "./dist/index.mjs"
     },
     "./lib/*": "./lib/*"
   },
@@ -54,6 +54,7 @@
     "eslint-import-resolver-typescript": "4.4.4",
     "pathe": "^2.0.3",
     "playcanvas": "2.14.4",
+    "publint": "0.3.16",
     "rollup": "4.54.0",
     "tslib": "2.8.1",
     "typescript": "5.9.3"
@@ -65,6 +66,7 @@
     "build": "rollup -c",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
+    "publint": "publint",
     "watch": "rollup -c -w",
     "test": "node --test test/*.test.mjs",
     "test:fixtures": "node test/fixtures/create-fixtures.mjs"


### PR DESCRIPTION
# Restore Publint for Publishing

## Problem

The publish workflow in [`.github/workflows/publish.yml`](.github/workflows/publish.yml) runs `npm run publint` at line 36, but in PR #137 ("Refactor: Library + CLI Architecture"), both the `publint` devDependency and the `publint` npm script were accidentally removed from [`package.json`](package.json).

This causes the publish job to fail when triggered on v0.17.0 tag push.

## Solution

Restore the publint package and script to `package.json`.

## Changes

**[`package.json`](package.json)**

1. Add `publint` back to devDependencies (use latest version `0.3.16` or newer)
2. Add the `publint` script back to the scripts section
```json
"devDependencies": {
  ...
  "publint": "0.3.16",
  ...
}
```
```json
"scripts": {
  ...
  "publint": "publint",
  ...
}
```
