### PR TITLE
Add Range request detection with memory fallback for UrlReadFileSystem

### DIFF
--- a/src/lib/io/read/memory-file-system.ts
+++ b/src/lib/io/read/memory-file-system.ts
@@ -102,4 +102,4 @@ class MemoryReadFileSystem implements ReadFileSystem {
     }
 }
 
-export { MemoryReadFileSystem };
+export { MemoryReadFileSystem, MemoryReadSource };


### PR DESCRIPTION
## Summary

- Automatically detect whether the server supports HTTP Range requests by probing with a `bytes=0-0` request
- If Range is supported (206 response), use streaming with Range headers for efficient seeking
- If not supported (e.g., Python's SimpleHTTPRequestHandler returns 200), fall back to downloading the entire file into memory first

This ensures compatibility with servers that don't support Range requests while maintaining optimal performance for servers that do.

## Technical Details

- Added `probeRangeSupport()` function that tests Range support by checking for 206 status (more reliable than `Accept-Ranges` header which is often CORS-blocked)
- The probe also extracts file size from the `Content-Range` header, avoiding a separate HEAD request when possible
- Exported `MemoryReadSource` to support the fallback path
- Added `createMemorySource()` private method with progress callback support

## Test Plan

- [x] Verify streaming works with servers that support Range requests
- [x] Verify fallback works with servers that don't support Range (e.g., `python -m http.server`)
- [ ] Verify progress callbacks work in both paths