### PR TITLE
Report peak memory usage and tidy data-table summary line

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -658,8 +658,14 @@ const main = async () => {
     // line, and terminates with status 1. Used by every non-success exit
     // path (early arg/overwrite checks, the main try/catch, and the
     // top-level uncaught{Exception,Rejection} handlers) so peak rss is
-    // always reported on failure - matching the success path.
-    const failExit = (err: unknown): never => {
+    // always reported on failure - matching the success path. The optional
+    // `label` preserves the failure kind/context (e.g. uncaughtException
+    // origin) that Node's default crash reporter would have surfaced, since
+    // installing the handlers below suppresses it.
+    const failExit = (err: unknown, label?: string): never => {
+        if (label) {
+            logger.error(`${label}:`);
+        }
         logger.error(err);
         reportDone();
         exit(1);
@@ -676,8 +682,12 @@ const main = async () => {
         output: chunk => process.stdout.write(chunk)
     }));
 
-    process.on('uncaughtException', failExit);
-    process.on('unhandledRejection', failExit);
+    process.on('uncaughtException', (err, origin) => {
+        failExit(err, `uncaughtException (${origin})`);
+    });
+    process.on('unhandledRejection', (reason) => {
+        failExit(reason, 'unhandledRejection');
+    });
 
     // read args
     let files: File[];

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -664,9 +664,10 @@ const main = async () => {
     // installing the handlers below suppresses it.
     const failExit = (err: unknown, label?: string): never => {
         if (label) {
-            logger.error(`${label}:`);
+            logger.error(`${label}:`, err);
+        } else {
+            logger.error(err);
         }
-        logger.error(err);
         reportDone();
         exit(1);
     };

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -636,6 +636,35 @@ EXAMPLES
 const main = async () => {
     const startTime = performance.now();
 
+    // Emit the final timing line plus the kernel-tracked peak resident set
+    // size. `process.resourceUsage().maxRSS` is reported in kilobytes on
+    // Linux/macOS and bytes on Windows; normalize to bytes for fmtBytes.
+    // Note: V8 fatal OOM (`FATAL ERROR: Reached heap limit`) and external
+    // SIGKILL bypass all JS handlers (uncaughtException, beforeExit, exit),
+    // so peak rss cannot be reported in those cases - use an external wrapper
+    // such as `/usr/bin/time -l` (macOS) or `/usr/bin/time -v` (Linux).
+    const reportDone = () => {
+        const elapsedMs = performance.now() - startTime;
+        const rawMaxRss = process.resourceUsage().maxRSS;
+        const maxRssBytes = process.platform === 'win32' ? rawMaxRss : rawMaxRss * 1024;
+        logger.info(`done in ${fmtTime(elapsedMs)}  [peak mem: ${fmtBytes(maxRssBytes)}]`);
+    };
+
+    const logDataTableInfo = (dataTable: DataTable) => {
+        logger.info(`${fmtCount(dataTable.numRows)} gaussians \u00b7 ${getSHBands(dataTable)} SH bands \u00b7 ${fmtBytes(dataTable.byteLength)}`);
+    };
+
+    process.on('uncaughtException', (err) => {
+        logger.error(err);
+        reportDone();
+        exit(1);
+    });
+    process.on('unhandledRejection', (reason) => {
+        logger.error(reason);
+        reportDone();
+        exit(1);
+    });
+
     // read args
     const { files, options } = await parseArguments();
 
@@ -813,7 +842,7 @@ const main = async () => {
                     throw new Error(`Unsupported data in file '${inputArg.filename}'`);
                 }
 
-                logger.info(`gaussians: ${fmtCount(dataTable.numRows)}, SH bands: ${getSHBands(dataTable)}, mem: ${fmtBytes(dataTable.byteLength)}`);
+                logDataTableInfo(dataTable);
 
                 const isEnv = dataTable.hasColumn('lod') && dataTable.getColumnByName('lod').data.every(v => v === -1);
                 if (!isEnv) {
@@ -852,7 +881,7 @@ const main = async () => {
                 index: phaseTotal,
                 total: phaseTotal
             });
-            logger.info(`gaussians: ${fmtCount(dataTable.numRows)}, SH bands: ${getSHBands(dataTable)}, mem: ${fmtBytes(dataTable.byteLength)}`);
+            logDataTableInfo(dataTable);
             await writeFile({
                 filename: outputFilename,
                 outputFormat: outputFormat!,
@@ -866,11 +895,11 @@ const main = async () => {
     } catch (err) {
         // handle errors
         logger.error(err);
+        reportDone();
         exit(1);
     }
 
-    const elapsedMs = performance.now() - startTime;
-    logger.info(`done in ${fmtTime(elapsedMs)}`);
+    reportDone();
 
     // something in webgpu seems to keep the process alive after returning
     // from main so force exit

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -654,26 +654,49 @@ const main = async () => {
         logger.info(`${fmtCount(dataTable.numRows)} gaussians \u00b7 ${getSHBands(dataTable)} SH bands \u00b7 ${fmtBytes(dataTable.byteLength)}`);
     };
 
-    process.on('uncaughtException', (err) => {
+    // Centralised failure exit: emits the error, the final timing/peak-mem
+    // line, and terminates with status 1. Used by every non-success exit
+    // path (early arg/overwrite checks, the main try/catch, and the
+    // top-level uncaught{Exception,Rejection} handlers) so peak rss is
+    // always reported on failure - matching the success path.
+    const failExit = (err: unknown): never => {
         logger.error(err);
         reportDone();
         exit(1);
-    });
-    process.on('unhandledRejection', (reason) => {
-        logger.error(reason);
-        reportDone();
-        exit(1);
-    });
+    };
 
-    // read args
-    const { files, options } = await parseArguments();
-
-    // install text renderer and configure verbosity
+    // Install a baseline text renderer immediately so any error emitted
+    // before parseArguments() completes (including from the top-level
+    // exception handlers below, or from parseArguments() itself) is
+    // actually visible. The default logger renderer is a NullRenderer
+    // that drops every event silently. The `--mem` overlay is layered
+    // on later once we've parsed the flag.
     logger.setRenderer(new TextRenderer({
         write: chunk => process.stderr.write(chunk),
-        output: chunk => process.stdout.write(chunk),
-        getMemoryUsage: options.mem ? () => process.memoryUsage() : undefined
+        output: chunk => process.stdout.write(chunk)
     }));
+
+    process.on('uncaughtException', failExit);
+    process.on('unhandledRejection', failExit);
+
+    // read args
+    let files: File[];
+    let options: CliOptions;
+    try {
+        ({ files, options } = await parseArguments());
+    } catch (err) {
+        failExit(err);
+    }
+
+    // re-install the text renderer with the memory-usage overlay if the
+    // user requested it via --mem; otherwise keep the baseline renderer.
+    if (options.mem) {
+        logger.setRenderer(new TextRenderer({
+            write: chunk => process.stderr.write(chunk),
+            output: chunk => process.stdout.write(chunk),
+            getMemoryUsage: () => process.memoryUsage()
+        }));
+    }
     if (options.quiet) {
         logger.setVerbosity('quiet');
     } else if (options.verbose) {
@@ -723,8 +746,7 @@ const main = async () => {
             exit(0);
         }
         // invalid invocation: route usage to stderr as an error
-        logger.error(formattedUsage);
-        exit(1);
+        failExit(formattedUsage);
     }
 
     const inputArgs = files.slice(0, -1);
@@ -746,8 +768,7 @@ const main = async () => {
         } else {
             // check overwrite before doing any work
             if (await fileExists(outputFilename)) {
-                logger.error(`File '${outputFilename}' already exists. Use -w option to overwrite.`);
-                exit(1);
+                failExit(`File '${outputFilename}' already exists. Use -w option to overwrite.`);
             }
 
             // for unbundled HTML, also check for additional files
@@ -763,8 +784,7 @@ const main = async () => {
 
                 for (const file of filesToCheck) {
                     if (await fileExists(file)) {
-                        logger.error(`File '${file}' already exists. Use -w option to overwrite.`);
-                        exit(1);
+                        failExit(`File '${file}' already exists. Use -w option to overwrite.`);
                     }
                 }
             }
@@ -893,10 +913,7 @@ const main = async () => {
             phase.end();
         }
     } catch (err) {
-        // handle errors
-        logger.error(err);
-        reportDone();
-        exit(1);
+        failExit(err);
     }
 
     reportDone();


### PR DESCRIPTION
## Summary

Two small CLI ergonomics improvements to `splat-transform`:

- **Peak memory at end of run.** Append `[peak mem: <size>]` to the final `done in ...` line, sourced from `process.resourceUsage().maxRSS` (the kernel's `getrusage(2)` high-water mark of resident set size). It is exact, free, and adds no sampling overhead. Units are normalised from kilobytes to bytes on Linux/macOS (Windows already returns bytes) before formatting via `fmtBytes`.
- **Reported on failure paths too.** Refactored the final log into a `reportDone()` helper and wired it into the existing `try/catch` and into new top-level `uncaughtException` / `unhandledRejection` handlers, so peak memory is reported even when the run aborts. A code comment notes the inherent gap: V8 fatal OOM (`FATAL ERROR: Reached heap limit`) and external SIGKILL bypass all JS handlers, so for those an external wrapper such as `/usr/bin/time -l` (macOS) or `/usr/bin/time -v` (Linux) is required.
- **Unified data-table summary line.** Extracted the duplicated per-input / per-output `gaussians: ..., SH bands: ..., mem: ...` log into a single `logDataTableInfo(dataTable)` helper and tightened the layout to a bullet-separated form: `<count> gaussians \u00b7 <bands> SH bands \u00b7 <bytes>`.

### Sample output

Before:

    \u25b8 [1/2] Input bunny.ply
      gaussians: 1.2M, SH bands: 3, mem: 128.4MB
      ...
    done in 12.4s

After:

    \u25b8 [1/2] Input bunny.ply
      \u00b7 1.2M gaussians \u00b7 3 SH bands \u00b7 128.4MB
      ...
    done in 12.4s  [peak mem: 842.3MB]

The `--mem` flag still controls the per-line `[rss/heap/ab]` overlay; this change is independent of it.

## Test plan

- [ ] Run a normal conversion (`splat-transform input.ply output.ply`) and confirm the new summary line and `[peak mem: ...]` suffix appear.
- [ ] Run with `--mem` and confirm the per-line overlay is unchanged.
- [ ] Trigger a recoverable failure (e.g. write to an existing file without `-w`, or a malformed input that throws) and confirm `[peak mem: ...]` is still printed.
- [ ] Trigger an unhandled rejection path (e.g. a corrupt input that rejects) and confirm the top-level handler reports peak memory before exit.
- [ ] Sanity-check on macOS and Linux (kB units) and, if available, Windows (bytes units).