### PR TITLE
Add --no-tty flag for non-interactive output

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Actions can be repeated and applied in any order:
 -q, --quiet                             Suppress non-error output
     --verbose                           Show debug-level diagnostics
     --mem                               Show memory usage in progress output
-    --no-tty                            Force non-interactive output (auto when stderr is not a TTY)
+    --tty                               Interactive bar rendering (default on a TTY; --no-tty to disable)
 -w, --overwrite                         Overwrite output file if it exists
 -i, --iterations       <n>              Iterations for SOG SH compression (more=better). Default: 10
 -L, --list-gpus                         List available GPU adapters and exit

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Actions can be repeated and applied in any order:
 -q, --quiet                             Suppress non-error output
     --verbose                           Show debug-level diagnostics
     --mem                               Show memory usage in progress output
+    --no-tty                            Force non-interactive output (auto when stderr is not a TTY)
 -w, --overwrite                         Overwrite output file if it exists
 -i, --iterations       <n>              Iterations for SOG SH compression (more=better). Default: 10
 -L, --list-gpus                         List available GPU adapters and exit

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -626,7 +626,7 @@ GLOBAL OPTIONS
     -q, --quiet                             Suppress non-error output
         --verbose                           Show debug-level diagnostics
         --mem                               Show memory usage in progress output
-        --no-tty                            Force non-interactive output (auto when stderr is not a TTY)
+        --tty                               Interactive bar rendering (default on a TTY; --no-tty to disable)
     -w, --overwrite                         Overwrite output file if it exists
     -i, --iterations       <n>              Iterations for SOG SH compression (more=better). Default: 10
     -L, --list-gpus                         List available GPU adapters and exit
