### PR TITLE
Add CommonJS build

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,14 @@
   "types": "dist/lib/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/lib/index.d.ts",
-      "import": "./dist/index.mjs"
+      "import": {
+        "types": "./dist/lib/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./lib/*": "./lib/*"
   },
@@ -65,7 +71,7 @@
     "playcanvas": ">=2.0.0"
   },
   "scripts": {
-    "build": "rollup -c",
+    "build": "rollup -c && node -e \"fs=require('fs');fs.copyFileSync('dist/lib/index.d.ts','dist/lib/index.d.cts')\"",
     "docs": "typedoc",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -2,8 +2,8 @@ import json from '@rollup/plugin-json';
 import resolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 
-// Library build - platform agnostic
-const library = {
+// Library build - ESM (platform agnostic)
+const esm = {
     input: 'src/lib/index.ts',
     output: {
         dir: 'dist',
@@ -17,6 +17,29 @@ const library = {
             tsconfig: './tsconfig.json',
             declaration: true,
             declarationDir: 'dist'
+        }),
+        resolve(),
+        json()
+    ],
+    cache: false
+};
+
+// Library build - CommonJS (for non-module apps)
+const cjs = {
+    input: 'src/lib/index.ts',
+    output: {
+        dir: 'dist',
+        format: 'cjs',
+        sourcemap: true,
+        entryFileNames: 'index.cjs',
+        exports: 'named'
+    },
+    external: ['playcanvas'],
+    plugins: [
+        typescript({
+            tsconfig: './tsconfig.json',
+            declaration: false,
+            declarationDir: undefined
         }),
         resolve(),
         json()
@@ -46,4 +69,4 @@ const cli = {
     cache: false
 };
 
-export default [library, cli];
+export default [esm, cjs, cli];


### PR DESCRIPTION
Adds CommonJS build output alongside ESM, enabling use in non-ES module environments.

### Changes

- Add CJS build configuration (`dist/index.cjs`)
- Update package exports with conditional `import`/`require` entries
- Generate `.d.cts` types for CJS consumers (fixes publint warning)

### Usage

```javascript
// ESM
import { readFile, writeFile } from '@playcanvas/splat-transform';

// CommonJS
const { readFile, writeFile } = require('@playcanvas/splat-transform');
```

### Build Output

- `dist/index.mjs` - ESM
- `dist/index.cjs` - CommonJS
- `dist/lib/index.d.ts` - ESM types
- `dist/lib/index.d.cts` - CJS types

- [x] I confirm I have read the [contributing guidelines](https://github.com/splat-transform/splat-transform/blob/main/.github/CONTRIBUTING.md)
