### PR TITLE
Deliver every scope/bar lifecycle event to renderers

### DIFF
--- a/src/lib/utils/logger.ts
+++ b/src/lib/utils/logger.ts
@@ -548,5 +548,5 @@ const logger = {
  */
 type Logger = typeof logger;
 
-export { logger };
+export { logger, verbosityRank };
 export type { Bar, Group, LogEvent, Logger, MessageKind, Renderer, Verbosity };

--- a/src/lib/utils/logger.ts
+++ b/src/lib/utils/logger.ts
@@ -38,10 +38,19 @@ type LogEvent =
     | { kind: 'output'; text: string };
 
 /**
- * Renderer interface. Receives semantic events (already filtered by the
- * active verbosity inside {@link LoggerCore}) and decides how to display
- * them. Renderers are pure presentation - they never need to consult or
- * track verbosity themselves.
+ * Renderer interface. Receives the full stream of semantic lifecycle
+ * events ({@link LogEvent}) and decides how to display them. The core
+ * does not filter scope/bar events by verbosity, so renderers see a
+ * faithful record of every scope open/close and bar progress update -
+ * embedders consuming the event stream can rely on this for progress
+ * UIs that must close themselves on completion. Visibility decisions
+ * (e.g. hiding successful `scopeEnd` footers at non-`verbose`
+ * verbosity) are the renderer's responsibility; {@link logger.getVerbosity}
+ * is available to consult.
+ *
+ * `message` events for `info`, `warn` and `debug` are gated by verbosity
+ * at the façade (see {@link LoggerCore.isLevelVisible}) before reaching
+ * the renderer; `error` is always delivered.
  */
 interface Renderer {
     /**
@@ -206,35 +215,19 @@ class LoggerCore {
     }
 
     /**
-     * Gate events by the current verbosity, then hand survivors to the
-     * renderer. Renderers see only visible events and never need to know
-     * about verbosity themselves.
+     * Hand the event to the renderer. Lifecycle events (`scopeStart`,
+     * `scopeEnd`, `barStart`, `barTick`, `barEnd`) and `output` are always
+     * forwarded; presentation policy (e.g. hiding successful `scopeEnd`
+     * footers at non-`verbose` verbosity) lives in the renderer so
+     * embedders consuming the event stream see a complete, faithful
+     * record of scope and bar lifecycles. `message` is assumed already
+     * gated at the façade via {@link LoggerCore.isLevelVisible} (so
+     * callers can skip formatting args for filtered levels); anything
+     * that reaches here is passed through.
      *
-     * - `output` is always shown (it's the pipeable channel).
-     * - `message` is assumed already gated at the façade via
-     *   {@link LoggerCore.isLevelVisible} (so callers can skip formatting
-     *   args for filtered levels); anything that reaches here is passed
-     *   through.
-     * - `scopeEnd` footers are noisy on the success path, so success-ends
-     *   are gated one rank higher than their matching start: visible only
-     *   at `verbose`, while `scopeStart` shows at `normal`. Failed ends
-     *   stay at the `normal` gate so the "failed in Xs" cascade from
-     *   `logger.error` / `unwindAll(true)` survives whenever scope
-     *   output is visible at all.
-     * - All other scope/bar events (`scopeStart`, `barStart`, `barTick`,
-     *   `barEnd`) are gated at `normal`.
-     *
-     * @param event - The candidate event.
+     * @param event - The event to deliver.
      */
     emit(event: LogEvent): void {
-        if (event.kind !== 'output' && event.kind !== 'message') {
-            const rank = verbosityRank[this.verbosity];
-            if (event.kind === 'scopeEnd' && !event.failed) {
-                if (rank < verbosityRank.verbose) return;
-            } else if (rank < verbosityRank.normal) {
-                return;
-            }
-        }
         this.renderer.handle(event);
     }
 
@@ -510,7 +503,10 @@ const logger = {
 
     /**
      * Replace the active renderer. Embedders install their own renderer here
-     * to consume `LogEvent`s; the default renderer is a no-op.
+     * to consume `LogEvent`s; the default renderer is a no-op. Renderers
+     * receive every scope/bar lifecycle event regardless of verbosity, so
+     * progress UIs can rely on `scopeStart`/`scopeEnd` and `barStart`/`barEnd`
+     * to manage their state.
      * @param r - The renderer to install.
      */
     setRenderer(r: Renderer): void {

--- a/src/lib/utils/text-renderer.ts
+++ b/src/lib/utils/text-renderer.ts
@@ -1,5 +1,5 @@
 import { fmtBytes, fmtTime } from './fmt';
-import type { LogEvent, Renderer } from './logger';
+import { logger, type LogEvent, type Renderer, type Verbosity } from './logger';
 
 /**
  * Output streams and optional memory-usage probe for {@link TextRenderer}.
@@ -26,6 +26,12 @@ interface TextRendererOptions {
     getMemoryUsage?: () => { rss: number; heapUsed: number; arrayBuffers: number };
 }
 
+const verbosityRank: Record<Verbosity, number> = {
+    quiet: 0,
+    normal: 1,
+    verbose: 2
+};
+
 const indent = (depth: number): string => '  '.repeat(Math.max(0, depth));
 
 const BAR_WIDTH = 20;
@@ -33,8 +39,8 @@ const BAR_WIDTH = 20;
 /**
  * Default human-readable text renderer. Emits one event per line - no
  * carriage-return rewriting, no TTY detection, no buffering. Scope starts
- * always emit a header line; successful `scopeEnd` footers are filtered
- * out at `normal` verbosity by `LoggerCore` (kept at `verbose`, and always
+ * always emit a header line; successful `scopeEnd` footers are hidden by
+ * this renderer at `normal` verbosity (shown at `verbose`, and always
  * shown when `failed`), so default-mode runs see headers without timing
  * footers and `--verbose` adds the matching `done in ...` lines. Bars
  * render as `[#### ...... ] duration`, with `#` appended incrementally on
@@ -43,9 +49,11 @@ const BAR_WIDTH = 20;
  * pipeable sink with a trailing `\n` appended (callers should not include
  * one themselves).
  *
- * Verbosity filtering is handled centrally by `LoggerCore` - this renderer
- * receives only events that have already passed the visibility gate, so it
- * is pure presentation.
+ * Verbosity is consulted directly from the shared {@link logger} on each
+ * event, so this renderer alone decides what to display - the core
+ * delivers every scope/bar lifecycle event so embedders consuming the
+ * event stream see a faithful record. At `quiet` the renderer suppresses
+ * every scope/bar line (errors, warnings and `output` still show).
  *
  * Sinks are injected (no `process` reference here) so the renderer works in
  * both Node CLI and browser/bundle contexts: the CLI passes
@@ -74,9 +82,14 @@ class TextRenderer implements Renderer {
         this.getMemoryUsage = options.getMemoryUsage;
     }
 
+    private rank(): number {
+        return verbosityRank[logger.getVerbosity()];
+    }
+
     handle(event: LogEvent): void {
         switch (event.kind) {
             case 'scopeStart': {
+                if (this.rank() < verbosityRank.normal) return;
                 this.commitDirty();
                 const numbered = event.index !== undefined && event.total !== undefined ?
                     `[${event.index}/${event.total}] ` : '';
@@ -84,12 +97,19 @@ class TextRenderer implements Renderer {
                 return;
             }
             case 'scopeEnd': {
+                const rank = this.rank();
+                if (event.failed) {
+                    if (rank < verbosityRank.normal) return;
+                } else if (rank < verbosityRank.verbose) {
+                    return;
+                }
                 this.commitDirty();
                 const verb = event.failed ? 'failed in' : 'done in';
                 this.write(`${indent(event.depth + 1)}${verb} ${fmtTime(event.durationMs)}${this.memSuffix()}\n`);
                 return;
             }
             case 'barStart': {
+                if (this.rank() < verbosityRank.normal) return;
                 this.commitDirty();
                 this.write(`${indent(event.depth)}\u25b8 ${event.name} [`);
                 this.lineDirty = true;
@@ -98,6 +118,7 @@ class TextRenderer implements Renderer {
             }
             case 'barTick': {
                 if (!this.lineDirty) return;
+                if (this.rank() < verbosityRank.normal) return;
                 const target = event.total <= 0 ? 0 :
                     Math.min(BAR_WIDTH, Math.floor((event.current / event.total) * BAR_WIDTH));
                 if (target > this.barFilled) {
@@ -107,6 +128,7 @@ class TextRenderer implements Renderer {
                 return;
             }
             case 'barEnd': {
+                if (this.rank() < verbosityRank.normal) return;
                 const suffix = event.failed ?
                     `] (failed) ${fmtTime(event.durationMs)}` :
                     `] ${fmtTime(event.durationMs)}`;

--- a/src/lib/utils/text-renderer.ts
+++ b/src/lib/utils/text-renderer.ts
@@ -1,5 +1,5 @@
 import { fmtBytes, fmtTime } from './fmt';
-import { logger, type LogEvent, type Renderer, type Verbosity } from './logger';
+import { logger, verbosityRank, type LogEvent, type Renderer } from './logger';
 
 /**
  * Output streams and optional memory-usage probe for {@link TextRenderer}.
@@ -26,25 +26,15 @@ interface TextRendererOptions {
     getMemoryUsage?: () => { rss: number; heapUsed: number; arrayBuffers: number };
 }
 
-const verbosityRank: Record<Verbosity, number> = {
-    quiet: 0,
-    normal: 1,
-    verbose: 2
-};
-
 const indent = (depth: number): string => '  '.repeat(Math.max(0, depth));
 
 const BAR_WIDTH = 20;
 
 /**
  * Default human-readable text renderer. Emits one event per line - no
- * carriage-return rewriting, no TTY detection, no buffering. Scope starts
- * always emit a header line; successful `scopeEnd` footers are hidden by
- * this renderer at `normal` verbosity (shown at `verbose`, and always
- * shown when `failed`), so default-mode runs see headers without timing
- * footers and `--verbose` adds the matching `done in ...` lines. Bars
- * render as `[#### ...... ] duration`, with `#` appended incrementally on
- * each `barTick` and the remainder padded with `.` on `barEnd`. `output`
+ * carriage-return rewriting, no TTY detection, no buffering. Bars render
+ * as `[#### ...... ] duration`, with `#` appended incrementally on each
+ * `barTick` and the remainder padded with `.` on `barEnd`. `output`
  * events are treated as line-oriented: their text is written to the
  * pipeable sink with a trailing `\n` appended (callers should not include
  * one themselves).
@@ -52,8 +42,17 @@ const BAR_WIDTH = 20;
  * Verbosity is consulted directly from the shared {@link logger} on each
  * event, so this renderer alone decides what to display - the core
  * delivers every scope/bar lifecycle event so embedders consuming the
- * event stream see a faithful record. At `quiet` the renderer suppresses
- * every scope/bar line (errors, warnings and `output` still show).
+ * event stream see a faithful record. The display rules are:
+ *
+ * - `quiet` - suppresses every scope/bar lifecycle line (start, tick,
+ *   end - including failed ends). Errors, warnings and `output` still
+ *   show.
+ * - `normal` (default) - shows scope/bar headers and bar progress;
+ *   shows failed `scopeEnd` / `barEnd` footers (the "failed in ..."
+ *   cascade from `logger.error` / `unwindAll(true)`); hides successful
+ *   `scopeEnd` footers.
+ * - `verbose` - shows everything, including successful `scopeEnd`
+ *   footers ("done in ...").
  *
  * Sinks are injected (no `process` reference here) so the renderer works in
  * both Node CLI and browser/bundle contexts: the CLI passes


### PR DESCRIPTION
## Overview

`LoggerCore.emit` was dropping successful `scopeEnd` events at the default `normal` verbosity (and dropping every scope/bar event at `quiet`). Custom renderers — typically progress UIs in embedders — therefore never received the close event for a top-level group, so any UI that listens for `scopeEnd` to dismiss itself was left dangling on success.

This change makes the core a faithful event source: every scope/bar lifecycle event is delivered to the active `Renderer` regardless of verbosity. The display policy that used to live in the core has been moved into `TextRenderer` so the CLI's output is byte-identical.

## Changes

- `LoggerCore.emit` no longer filters scope/bar events. `output` and `message` paths are unchanged (`message` is still gated at the façade by `isLevelVisible` so filtered levels skip arg formatting).
- `TextRenderer` now consults `logger.getVerbosity()` directly and applies the same visibility rules the core used to apply:
  - `quiet` — suppresses every scope/bar lifecycle line (errors, warnings and `output` still show).
  - `normal` (default) — shows scope/bar headers and bar progress; hides successful `scopeEnd` footers; failed ends always show.
  - `verbose` — shows everything, including `done in …` footers.
- Doc comments on `Renderer`, `LoggerCore.emit` and `logger.setRenderer` updated to spell out the new contract: renderers receive a complete record of scope/bar lifecycles and decide presentation themselves.

## Public API

No surface changes. The `Renderer`, `LogEvent`, `Verbosity` and `logger` shapes are all unchanged. The behavioural change is only visible to embedders that install a custom `Renderer`: they now reliably receive every `scopeStart`/`scopeEnd` and `barStart`/`barTick`/`barEnd` pair, which is what the documentation already promised.

## CLI behaviour

Unchanged across `--quiet`, default and `--verbose`. The same lines are written to stderr/stdout as before; the filtering simply moved one layer outward.

## Why

The previous behaviour broke a valid embedder use case (a progress dialog in SuperSplat that opens on the depth-0 `scopeStart` and closes on the matching `scopeEnd`). The dialog never closed on success because the close event was filtered out by the core before reaching the renderer. Moving the visibility decision into the renderer keeps it where it belongs — pure presentation — and lets every embedded `Renderer` see a faithful event stream.

## Test plan

- `npm run lint` — clean.
- `npm run build` — clean.
- `npm test` — all 468 tests pass (no logger-specific tests existed; behaviour validated via CLI output spot-check).