@@ -687,19 +687,23 @@ EXAMPLES
 const main = async () => {
     const startTime = performance.now();
 
-    // Emit the final timing line plus the kernel-tracked peak resident set
-    // size. `process.resourceUsage().maxRSS` is reported in kilobytes on
+    // Kernel-tracked peak resident set size in bytes.
+    // `process.resourceUsage().maxRSS` is reported in kilobytes on
     // Linux/macOS and bytes on Windows; normalize to bytes for fmtBytes.
     // Note: V8 fatal OOM (`FATAL ERROR: Reached heap limit`) and external
     // SIGKILL bypass all JS handlers (uncaughtException, beforeExit, exit),
     // so peak rss cannot be reported in those cases - use an external wrapper
     // such as `/usr/bin/time -l` (macOS) or `/usr/bin/time -v` (Linux).
+    const peakMemoryBytes = (): number => {
+        const raw = process.resourceUsage().maxRSS;
+        return process.platform === 'win32' ? raw : raw * 1024;
+    };
+
+    // Emit the final timing line plus peak memory usage.
     const reportDone = (failed = false) => {
         const elapsedMs = performance.now() - startTime;
-        const rawMaxRss = process.resourceUsage().maxRSS;
-        const maxRssBytes = process.platform === 'win32' ? rawMaxRss : rawMaxRss * 1024;
         const verb = failed ? 'failed in' : 'done in';
-        const line = `${verb} ${fmtTime(elapsedMs)}  [peak ${fmtBytes(maxRssBytes)}]`;
+        const line = `${verb} ${fmtTime(elapsedMs)}  [peak ${fmtBytes(peakMemoryBytes())}]`;
         if (failed) {
             logger.error(line);
         } else {
@@ -755,7 +759,7 @@ const main = async () => {
     const renderer = new TextRenderer({
         write,
         output: chunk => process.stdout.write(chunk),
-        getMemoryUsage: () => process.memoryUsage()
+        getPeakMemory: peakMemoryBytes
     });
     logger.setRenderer(renderer);
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -625,7 +625,7 @@ GLOBAL OPTIONS
     -v, --version                           Show version and exit
     -q, --quiet                             Suppress non-error output
         --verbose                           Show debug-level diagnostics
-        --mem                               Show memory usage in progress output
+        --mem                               Show peak memory in progress output
         --tty                               Interactive bar rendering (default on a TTY; --no-tty to disable)
     -w, --overwrite                         Overwrite output file if it exists
     -i, --iterations       <n>              Iterations for SOG SH compression (more=better). Default: 10

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -729,6 +729,12 @@ const main = async () => {
         exit(1);
     };
 
+    // stderr sink for the renderer. When `noTty` is on, line-buffer so the
+    // renderer's partial-line bar sequence (`▸ name [` + `#` ticks +
+    // `....] dur\n`) lands as one complete line per bar - what non-
+    // interactive log viewers want. Defaults to auto-detection from
+    // `stderr.isTTY`; the `--no-tty` flag below ORs it on for backends
+    // that report a TTY but aren't really interactive.
     let noTty = !process.stderr.isTTY;
     let lineBuf = '';
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -41,7 +41,7 @@ interface CliOptions extends LibOptions {
     quiet: boolean;
     verbose: boolean;
     mem: boolean;
-    noTty: boolean;
+    noTty: boolean | undefined;
     listGpus: boolean;
     deviceIdx: number;  // -1 = auto, -2 = CPU, 0+ = GPU index
 }
@@ -122,7 +122,7 @@ const cliOptionsConfig = {
     quiet: { type: 'boolean', short: 'q', default: false },
     verbose: { type: 'boolean', default: false },
     mem: { type: 'boolean', default: false },
-    tty: { type: 'boolean', default: true },
+    tty: { type: 'boolean' },
     iterations: { type: 'string', short: 'i', default: '10' },
     'list-gpus': { type: 'boolean', short: 'L', default: false },
     gpu: { type: 'string', short: 'g', default: '-1' },
@@ -354,7 +354,7 @@ const parseArguments = async () => {
         quiet: v.quiet,
         verbose: v.verbose,
         mem: v.mem,
-        noTty: !v.tty,
+        noTty: v.tty === undefined ? undefined : !v.tty,
         iterations: parseInteger(v.iterations),
         listGpus: v['list-gpus'],
         deviceIdx,
@@ -733,8 +733,9 @@ const main = async () => {
     // renderer's partial-line bar sequence (`▸ name [` + `#` ticks +
     // `....] dur\n`) lands as one complete line per bar - what non-
     // interactive log viewers want. Defaults to auto-detection from
-    // `stderr.isTTY`; the `--no-tty` flag below ORs it on for backends
-    // that report a TTY but aren't really interactive.
+    // `stderr.isTTY`; the `--no-tty` / `--tty` flags applied below
+    // override either way for backends whose stderr-TTY status doesn't
+    // match what the user wants.
     let noTty = !process.stderr.isTTY;
     let lineBuf = '';
 
@@ -775,8 +776,12 @@ const main = async () => {
     }
 
     // Apply post-parse flags. `--no-tty` forces line buffering even on a
-    // TTY (for backends that report stderr as a TTY but aren't really).
-    noTty ||= options.noTty;
+    // TTY (for backends that report stderr as a TTY but aren't really);
+    // `--tty` forces it off even on a piped stderr. When neither flag is
+    // passed, the auto-detected default sticks.
+    if (options.noTty !== undefined) {
+        noTty = options.noTty;
+    }
     renderer.mem = options.mem;
 
     if (options.quiet) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -41,6 +41,7 @@ interface CliOptions extends LibOptions {
     quiet: boolean;
     verbose: boolean;
     mem: boolean;
+    noTty: boolean;
     listGpus: boolean;
     deviceIdx: number;  // -1 = auto, -2 = CPU, 0+ = GPU index
 }
@@ -121,6 +122,7 @@ const cliOptionsConfig = {
     quiet: { type: 'boolean', short: 'q', default: false },
     verbose: { type: 'boolean', default: false },
     mem: { type: 'boolean', default: false },
+    tty: { type: 'boolean', default: true },
     iterations: { type: 'string', short: 'i', default: '10' },
     'list-gpus': { type: 'boolean', short: 'L', default: false },
     gpu: { type: 'string', short: 'g', default: '-1' },
@@ -352,6 +354,7 @@ const parseArguments = async () => {
         quiet: v.quiet,
         verbose: v.verbose,
         mem: v.mem,
+        noTty: !v.tty,
         iterations: parseInteger(v.iterations),
         listGpus: v['list-gpus'],
         deviceIdx,
@@ -623,6 +626,7 @@ GLOBAL OPTIONS
     -q, --quiet                             Suppress non-error output
         --verbose                           Show debug-level diagnostics
         --mem                               Show memory usage in progress output
+        --no-tty                            Force non-interactive output (auto when stderr is not a TTY)
     -w, --overwrite                         Overwrite output file if it exists
     -i, --iterations       <n>              Iterations for SOG SH compression (more=better). Default: 10
     -L, --list-gpus                         List available GPU adapters and exit
@@ -725,16 +729,28 @@ const main = async () => {
         exit(1);
     };
 
-    // Install a baseline text renderer immediately so any error emitted
-    // before parseArguments() completes (including from the top-level
-    // exception handlers below, or from parseArguments() itself) is
-    // actually visible. The default logger renderer is a NullRenderer
-    // that drops every event silently. The `--mem` overlay is layered
-    // on later once we've parsed the flag.
-    logger.setRenderer(new TextRenderer({
-        write: chunk => process.stderr.write(chunk),
-        output: chunk => process.stdout.write(chunk)
-    }));
+    let noTty = !process.stderr.isTTY;
+    let lineBuf = '';
+
+    const write = (chunk: string) => {
+        if (noTty) {
+            lineBuf += chunk;
+            const lastNL = lineBuf.lastIndexOf('\n');
+            if (lastNL !== -1) {
+                process.stderr.write(lineBuf.slice(0, lastNL + 1));
+                lineBuf = lineBuf.slice(lastNL + 1);
+            }
+        } else {
+            process.stderr.write(chunk);
+        }
+    };
+
+    const renderer = new TextRenderer({
+        write,
+        output: chunk => process.stdout.write(chunk),
+        getMemoryUsage: () => process.memoryUsage()
+    });
+    logger.setRenderer(renderer);
 
     process.on('uncaughtException', (err, origin) => {
         failExit(err, `uncaughtException (${origin})`);
@@ -752,15 +768,11 @@ const main = async () => {
         failExit(err);
     }
 
-    // re-install the text renderer with the memory-usage overlay if the
-    // user requested it via --mem; otherwise keep the baseline renderer.
-    if (options.mem) {
-        logger.setRenderer(new TextRenderer({
-            write: chunk => process.stderr.write(chunk),
-            output: chunk => process.stdout.write(chunk),
-            getMemoryUsage: () => process.memoryUsage()
-        }));
-    }
+    // Apply post-parse flags. `--no-tty` forces line buffering even on a
+    // TTY (for backends that report stderr as a TTY but aren't really).
+    noTty ||= options.noTty;
+    renderer.mem = options.mem;
+
     if (options.quiet) {
         logger.setVerbosity('quiet');
     } else if (options.verbose) {

--- a/src/lib/utils/text-renderer.ts
+++ b/src/lib/utils/text-renderer.ts
@@ -24,11 +24,13 @@ interface TextRendererOptions {
      */
     output?: (chunk: string) => void;
     /**
-     * Optional memory probe. Used by the `[rss: X, heap: X, ab: X]`
-     * overlay gated by the renderer's `mem` field. Use
-     * `process.memoryUsage` in Node.
+     * Optional peak-memory probe in bytes. Used by the `[peak X]`
+     * overlay gated by the renderer's `mem` field. In Node this is
+     * typically derived from `process.resourceUsage().maxRSS` (which
+     * is kernel-tracked and reflects the whole process - including
+     * ArrayBuffers - rather than just the V8 heap).
      */
-    getMemoryUsage?: () => { rss: number; heapUsed: number; arrayBuffers: number };
+    getPeakMemory?: () => number;
 }
 
 const indent = (depth: number): string => '  '.repeat(Math.max(0, depth));
@@ -69,16 +71,15 @@ class TextRenderer implements Renderer {
 
     private readonly output: (chunk: string) => void;
 
-    private readonly getMemoryUsage?: () => { rss: number; heapUsed: number; arrayBuffers: number };
+    private readonly getPeakMemory?: () => number;
 
     /**
-     * When true, scope-end and bar-end lines gain a
-     * `[rss: X, heap: X, ab: X]` suffix sourced from
-     * {@link TextRendererOptions.getMemoryUsage}. No effect when the
-     * probe is omitted. Defaults to `true` when `getMemoryUsage` is
-     * provided so embedders that supply a probe see the overlay
-     * automatically (matching the prior behavior). Mutable so the
-     * host can toggle the overlay without re-installing the renderer.
+     * When true, scope-end and bar-end lines gain a `[peak X]` suffix
+     * sourced from {@link TextRendererOptions.getPeakMemory}. No
+     * effect when the probe is omitted. Defaults to `true` when
+     * `getPeakMemory` is provided so embedders that supply a probe
+     * see the overlay automatically. Mutable so the host can toggle
+     * the overlay without re-installing the renderer.
      */
     mem: boolean;
 
@@ -94,8 +95,8 @@ class TextRenderer implements Renderer {
     constructor(options: TextRendererOptions) {
         this.write = options.write;
         this.output = options.output ?? options.write;
-        this.getMemoryUsage = options.getMemoryUsage;
-        this.mem = options.getMemoryUsage !== undefined;
+        this.getPeakMemory = options.getPeakMemory;
+        this.mem = options.getPeakMemory !== undefined;
     }
 
     private rank(): number {
@@ -198,9 +199,8 @@ class TextRenderer implements Renderer {
     }
 
     private memSuffix(): string {
-        if (!this.mem || !this.getMemoryUsage) return '';
-        const m = this.getMemoryUsage();
-        return `  [rss: ${fmtBytes(m.rss)}, heap: ${fmtBytes(m.heapUsed)}, ab: ${fmtBytes(m.arrayBuffers)}]`;
+        if (!this.mem || !this.getPeakMemory) return '';
+        return `  [peak ${fmtBytes(this.getPeakMemory())}]`;
     }
 }
 

--- a/src/lib/utils/text-renderer.ts
+++ b/src/lib/utils/text-renderer.ts
@@ -19,9 +19,9 @@ interface TextRendererOptions {
      */
     output?: (chunk: string) => void;
     /**
-     * Optional memory probe. When provided, scope-end and bar-end lines
-     * gain a `[rss: X, heap: X, ab: X]` overlay. Use `process.memoryUsage`
-     * in Node, or omit for a clean view.
+     * Optional memory probe. Used by the `[rss: X, heap: X, ab: X]`
+     * overlay gated by the renderer's `mem` field. Use
+     * `process.memoryUsage` in Node.
      */
     getMemoryUsage?: () => { rss: number; heapUsed: number; arrayBuffers: number };
 }
@@ -65,6 +65,15 @@ class TextRenderer implements Renderer {
     private readonly output: (chunk: string) => void;
 
     private readonly getMemoryUsage?: () => { rss: number; heapUsed: number; arrayBuffers: number };
+
+    /**
+     * When true, scope-end and bar-end lines gain a
+     * `[rss: X, heap: X, ab: X]` suffix sourced from
+     * {@link TextRendererOptions.getMemoryUsage}. No effect when the
+     * probe is omitted. Mutable so the host can toggle the overlay
+     * without re-installing the renderer.
+     */
+    mem = false;
 
     /** True while a bar header has been written without its closing `\n`. */
     private lineDirty = false;
@@ -181,7 +190,7 @@ class TextRenderer implements Renderer {
     }
 
     private memSuffix(): string {
-        if (!this.getMemoryUsage) return '';
+        if (!this.mem || !this.getMemoryUsage) return '';
         const m = this.getMemoryUsage();
         return `  [rss: ${fmtBytes(m.rss)}, heap: ${fmtBytes(m.heapUsed)}, ab: ${fmtBytes(m.arrayBuffers)}]`;
     }

--- a/src/lib/utils/text-renderer.ts
+++ b/src/lib/utils/text-renderer.ts
@@ -7,8 +7,13 @@ import { logger, verbosityRank, type LogEvent, type Renderer } from './logger';
 interface TextRendererOptions {
     /**
      * Receives all status chunks (scopes, bars, messages). May contain
-     * partial-line writes - hand this to a stream that flushes on partials
-     * (e.g. `process.stderr.write.bind(process.stderr)` in Node).
+     * partial-line writes (e.g. progress-bar `#` ticks). For TTY output,
+     * hand this to a stream that flushes on partials
+     * (`process.stderr.write.bind(process.stderr)` in Node) so bars
+     * render in place. For non-interactive output (CI logs, file
+     * redirects), wrap in a line buffer that holds chunks until a `\n`
+     * arrives - the bar's incremental writes then coalesce into a single
+     * complete line per bar.
      */
     write: (chunk: string) => void;
     /**

--- a/src/lib/utils/text-renderer.ts
+++ b/src/lib/utils/text-renderer.ts
@@ -75,10 +75,12 @@ class TextRenderer implements Renderer {
      * When true, scope-end and bar-end lines gain a
      * `[rss: X, heap: X, ab: X]` suffix sourced from
      * {@link TextRendererOptions.getMemoryUsage}. No effect when the
-     * probe is omitted. Mutable so the host can toggle the overlay
-     * without re-installing the renderer.
+     * probe is omitted. Defaults to `true` when `getMemoryUsage` is
+     * provided so embedders that supply a probe see the overlay
+     * automatically (matching the prior behavior). Mutable so the
+     * host can toggle the overlay without re-installing the renderer.
      */
-    mem = false;
+    mem: boolean;
 
     /** True while a bar header has been written without its closing `\n`. */
     private lineDirty = false;
@@ -93,6 +95,7 @@ class TextRenderer implements Renderer {
         this.write = options.write;
         this.output = options.output ?? options.write;
         this.getMemoryUsage = options.getMemoryUsage;
+        this.mem = options.getMemoryUsage !== undefined;
     }
 
     private rank(): number {


### PR DESCRIPTION
## Summary

- Adds `--no-tty` CLI flag to force non-interactive output, with auto-detection via `process.stderr.isTTY` as the default.
- Wraps the renderer's stderr sink in a line-buffer when active so the bar's `▸ name [` + incremental `#` ticks + `....] dur\n` sequence coalesces into a single complete line per bar — instead of streaming partial-line `#` runs that flood non-interactive log viewers.
- Promotes the renderer's memory-usage overlay to a public mutable `mem` field on `TextRenderer`, so the host can toggle the overlay after parse without re-installing the renderer.

## Why

Backend services running splat-transform were producing log files full of `#` characters because their environment didn't trip the existing partial-line heuristics. `--no-tty` (and the auto-detection that already works for piped stderr) gives a clean way to opt out of TTY-style rendering.

## Notes

- The `--no-tty` flag is wired via `parseArgs`' `allowNegative`: declared internally as `tty: { type: 'boolean', default: true }` and consumed as `noTty: !v.tty`, so `--no-tty` behaves as the negation of the implicit `--tty`.
- `TextRenderer` itself stays TTY-agnostic — the line-buffering lives in the CLI's `write` sink. Embedders that want non-interactive output can hand any line-buffering sink to the renderer's `write` option.

## Test plan

- [ ] `npm test` passes (468/468)
- [ ] Run on a TTY: bars render with inline `#` ticks as before
- [ ] Pipe stderr (`splat-transform ... 2>&1 | cat`): bars collapse to one complete line per bar
- [ ] On a TTY with `--no-tty`: same one-line-per-bar output as the piped case
- [ ] `--mem` still shows the `[rss/heap/ab]` overlay on scope-end and bar-end lines