### PR TITLE
Support http(s):// URL inputs in the CLI

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -21,10 +21,12 @@ import {
     writeFile,
     processDataTable,
     TextRenderer,
+    UrlReadFileSystem,
     type ProcessAction,
     type FilterFloaters,
     type FilterCluster,
     type Options as LibOptions,
+    type ReadFileSystem,
     logger
 } from '../lib';
 
@@ -52,6 +54,38 @@ const fileExists = async (filename: string) => {
         }
         throw e; // real error (permissions, etc)
     }
+};
+
+const isHttpUrl = (s: string) => /^https?:\/\//i.test(s);
+
+type ResolvedInput = {
+    filename: string;
+    fileSystem: ReadFileSystem;
+    classifyName: string;
+};
+
+// Resolve a CLI input arg into a (filename, fileSystem) pair. http(s):// URLs
+// are split into a baseUrl (directory) + leaf filename so multi-file formats
+// (SOG meta.json, LCC) can fetch siblings via UrlReadFileSystem's
+// `new URL(filename, baseUrl)` resolution.
+const resolveInput = (arg: string): ResolvedInput => {
+    if (isHttpUrl(arg)) {
+        const url = new URL(arg);
+        const lastSlash = url.pathname.lastIndexOf('/');
+        const leaf = url.pathname.slice(lastSlash + 1) || 'index';
+        const baseUrl = new URL('./', url).href;
+        return {
+            filename: leaf,
+            fileSystem: new UrlReadFileSystem(baseUrl),
+            classifyName: leaf
+        };
+    }
+    const resolved = resolve(arg);
+    return {
+        filename: resolved,
+        fileSystem: new NodeReadFileSystem(),
+        classifyName: resolved
+    };
 };
 
 const isGSDataTable = (dataTable: DataTable) => {
@@ -543,6 +577,9 @@ USAGE
 SUPPORTED INPUTS
     .ply   .compressed.ply   .sog   meta.json   .ksplat   .splat   .spz   .mjs   .lcc
 
+    Input filenames may also be http(s):// URLs (downloaded on demand;
+    .mjs generators are local-only).
+
 SUPPORTED OUTPUTS
     .ply   .compressed.ply   .sog   meta.json   lod-meta.json   .glb   .csv   .html   .voxel.json   null
 
@@ -631,6 +668,9 @@ EXAMPLES
 
     # Print summary without writing a file (discard output)
     splat-transform bunny.ply -m null
+
+    # Read input from a URL and write to a local file
+    splat-transform https://example.com/scene.ply scene.sog
 `;
 
 const main = async () => {
@@ -643,11 +683,17 @@ const main = async () => {
     // SIGKILL bypass all JS handlers (uncaughtException, beforeExit, exit),
     // so peak rss cannot be reported in those cases - use an external wrapper
     // such as `/usr/bin/time -l` (macOS) or `/usr/bin/time -v` (Linux).
-    const reportDone = () => {
+    const reportDone = (failed = false) => {
         const elapsedMs = performance.now() - startTime;
         const rawMaxRss = process.resourceUsage().maxRSS;
         const maxRssBytes = process.platform === 'win32' ? rawMaxRss : rawMaxRss * 1024;
-        logger.info(`done in ${fmtTime(elapsedMs)}  [peak mem: ${fmtBytes(maxRssBytes)}]`);
+        const verb = failed ? 'failed in' : 'done in';
+        const line = `${verb} ${fmtTime(elapsedMs)}  [peak mem: ${fmtBytes(maxRssBytes)}]`;
+        if (failed) {
+            logger.error(line);
+        } else {
+            logger.info(line);
+        }
     };
 
     const logDataTableInfo = (dataTable: DataTable) => {
@@ -668,7 +714,7 @@ const main = async () => {
         } else {
             logger.error(err);
         }
-        reportDone();
+        reportDone(true);
         exit(1);
     };
 
@@ -763,6 +809,11 @@ const main = async () => {
     const inputArgs = files.slice(0, -1);
     const outputArg = files[files.length - 1];
 
+    if (isHttpUrl(outputArg.filename)) {
+        logger.error(`Output to a URL is not supported: ${outputArg.filename}`);
+        exit(1);
+    }
+
     const outputFilename = resolve(outputArg.filename);
 
     // Check for null output (discard file writing)
@@ -845,9 +896,14 @@ const main = async () => {
                 return { name: p.name, value: p.value };
             });
 
-            // read input
-            const filename = resolve(inputArg.filename);
-            const inputFormat = getInputFormat(filename);
+            // read input - supports both local paths and http(s):// URLs
+            const { filename, fileSystem, classifyName } = resolveInput(inputArg.filename);
+            const inputFormat = getInputFormat(classifyName);
+
+            // mjs generators require local filesystem access (dynamic import)
+            if (inputFormat === 'mjs' && isHttpUrl(inputArg.filename)) {
+                throw new Error(`.mjs generator inputs cannot be loaded from a URL: ${inputArg.filename}`);
+            }
 
             // For mjs format, convert to file:// URL (Node.js-specific)
             const readFilename = inputFormat === 'mjs' ? `file://${filename}` : filename;
@@ -862,7 +918,7 @@ const main = async () => {
                 inputFormat,
                 options,
                 params,
-                fileSystem: new NodeReadFileSystem()
+                fileSystem
             });
             readingGroup.end();
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -67,15 +67,21 @@ type ResolvedInput = {
 // Resolve a CLI input arg into a (filename, fileSystem) pair. http(s):// URLs
 // are split into a baseUrl (directory) + leaf filename so multi-file formats
 // (SOG meta.json, LCC) can fetch siblings via UrlReadFileSystem's
-// `new URL(filename, baseUrl)` resolution.
+// `new URL(filename, baseUrl)` resolution. Any querystring/fragment on the
+// original URL (e.g. presigned `?token=...`) is preserved on `filename` so
+// the initial fetch carries it; `classifyName` is the bare leaf so format
+// detection sees only the path.
 const resolveInput = (arg: string): ResolvedInput => {
     if (isHttpUrl(arg)) {
         const url = new URL(arg);
         const lastSlash = url.pathname.lastIndexOf('/');
-        const leaf = url.pathname.slice(lastSlash + 1) || 'index';
+        const leaf = url.pathname.slice(lastSlash + 1);
+        if (!leaf) {
+            throw new Error(`Input URL must include a filename: ${arg}`);
+        }
         const baseUrl = new URL('./', url).href;
         return {
-            filename: leaf,
+            filename: `${leaf}${url.search}${url.hash}`,
             fileSystem: new UrlReadFileSystem(baseUrl),
             classifyName: leaf
         };
@@ -810,8 +816,7 @@ const main = async () => {
     const outputArg = files[files.length - 1];
 
     if (isHttpUrl(outputArg.filename)) {
-        logger.error(`Output to a URL is not supported: ${outputArg.filename}`);
-        exit(1);
+        failExit(`Output to a URL is not supported: ${outputArg.filename}`);
     }
 
     const outputFilename = resolve(outputArg.filename);

--- a/src/lib/io/read/index.ts
+++ b/src/lib/io/read/index.ts
@@ -3,7 +3,7 @@ export { ReadStream, type ReadSource, type ReadFileSystem, type ProgressCallback
 export { BufferedReadStream } from './buffered-read-stream';
 
 // Platform-agnostic path utilities
-export { dirname, join } from 'pathe';
+export { basename, dirname, join } from 'pathe';
 
 // Filesystem implementations (platform-agnostic only)
 export { MemoryReadFileSystem } from './memory-file-system';

--- a/src/lib/read.ts
+++ b/src/lib/read.ts
@@ -29,17 +29,20 @@ type InputFormat = 'mjs' | 'ksplat' | 'splat' | 'sog' | 'ply' | 'spz' | 'lcc';
  * const format2 = getInputFormat('scene.splat');  // returns 'splat'
  * ```
  */
-// For http(s):// URL inputs only, strip a trailing `?...` querystring and/or
-// `#...` fragment so that extension sniffing works for presigned URLs like
-// `scene.sog?token=...`. Local paths are returned unchanged - on POSIX, `?`
-// and `#` are valid characters in file/directory names and must not be
-// truncated.
+// Strip a trailing `?...` querystring and/or `#...` fragment from the
+// *basename* so that extension sniffing works for URL-shaped inputs:
+//   - full URLs:   `https://host/scene.sog?token=...`
+//   - CLI splits:  `scene.sog?token=...` (resolveInput passes the bare leaf
+//                  + query down to readFile so the initial fetch carries it)
+// Only the basename (text after the last `/` or `\`) is considered, so
+// POSIX paths containing `?` or `#` in *directory* segments are left
+// untouched. Local files literally named with `?`/`#` in the basename are
+// an unsupported edge case (the extension would be ambiguous anyway).
 const stripQueryAndHash = (filename: string): string => {
-    if (!/^https?:\/\//i.test(filename)) {
-        return filename;
-    }
-    const q = filename.search(/[?#]/);
-    return q < 0 ? filename : filename.slice(0, q);
+    const lastSep = Math.max(filename.lastIndexOf('/'), filename.lastIndexOf('\\'));
+    const basenameStart = lastSep + 1;
+    const q = filename.slice(basenameStart).search(/[?#]/);
+    return q < 0 ? filename : filename.slice(0, basenameStart + q);
 };
 
 const getInputFormat = (filename: string): InputFormat => {

--- a/src/lib/read.ts
+++ b/src/lib/read.ts
@@ -29,10 +29,15 @@ type InputFormat = 'mjs' | 'ksplat' | 'splat' | 'sog' | 'ply' | 'spz' | 'lcc';
  * const format2 = getInputFormat('scene.splat');  // returns 'splat'
  * ```
  */
-// Strip a trailing `?...` querystring and/or `#...` fragment so that
-// extension sniffing works for http(s):// URL inputs (e.g. presigned
-// URLs like `scene.sog?token=...`).
+// For http(s):// URL inputs only, strip a trailing `?...` querystring and/or
+// `#...` fragment so that extension sniffing works for presigned URLs like
+// `scene.sog?token=...`. Local paths are returned unchanged - on POSIX, `?`
+// and `#` are valid characters in file/directory names and must not be
+// truncated.
 const stripQueryAndHash = (filename: string): string => {
+    if (!/^https?:\/\//i.test(filename)) {
+        return filename;
+    }
     const q = filename.search(/[?#]/);
     return q < 0 ? filename : filename.slice(0, q);
 };

--- a/src/lib/read.ts
+++ b/src/lib/read.ts
@@ -29,8 +29,16 @@ type InputFormat = 'mjs' | 'ksplat' | 'splat' | 'sog' | 'ply' | 'spz' | 'lcc';
  * const format2 = getInputFormat('scene.splat');  // returns 'splat'
  * ```
  */
+// Strip a trailing `?...` querystring and/or `#...` fragment so that
+// extension sniffing works for http(s):// URL inputs (e.g. presigned
+// URLs like `scene.sog?token=...`).
+const stripQueryAndHash = (filename: string): string => {
+    const q = filename.search(/[?#]/);
+    return q < 0 ? filename : filename.slice(0, q);
+};
+
 const getInputFormat = (filename: string): InputFormat => {
-    const lowerFilename = filename.toLowerCase();
+    const lowerFilename = stripQueryAndHash(filename).toLowerCase();
 
     if (lowerFilename.endsWith('.mjs')) {
         return 'mjs';
@@ -103,7 +111,7 @@ const readFile = async (readFileOptions: ReadFileOptions): Promise<DataTable[]> 
     if (inputFormat === 'mjs') {
         result = [await readMjs(filename, params)];
     } else if (inputFormat === 'sog') {
-        const lowerFilename = filename.toLowerCase();
+        const lowerFilename = stripQueryAndHash(filename).toLowerCase();
         if (lowerFilename.endsWith('.sog')) {
             // Outer .sog is a ZIP container - mount it and let the inner SOG
             // reader drive its own decode bar against the zipped payloads.

--- a/src/lib/readers/read-sog.ts
+++ b/src/lib/readers/read-sog.ts
@@ -69,9 +69,9 @@ const sigmoidInv = (y: number) => {
  * Read a SOG file from a ReadFileSystem.
  * @param fileSystem - The file system to read from
  * @param filename - Path to meta.json (relative paths resolved from its directory).
- *                   The basename is used verbatim for the initial meta fetch so
- *                   any URL querystring/fragment (e.g. presigned `?token=...`)
- *                   is preserved.
+ * The basename is used verbatim for the initial meta fetch so
+ * any URL querystring/fragment (e.g. presigned `?token=...`)
+ * is preserved.
  * @returns DataTable with Gaussian splat data
  * @ignore
  */

--- a/src/lib/readers/read-sog.ts
+++ b/src/lib/readers/read-sog.ts
@@ -1,5 +1,5 @@
 import { Column, DataTable } from '../data-table';
-import { dirname, join, type ReadFileSystem, readFile } from '../io/read';
+import { basename, dirname, join, type ReadFileSystem, readFile } from '../io/read';
 import { logger, Transform, WebPCodec } from '../utils';
 
 type Meta = {
@@ -68,7 +68,10 @@ const sigmoidInv = (y: number) => {
 /**
  * Read a SOG file from a ReadFileSystem.
  * @param fileSystem - The file system to read from
- * @param filename - Path to meta.json (relative paths resolved from its directory)
+ * @param filename - Path to meta.json (relative paths resolved from its directory).
+ *                   The basename is used verbatim for the initial meta fetch so
+ *                   any URL querystring/fragment (e.g. presigned `?token=...`)
+ *                   is preserved.
  * @returns DataTable with Gaussian splat data
  * @ignore
  */
@@ -76,9 +79,10 @@ const readSog = async (fileSystem: ReadFileSystem, filename: string): Promise<Da
     const decoder = await WebPCodec.create();
 
     const baseDir = dirname(filename);
+    const metaName = basename(filename);
     const resolve = (name: string) => (baseDir ? join(baseDir, name) : name);
 
-    const metaBytes = await readFile(fileSystem, resolve('meta.json'));
+    const metaBytes = await readFile(fileSystem, resolve(metaName));
     const meta = JSON.parse(new TextDecoder().decode(metaBytes)) as Meta;
     const count = meta.count;
 

--- a/test/url-file-system.test.mjs
+++ b/test/url-file-system.test.mjs
@@ -18,11 +18,21 @@ import { fileURLToPath } from 'node:url';
 import {
     getInputFormat,
     readFile,
-    UrlReadFileSystem
+    Transform,
+    UrlReadFileSystem,
+    MemoryFileSystem,
+    WebPCodec,
+    writeSog
 } from '../src/lib/index.js';
+
+import { createMinimalTestData } from './helpers/test-utils.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const fixturesDir = join(__dirname, 'fixtures', 'splat');
+
+// Required so the SOG writer/reader can locate the WebP wasm during the
+// in-process .sog round-trip test below.
+WebPCodec.wasmUrl = join(__dirname, '..', 'lib', 'webp.wasm');
 
 /**
  * Start an http server serving a fixed map of `pathname -> body`.
@@ -204,6 +214,62 @@ describe('UrlReadFileSystem (CLI integration)', () => {
             assert.ok(
                 server.requests.some(u => u.includes('token=abc')),
                 `expected querystring on at least one request, got ${JSON.stringify(server.requests)}`
+            );
+        } finally {
+            await server.close();
+        }
+    });
+
+    it('routes a .sog?token=... URL to the ZIP-container path (presigned SOG)', async () => {
+        // Regression test for the SOG dispatch in readFile(): a presigned URL
+        // like `scene.sog?token=abc` must be recognised as an outer .sog ZIP
+        // (not misrouted to the meta.json branch) and the initial fetch must
+        // carry the querystring. Generate a real bundled SOG in-memory so the
+        // ZIP container is structurally valid and gets fully decoded.
+        const testData = createMinimalTestData();
+        testData.transform = Transform.PLY.clone();
+
+        const writeFs = new MemoryFileSystem();
+        await writeSog({
+            filename: 'scene.sog',
+            dataTable: testData,
+            bundle: true,
+            iterations: 5
+        }, writeFs);
+        const sogBody = writeFs.results.get('scene.sog');
+        assert.ok(sogBody && sogBody.length > 0, 'expected non-empty .sog fixture');
+
+        const server = await startServer({ '/scene.sog': sogBody }, true);
+        try {
+            const baseUrl = `${server.url}/`;
+            const fileSystem = new UrlReadFileSystem(baseUrl);
+
+            // Filename keeps the querystring (mirrors how the CLI's
+            // resolveInput() splits a presigned URL); inputFormat is sniffed
+            // via getInputFormat() to also exercise the URL-aware extension
+            // stripping.
+            const filename = 'scene.sog?token=abc';
+            const inputFormat = getInputFormat(`${baseUrl}${filename}`);
+            assert.strictEqual(inputFormat, 'sog');
+
+            const tables = await readFile({
+                filename,
+                inputFormat,
+                options: {},
+                params: [],
+                fileSystem
+            });
+            assert.strictEqual(tables.length, 1);
+            assert.strictEqual(tables[0].numRows, testData.numRows);
+
+            // The outer .sog request must have been the one carrying the
+            // token. (Inner meta.json / WebP fetches happen against the
+            // mounted ZipReadFileSystem and never hit the network.)
+            const sogRequests = server.requests.filter(u => new URL(u, 'http://localhost').pathname === '/scene.sog');
+            assert.ok(sogRequests.length > 0, 'expected at least one /scene.sog request');
+            assert.ok(
+                sogRequests.some(u => u.includes('token=abc')),
+                `expected querystring on /scene.sog request, got ${JSON.stringify(sogRequests)}`
             );
         } finally {
             await server.close();

--- a/test/url-file-system.test.mjs
+++ b/test/url-file-system.test.mjs
@@ -8,7 +8,7 @@
  * This validates both code paths in UrlReadFileSystem (streaming + memory fallback).
  */
 
-import { describe, it, before, after } from 'node:test';
+import { describe, it, before } from 'node:test';
 import assert from 'node:assert';
 import http from 'node:http';
 import { readFile as fsReadFile } from 'node:fs/promises';
@@ -25,14 +25,34 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const fixturesDir = join(__dirname, 'fixtures', 'splat');
 
 /**
- * Start an http server serving a single fixture file at /fixture.<ext>.
- * @param {Uint8Array} body - file body to serve
+ * Start an http server serving a fixed map of `pathname -> body`.
+ *
+ * Any request whose pathname is not present in `routes` returns 404. This
+ * means tests fail loudly if URL resolution (baseUrl + leaf joining,
+ * querystring stripping, sibling lookup, ...) targets the wrong path
+ * rather than silently succeeding.
+ *
+ * @param {Record<string, Uint8Array>} routes - map of pathname (e.g. `/minimal.splat`) to body
  * @param {boolean} supportRange - if true, respect Range headers (206); else always 200
- * @returns {Promise<{ url: string, close: () => Promise<void> }>}
+ * @returns {Promise<{ url: string, requests: string[], close: () => Promise<void> }>}
  */
-const startServer = (body, supportRange) => {
+const startServer = (routes, supportRange) => {
     return new Promise((resolve) => {
+        const requests = [];
         const server = http.createServer((req, res) => {
+            // Track the full request line so tests can assert on querystrings too.
+            requests.push(req.url);
+
+            // Match on pathname only; querystring/fragment are ignored for routing
+            // (but the server records them via `requests` for assertions).
+            const pathname = new URL(req.url, 'http://localhost').pathname;
+            const body = routes[pathname];
+            if (!body) {
+                res.writeHead(404, { 'Content-Type': 'text/plain' });
+                res.end(`Not Found: ${pathname}`);
+                return;
+            }
+
             const range = req.headers.range;
             if (supportRange && range) {
                 const match = /^bytes=(\d+)-(\d*)$/.exec(range);
@@ -62,6 +82,7 @@ const startServer = (body, supportRange) => {
             const { port } = server.address();
             resolve({
                 url: `http://127.0.0.1:${port}`,
+                requests,
                 close: () => new Promise(r => server.close(() => r()))
             });
         });
@@ -78,7 +99,7 @@ describe('UrlReadFileSystem (CLI integration)', () => {
     });
 
     it('reads a .splat file via URL with Range support (streaming path)', async () => {
-        const server = await startServer(splatBody, true);
+        const server = await startServer({ '/minimal.splat': splatBody }, true);
         try {
             const url = `${server.url}/minimal.splat`;
             const fileSystem = new UrlReadFileSystem();
@@ -97,7 +118,7 @@ describe('UrlReadFileSystem (CLI integration)', () => {
     });
 
     it('reads a .ksplat file via URL with no Range support (memory fallback)', async () => {
-        const server = await startServer(ksplatBody, false);
+        const server = await startServer({ '/minimal.ksplat': ksplatBody }, false);
         try {
             const url = `${server.url}/minimal.ksplat`;
             const fileSystem = new UrlReadFileSystem();
@@ -115,13 +136,21 @@ describe('UrlReadFileSystem (CLI integration)', () => {
         }
     });
 
-    it('resolves sibling fetches via baseUrl for multi-file scenarios', async () => {
-        // Use a baseUrl + leaf-filename split (the same pattern used by the CLI
-        // for multi-file formats like SOG meta.json / LCC).
-        const server = await startServer(splatBody, true);
+    it('resolves leaf and sibling fetches via baseUrl', async () => {
+        // Models the CLI's baseUrl + leaf-filename split used for multi-file
+        // formats (SOG meta.json / LCC). Serves a primary leaf plus a sibling
+        // file at distinct paths and asserts both resolve correctly via
+        // `new URL(name, baseUrl)`.
+        const siblingBody = new Uint8Array([1, 2, 3, 4, 5]);
+        const server = await startServer({
+            '/scene/minimal.splat': splatBody,
+            '/scene/sibling.bin': siblingBody
+        }, true);
         try {
-            const baseUrl = `${server.url}/`;
+            const baseUrl = `${server.url}/scene/`;
             const fileSystem = new UrlReadFileSystem(baseUrl);
+
+            // Primary leaf read goes through readFile().
             const tables = await readFile({
                 filename: 'minimal.splat',
                 inputFormat: 'splat',
@@ -130,6 +159,52 @@ describe('UrlReadFileSystem (CLI integration)', () => {
                 fileSystem
             });
             assert.strictEqual(tables[0].numRows, 4);
+
+            // Explicit sibling fetch via createSource() to prove relative
+            // resolution (e.g. SOG fetching `means_l.webp` next to
+            // `meta.json`, or LCC fetching chunk files).
+            const siblingSource = await fileSystem.createSource('sibling.bin');
+            try {
+                const bytes = await siblingSource.read().readAll();
+                assert.deepStrictEqual(Array.from(bytes), Array.from(siblingBody));
+            } finally {
+                siblingSource.close();
+            }
+
+            // The sibling request must have hit `/scene/sibling.bin`, not
+            // `/sibling.bin` (which would 404). The 404 path would already
+            // have failed the assertion above; this is a belt-and-braces
+            // check that the server actually saw both expected pathnames.
+            const pathnames = server.requests.map(u => new URL(u, 'http://localhost').pathname);
+            assert.ok(pathnames.includes('/scene/minimal.splat'), `expected /scene/minimal.splat in ${JSON.stringify(pathnames)}`);
+            assert.ok(pathnames.includes('/scene/sibling.bin'), `expected /scene/sibling.bin in ${JSON.stringify(pathnames)}`);
+        } finally {
+            await server.close();
+        }
+    });
+
+    it('preserves URL querystring on the initial fetch (presigned URL use case)', async () => {
+        // CLI splits `https://host/scene.splat?token=abc` into
+        // baseUrl=`https://host/` and filename=`scene.splat?token=abc`. The
+        // initial fetch must carry the token; the in-process server records
+        // the raw request line so we can assert on it.
+        const server = await startServer({ '/scene.splat': splatBody }, true);
+        try {
+            const baseUrl = `${server.url}/`;
+            const fileSystem = new UrlReadFileSystem(baseUrl);
+            const tables = await readFile({
+                filename: 'scene.splat?token=abc',
+                inputFormat: 'splat',
+                options: {},
+                params: [],
+                fileSystem
+            });
+            assert.strictEqual(tables[0].numRows, 4);
+
+            assert.ok(
+                server.requests.some(u => u.includes('token=abc')),
+                `expected querystring on at least one request, got ${JSON.stringify(server.requests)}`
+            );
         } finally {
             await server.close();
         }

--- a/test/url-file-system.test.mjs
+++ b/test/url-file-system.test.mjs
@@ -1,0 +1,137 @@
+/**
+ * Tests for reading splat files via http(s):// URLs through UrlReadFileSystem.
+ *
+ * Spins up an in-process http server serving fixture files in two modes:
+ *  - Range-supporting (responds to Range headers with 206 Partial Content)
+ *  - Range-ignoring (always returns the whole body with 200 OK)
+ *
+ * This validates both code paths in UrlReadFileSystem (streaming + memory fallback).
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import http from 'node:http';
+import { readFile as fsReadFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+    getInputFormat,
+    readFile,
+    UrlReadFileSystem
+} from '../src/lib/index.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = join(__dirname, 'fixtures', 'splat');
+
+/**
+ * Start an http server serving a single fixture file at /fixture.<ext>.
+ * @param {Uint8Array} body - file body to serve
+ * @param {boolean} supportRange - if true, respect Range headers (206); else always 200
+ * @returns {Promise<{ url: string, close: () => Promise<void> }>}
+ */
+const startServer = (body, supportRange) => {
+    return new Promise((resolve) => {
+        const server = http.createServer((req, res) => {
+            const range = req.headers.range;
+            if (supportRange && range) {
+                const match = /^bytes=(\d+)-(\d*)$/.exec(range);
+                if (match) {
+                    const start = parseInt(match[1], 10);
+                    const end = match[2] ? parseInt(match[2], 10) : body.length - 1;
+                    const slice = body.subarray(start, end + 1);
+                    res.writeHead(206, {
+                        'Content-Type': 'application/octet-stream',
+                        'Content-Length': String(slice.length),
+                        'Content-Range': `bytes ${start}-${end}/${body.length}`,
+                        'Accept-Ranges': 'bytes'
+                    });
+                    res.end(slice);
+                    return;
+                }
+            }
+
+            // Plain 200 OK with the entire body (no Range support).
+            res.writeHead(200, {
+                'Content-Type': 'application/octet-stream',
+                'Content-Length': String(body.length)
+            });
+            res.end(body);
+        });
+        server.listen(0, '127.0.0.1', () => {
+            const { port } = server.address();
+            resolve({
+                url: `http://127.0.0.1:${port}`,
+                close: () => new Promise(r => server.close(() => r()))
+            });
+        });
+    });
+};
+
+describe('UrlReadFileSystem (CLI integration)', () => {
+    let splatBody;
+    let ksplatBody;
+
+    before(async () => {
+        splatBody = await fsReadFile(join(fixturesDir, 'minimal.splat'));
+        ksplatBody = await fsReadFile(join(fixturesDir, 'minimal.ksplat'));
+    });
+
+    it('reads a .splat file via URL with Range support (streaming path)', async () => {
+        const server = await startServer(splatBody, true);
+        try {
+            const url = `${server.url}/minimal.splat`;
+            const fileSystem = new UrlReadFileSystem();
+            const tables = await readFile({
+                filename: url,
+                inputFormat: getInputFormat(url),
+                options: {},
+                params: [],
+                fileSystem
+            });
+            assert.strictEqual(tables.length, 1);
+            assert.strictEqual(tables[0].numRows, 4);
+        } finally {
+            await server.close();
+        }
+    });
+
+    it('reads a .ksplat file via URL with no Range support (memory fallback)', async () => {
+        const server = await startServer(ksplatBody, false);
+        try {
+            const url = `${server.url}/minimal.ksplat`;
+            const fileSystem = new UrlReadFileSystem();
+            const tables = await readFile({
+                filename: url,
+                inputFormat: getInputFormat(url),
+                options: {},
+                params: [],
+                fileSystem
+            });
+            assert.strictEqual(tables.length, 1);
+            assert.strictEqual(tables[0].numRows, 4);
+        } finally {
+            await server.close();
+        }
+    });
+
+    it('resolves sibling fetches via baseUrl for multi-file scenarios', async () => {
+        // Use a baseUrl + leaf-filename split (the same pattern used by the CLI
+        // for multi-file formats like SOG meta.json / LCC).
+        const server = await startServer(splatBody, true);
+        try {
+            const baseUrl = `${server.url}/`;
+            const fileSystem = new UrlReadFileSystem(baseUrl);
+            const tables = await readFile({
+                filename: 'minimal.splat',
+                inputFormat: 'splat',
+                options: {},
+                params: [],
+                fileSystem
+            });
+            assert.strictEqual(tables[0].numRows, 4);
+        } finally {
+            await server.close();
+        }
+    });
+});


### PR DESCRIPTION
Fixes: #210

## Summary

- Adds support for passing `http(s)://` URLs as input arguments to the `splat-transform` CLI. URLs are resolved via the existing `UrlReadFileSystem`, splitting the URL into a `baseUrl` (directory) + leaf filename so multi-file formats (SOG `meta.json`, LCC) can fetch siblings via `new URL(filename, baseUrl)`.
- Output-to-URL is rejected with a clear error.
- `.mjs` generator inputs remain local-only (they require dynamic import) and now produce an explicit error if a URL is passed.
- Updates `--help` to document URL inputs and adds an example.
- Makes the CLI's final timing/peak-mem footer failure-aware: failure exits now emit `failed in <elapsed>  [peak mem: ...]` instead of the previous misleading `done in ...`, and the line is routed through `logger.error` so it survives `--quiet`. The success path is unchanged (`done in ...` via `logger.info`, suppressed under `-q`).
- Adds `test/url-file-system.test.mjs`: spins up an in-process HTTP server serving a fixture splat in two modes (Range-supporting / 206 and Range-ignoring / 200) to cover both code paths in `UrlReadFileSystem` (streaming + whole-body fallback).

## Examples

```bash
# Read input from a URL and write to a local file
splat-transform https://example.com/scene.ply scene.sog
```

## Test plan

- [x] `npm run build`
- [x] `npm test` (incl. new `url-file-system.test.mjs`)
- [x] Manual smoke: local input -> local output (success path, `done in ...` unchanged)
- [x] Manual smoke: failing run (e.g. overwrite without `-w`, missing input) emits `failed in ... [peak mem: ...]` at default and `-q` verbosities, with no leftover `done in ...` line
- [ ] Manual smoke: URL input -> local output against a real host (e.g. an S3-hosted .ply / SOG bundle)
- [ ] Manual smoke: URL input pointing at SOG `meta.json` to confirm sibling chunk fetches resolve correctly
- [ ] Manual smoke: URL passed as output → expect rejection
- [ ] Manual smoke: URL pointing at a `.mjs` → expect rejection