### PR TITLE
Voxel pipeline memory optimizations for large grids

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -699,6 +699,17 @@ const main = async () => {
         return process.platform === 'win32' ? raw : raw * 1024;
     };
 
+    // V8-tracked currently-live memory: heapUsed (JS objects) + external
+    // (C++-bound, includes ArrayBuffer storage for typed arrays — which is
+    // most of our memory in this app). Drops when GC reclaims, so the
+    // delta between phase boundaries reveals whether each phase actually
+    // releases its scratch buffers (vs the kernel maxRSS metric, which is
+    // monotonic).
+    const liveMemoryBytes = (): number => {
+        const u = process.memoryUsage();
+        return u.heapUsed + u.external;
+    };
+
     // Emit the final timing line plus peak memory usage.
     const reportDone = (failed = false) => {
         const elapsedMs = performance.now() - startTime;
@@ -759,7 +770,8 @@ const main = async () => {
     const renderer = new TextRenderer({
         write,
         output: chunk => process.stdout.write(chunk),
-        getPeakMemory: peakMemoryBytes
+        getPeakMemory: peakMemoryBytes,
+        getLiveMemory: liveMemoryBytes
     });
     logger.setRenderer(renderer);
 

--- a/src/lib/utils/text-renderer.ts
+++ b/src/lib/utils/text-renderer.ts
@@ -31,6 +31,18 @@ interface TextRendererOptions {
      * ArrayBuffers - rather than just the V8 heap).
      */
     getPeakMemory?: () => number;
+    /**
+     * Optional currently-live memory probe in bytes. When supplied
+     * alongside `getPeakMemory`, the `--mem` overlay becomes
+     * `[peak X | live Y]`, where `live` reflects memory that V8 still
+     * tracks as alive. Unlike `peak` (kernel max RSS, monotonic), this
+     * value drops when the GC reclaims unreferenced allocations, so
+     * the gap between consecutive phases reveals whether each phase
+     * actually releases its scratch buffers. In Node this is typically
+     * `heapUsed + external` from `process.memoryUsage()` so ArrayBuffer
+     * storage (typed arrays) is included.
+     */
+    getLiveMemory?: () => number;
 }
 
 const indent = (depth: number): string => '  '.repeat(Math.max(0, depth));
@@ -73,13 +85,16 @@ class TextRenderer implements Renderer {
 
     private readonly getPeakMemory?: () => number;
 
+    private readonly getLiveMemory?: () => number;
+
     /**
      * When true, scope-end and bar-end lines gain a `[peak X]` suffix
-     * sourced from {@link TextRendererOptions.getPeakMemory}. No
-     * effect when the probe is omitted. Defaults to `true` when
-     * `getPeakMemory` is provided so embedders that supply a probe
-     * see the overlay automatically. Mutable so the host can toggle
-     * the overlay without re-installing the renderer.
+     * (or `[peak X | live Y]` when {@link TextRendererOptions.getLiveMemory}
+     * is also supplied) sourced from
+     * {@link TextRendererOptions.getPeakMemory}. No effect when the probe
+     * is omitted. Defaults to `true` when `getPeakMemory` is provided so
+     * embedders that supply a probe see the overlay automatically. Mutable
+     * so the host can toggle the overlay without re-installing the renderer.
      */
     mem: boolean;
 
@@ -96,6 +111,7 @@ class TextRenderer implements Renderer {
         this.write = options.write;
         this.output = options.output ?? options.write;
         this.getPeakMemory = options.getPeakMemory;
+        this.getLiveMemory = options.getLiveMemory;
         this.mem = options.getPeakMemory !== undefined;
     }
 
@@ -200,7 +216,9 @@ class TextRenderer implements Renderer {
 
     private memSuffix(): string {
         if (!this.mem || !this.getPeakMemory) return '';
-        return `  [peak ${fmtBytes(this.getPeakMemory())}]`;
+        const peak = fmtBytes(this.getPeakMemory());
+        if (!this.getLiveMemory) return `  [peak ${peak}]`;
+        return `  [peak ${peak} | live ${fmtBytes(this.getLiveMemory())}]`;
     }
 }
 

--- a/src/lib/voxel/block-cleanup.ts
+++ b/src/lib/voxel/block-cleanup.ts
@@ -62,7 +62,7 @@ function filterAndFillBlocks(buffer: BlockMaskBuffer): BlockMaskBuffer {
     }
 
     // New masks array (snapshot: cross-block lookups always read the original masks)
-    const newMasks = new Array<number>(masks.length);
+    const newMasks = new Uint32Array(masks.length);
     let voxelsRemoved = 0;
     let voxelsFilled = 0;
 
@@ -188,7 +188,7 @@ function addCrossFace(
     nx: number, ny: number, nz: number,
     solidSet: Set<number>,
     mixedMap: Map<number, number>,
-    masks: number[],
+    masks: Uint32Array,
     ourFaceMask: number,
     adjFaceMask: number,
     shiftAmount: number,
@@ -225,7 +225,7 @@ function addCrossFaceZ(
     nx: number, ny: number, nz: number,
     solidSet: Set<number>,
     mixedMap: Map<number, number>,
-    masks: number[],
+    masks: Uint32Array,
     plusZ: boolean,
     curLo: number, curHi: number,
     write: (lo: number, hi: number) => void

--- a/src/lib/voxel/block-mask-buffer.ts
+++ b/src/lib/voxel/block-mask-buffer.ts
@@ -23,20 +23,24 @@ const growUint32 = (src: Uint32Array, newCap: number): Uint32Array => {
  * voxel masks use Uint32Array. This raises the per-buffer capacity well
  * above V8's regular-array backing-store limit so very large grids can
  * round-trip without throwing `RangeError: Invalid array length`.
+ *
+ * Buffers start at length 0 and the first `addBlock` allocates
+ * `INITIAL_CAPACITY` entries; subsequent grows double. A freshly cleared
+ * instance therefore retains no allocations until it is reused.
  */
 class BlockMaskBuffer {
     /** Morton codes for solid blocks (mask is implicitly all 1s) */
-    private _solidMorton: Float64Array = new Float64Array(INITIAL_CAPACITY);
+    private _solidMorton: Float64Array = new Float64Array(0);
     private _solidCount = 0;
-    private _solidCap = INITIAL_CAPACITY;
+    private _solidCap = 0;
 
     /** Morton codes for mixed blocks */
-    private _mixedMorton: Float64Array = new Float64Array(INITIAL_CAPACITY);
+    private _mixedMorton: Float64Array = new Float64Array(0);
     private _mixedCount = 0;
-    private _mixedCap = INITIAL_CAPACITY;
+    private _mixedCap = 0;
 
     /** Interleaved voxel masks for mixed blocks: [lo0, hi0, lo1, hi1, ...] */
-    private _mixedMasks: Uint32Array = new Uint32Array(INITIAL_CAPACITY * 2);
+    private _mixedMasks: Uint32Array = new Uint32Array(0);
 
     /**
      * Add a non-empty block to the buffer.
@@ -53,13 +57,14 @@ class BlockMaskBuffer {
 
         if (isSolid(lo, hi)) {
             if (this._solidCount === this._solidCap) {
-                this._solidCap *= 2;
+                // First grow: 0 → INITIAL_CAPACITY. Subsequent: double.
+                this._solidCap = this._solidCap === 0 ? INITIAL_CAPACITY : this._solidCap * 2;
                 this._solidMorton = growFloat64(this._solidMorton, this._solidCap);
             }
             this._solidMorton[this._solidCount++] = morton;
         } else {
             if (this._mixedCount === this._mixedCap) {
-                this._mixedCap *= 2;
+                this._mixedCap = this._mixedCap === 0 ? INITIAL_CAPACITY : this._mixedCap * 2;
                 this._mixedMorton = growFloat64(this._mixedMorton, this._mixedCap);
                 this._mixedMasks = growUint32(this._mixedMasks, this._mixedCap * 2);
             }
@@ -121,17 +126,18 @@ class BlockMaskBuffer {
 
     /**
      * Clear all buffered blocks. Releases the underlying buffers so a cleared
-     * instance does not retain peak memory.
+     * instance does not retain peak memory; the next `addBlock` re-allocates
+     * to `INITIAL_CAPACITY`.
      */
     clear(): void {
-        this._solidMorton = new Float64Array(INITIAL_CAPACITY);
+        this._solidMorton = new Float64Array(0);
         this._solidCount = 0;
-        this._solidCap = INITIAL_CAPACITY;
+        this._solidCap = 0;
 
-        this._mixedMorton = new Float64Array(INITIAL_CAPACITY);
-        this._mixedMasks = new Uint32Array(INITIAL_CAPACITY * 2);
+        this._mixedMorton = new Float64Array(0);
+        this._mixedMasks = new Uint32Array(0);
         this._mixedCount = 0;
-        this._mixedCap = INITIAL_CAPACITY;
+        this._mixedCap = 0;
     }
 }
 

--- a/src/lib/voxel/block-mask-buffer.ts
+++ b/src/lib/voxel/block-mask-buffer.ts
@@ -1,18 +1,42 @@
 import { isSolid, isEmpty } from './morton';
 
+const INITIAL_CAPACITY = 1024;
+
+const growFloat64 = (src: Float64Array, newCap: number): Float64Array => {
+    const grown = new Float64Array(newCap);
+    grown.set(src);
+    return grown;
+};
+
+const growUint32 = (src: Uint32Array, newCap: number): Uint32Array => {
+    const grown = new Uint32Array(newCap);
+    grown.set(src);
+    return grown;
+};
+
 /**
  * Append-only buffer for streaming voxelization results.
  * Stores block masks using Morton codes for efficient octree construction.
+ *
+ * Backed by typed arrays that grow geometrically. Morton codes use
+ * Float64Array (51 bits of precision needed; exceeds Smi range), and
+ * voxel masks use Uint32Array. This raises the per-buffer capacity well
+ * above V8's regular-array backing-store limit so very large grids can
+ * round-trip without throwing `RangeError: Invalid array length`.
  */
 class BlockMaskBuffer {
+    /** Morton codes for solid blocks (mask is implicitly all 1s) */
+    private _solidMorton: Float64Array = new Float64Array(INITIAL_CAPACITY);
+    private _solidCount = 0;
+    private _solidCap = INITIAL_CAPACITY;
+
     /** Morton codes for mixed blocks */
-    private _mixedMorton: number[] = [];
+    private _mixedMorton: Float64Array = new Float64Array(INITIAL_CAPACITY);
+    private _mixedCount = 0;
+    private _mixedCap = INITIAL_CAPACITY;
 
     /** Interleaved voxel masks for mixed blocks: [lo0, hi0, lo1, hi1, ...] */
-    private _mixedMasks: number[] = [];
-
-    /** Morton codes for solid blocks (mask is implicitly all 1s) */
-    private _solidMorton: number[] = [];
+    private _mixedMasks: Uint32Array = new Uint32Array(INITIAL_CAPACITY * 2);
 
     /**
      * Add a non-empty block to the buffer.
@@ -28,32 +52,44 @@ class BlockMaskBuffer {
         }
 
         if (isSolid(lo, hi)) {
-            this._solidMorton.push(morton);
+            if (this._solidCount === this._solidCap) {
+                this._solidCap *= 2;
+                this._solidMorton = growFloat64(this._solidMorton, this._solidCap);
+            }
+            this._solidMorton[this._solidCount++] = morton;
         } else {
-            this._mixedMorton.push(morton);
-            this._mixedMasks.push(lo, hi);
+            if (this._mixedCount === this._mixedCap) {
+                this._mixedCap *= 2;
+                this._mixedMorton = growFloat64(this._mixedMorton, this._mixedCap);
+                this._mixedMasks = growUint32(this._mixedMasks, this._mixedCap * 2);
+            }
+            this._mixedMorton[this._mixedCount] = morton;
+            this._mixedMasks[this._mixedCount * 2] = lo;
+            this._mixedMasks[this._mixedCount * 2 + 1] = hi;
+            this._mixedCount++;
         }
     }
 
     /**
-     * Get all mixed blocks.
+     * Get all mixed blocks as views into the underlying buffers.
+     * Index `i` of `morton` corresponds to mask pair `(masks[i*2], masks[i*2+1])`.
      *
      * @returns Object with morton codes and interleaved masks
      */
-    getMixedBlocks(): { morton: number[]; masks: number[] } {
+    getMixedBlocks(): { morton: Float64Array; masks: Uint32Array } {
         return {
-            morton: this._mixedMorton,
-            masks: this._mixedMasks
+            morton: this._mixedMorton.subarray(0, this._mixedCount),
+            masks: this._mixedMasks.subarray(0, this._mixedCount * 2)
         };
     }
 
     /**
-     * Get all solid blocks.
+     * Get all solid blocks as a view into the underlying buffer.
      *
      * @returns Array of Morton codes
      */
-    getSolidBlocks(): number[] {
-        return this._solidMorton;
+    getSolidBlocks(): Float64Array {
+        return this._solidMorton.subarray(0, this._solidCount);
     }
 
     /**
@@ -62,7 +98,7 @@ class BlockMaskBuffer {
      * @returns Count of mixed + solid blocks
      */
     get count(): number {
-        return this._mixedMorton.length + this._solidMorton.length;
+        return this._mixedCount + this._solidCount;
     }
 
     /**
@@ -71,7 +107,7 @@ class BlockMaskBuffer {
      * @returns Count of mixed blocks
      */
     get mixedCount(): number {
-        return this._mixedMorton.length;
+        return this._mixedCount;
     }
 
     /**
@@ -80,16 +116,22 @@ class BlockMaskBuffer {
      * @returns Count of solid blocks
      */
     get solidCount(): number {
-        return this._solidMorton.length;
+        return this._solidCount;
     }
 
     /**
-     * Clear all buffered blocks.
+     * Clear all buffered blocks. Releases the underlying buffers so a cleared
+     * instance does not retain peak memory.
      */
     clear(): void {
-        this._mixedMorton.length = 0;
-        this._mixedMasks.length = 0;
-        this._solidMorton.length = 0;
+        this._solidMorton = new Float64Array(INITIAL_CAPACITY);
+        this._solidCount = 0;
+        this._solidCap = INITIAL_CAPACITY;
+
+        this._mixedMorton = new Float64Array(INITIAL_CAPACITY);
+        this._mixedMasks = new Uint32Array(INITIAL_CAPACITY * 2);
+        this._mixedCount = 0;
+        this._mixedCap = INITIAL_CAPACITY;
     }
 }
 

--- a/src/lib/voxel/carve.ts
+++ b/src/lib/voxel/carve.ts
@@ -50,7 +50,8 @@ const carve = (
 
     const gridA = SparseVoxelGrid.fromBuffer(buffer, nx, ny, nz);
 
-    const blocked = sparseDilate3(gridA, kernelR, yHalfExtent);
+    // gridA is read only by this dilate; consume it as scratch.
+    const blocked = sparseDilate3(gridA, kernelR, yHalfExtent, true);
 
     let seedIx = Math.floor((seed.x - gridBounds.min.x) / voxelResolution);
     let seedIy = Math.floor((seed.y - gridBounds.min.y) / voxelResolution);
@@ -81,7 +82,8 @@ const carve = (
 
     const emptyGrid = computeEmptyGrid(visited, blocked);
 
-    const navRegion = sparseDilate3(emptyGrid, kernelR, yHalfExtent);
+    // emptyGrid is read only by this dilate; consume it as scratch.
+    const navRegion = sparseDilate3(emptyGrid, kernelR, yHalfExtent, true);
 
     const navBounds = navRegion.getOccupiedBlockBounds();
 

--- a/src/lib/voxel/carve.ts
+++ b/src/lib/voxel/carve.ts
@@ -75,7 +75,7 @@ const carve = (
     }
 
     const seedBlockIdx = (seedIx >> 2) + (seedIy >> 2) * nbx + (seedIz >> 2) * (nbx * nby);
-    const seedBt = blocked.blockType[seedBlockIdx];
+    const seedBt = blocked.getBlockType(seedBlockIdx);
     const bSeeds = seedBt === BLOCK_EMPTY ? [seedBlockIdx] : [];
     const vSeeds = seedBt === BLOCK_EMPTY ? [] : [{ ix: seedIx, iy: seedIy, iz: seedIz }];
     const visited = twoLevelBFS(blocked, bSeeds, vSeeds, nx, ny, nz);

--- a/src/lib/voxel/dilation.ts
+++ b/src/lib/voxel/dilation.ts
@@ -1,7 +1,8 @@
 import {
     BLOCK_EMPTY,
-    BLOCK_MIXED,
     BLOCK_SOLID,
+    BLOCKS_PER_WORD,
+    EVEN_BITS,
     SOLID_HI,
     SOLID_LO,
     SparseVoxelGrid
@@ -10,21 +11,31 @@ import { logger } from '../utils';
 
 // ============================================================================
 // Active Pair Computation
+//
+// Each function iterates `grid.types` (packed 2-bit blockTypes, 16 blocks
+// per word) and derives a per-word "non-empty lane" mask using the trick
+//   nonEmpty = (word & 0x55555555) | ((word >>> 1) & 0x55555555)
+// which sets bit 2k iff lane k is non-zero. The set bits are then walked
+// the same way the old occupancy bitfield was.
 // ============================================================================
 
 function getActiveYZPairs(grid: SparseVoxelGrid): Set<number> {
     const pairs = new Set<number>();
     const { nbx } = grid;
     const totalBlocks = grid.nbx * grid.nby * grid.nbz;
-    for (let w = 0; w < grid.occupancy.length; w++) {
-        let bits = grid.occupancy[w];
-        while (bits) {
-            const bitPos = 31 - Math.clz32(bits & -bits);
-            const blockIdx = w * 32 + bitPos;
+    const types = grid.types;
+    for (let w = 0; w < types.length; w++) {
+        const word = types[w];
+        if (word === 0) continue;
+        let nonEmpty = ((word & EVEN_BITS) | ((word >>> 1) & EVEN_BITS)) >>> 0;
+        const baseIdx = w * BLOCKS_PER_WORD;
+        while (nonEmpty) {
+            const bp = 31 - Math.clz32(nonEmpty & -nonEmpty);
+            const blockIdx = baseIdx + (bp >>> 1);
             if (blockIdx < totalBlocks) {
                 pairs.add((blockIdx / nbx) | 0);
             }
-            bits &= bits - 1;
+            nonEmpty &= nonEmpty - 1;
         }
     }
     return pairs;
@@ -34,17 +45,21 @@ function getActiveXZPairs(grid: SparseVoxelGrid): Set<number> {
     const pairs = new Set<number>();
     const { nbx, bStride } = grid;
     const totalBlocks = grid.nbx * grid.nby * grid.nbz;
-    for (let w = 0; w < grid.occupancy.length; w++) {
-        let bits = grid.occupancy[w];
-        while (bits) {
-            const bitPos = 31 - Math.clz32(bits & -bits);
-            const blockIdx = w * 32 + bitPos;
+    const types = grid.types;
+    for (let w = 0; w < types.length; w++) {
+        const word = types[w];
+        if (word === 0) continue;
+        let nonEmpty = ((word & EVEN_BITS) | ((word >>> 1) & EVEN_BITS)) >>> 0;
+        const baseIdx = w * BLOCKS_PER_WORD;
+        while (nonEmpty) {
+            const bp = 31 - Math.clz32(nonEmpty & -nonEmpty);
+            const blockIdx = baseIdx + (bp >>> 1);
             if (blockIdx < totalBlocks) {
                 const bx = blockIdx % nbx;
                 const bz = (blockIdx / bStride) | 0;
                 pairs.add(bx + bz * nbx);
             }
-            bits &= bits - 1;
+            nonEmpty &= nonEmpty - 1;
         }
     }
     return pairs;
@@ -54,17 +69,21 @@ function getActiveXYPairs(grid: SparseVoxelGrid): Set<number> {
     const pairs = new Set<number>();
     const { nbx, nby } = grid;
     const totalBlocks = grid.nbx * grid.nby * grid.nbz;
-    for (let w = 0; w < grid.occupancy.length; w++) {
-        let bits = grid.occupancy[w];
-        while (bits) {
-            const bitPos = 31 - Math.clz32(bits & -bits);
-            const blockIdx = w * 32 + bitPos;
+    const types = grid.types;
+    for (let w = 0; w < types.length; w++) {
+        const word = types[w];
+        if (word === 0) continue;
+        let nonEmpty = ((word & EVEN_BITS) | ((word >>> 1) & EVEN_BITS)) >>> 0;
+        const baseIdx = w * BLOCKS_PER_WORD;
+        while (nonEmpty) {
+            const bp = 31 - Math.clz32(nonEmpty & -nonEmpty);
+            const blockIdx = baseIdx + (bp >>> 1);
             if (blockIdx < totalBlocks) {
                 const bx = blockIdx % nbx;
                 const by = ((blockIdx / nbx) | 0) % nby;
                 pairs.add(bx + by * nbx);
             }
-            bits &= bits - 1;
+            nonEmpty &= nonEmpty - 1;
         }
     }
     return pairs;
@@ -72,6 +91,9 @@ function getActiveXYPairs(grid: SparseVoxelGrid): Set<number> {
 
 // ============================================================================
 // Line Extraction / Write-back
+//
+// `getType` reads a packed 2-bit block type. V8 should JIT this into a few
+// inline ops per call; small overhead vs the old direct Uint8Array read.
 // ============================================================================
 
 function extractLineX(grid: SparseVoxelGrid, iy: number, iz: number, buf: Uint32Array): void {
@@ -80,9 +102,10 @@ function extractLineX(grid: SparseVoxelGrid, iy: number, iz: number, buf: Uint32
     const inHi = bitBase >= 32;
     const shift = inHi ? bitBase - 32 : bitBase;
     const lineBase = by * grid.nbx + bz * grid.bStride;
+    const types = grid.types;
     for (let bx = 0; bx < grid.nbx; bx++) {
         const blockIdx = lineBase + bx;
-        const bt = grid.blockType[blockIdx];
+        const bt = (types[blockIdx >>> 4] >>> ((blockIdx & 15) << 1)) & 0x3;
         if (bt === BLOCK_EMPTY) continue;
         let row4: number;
         if (bt === BLOCK_SOLID) {
@@ -121,9 +144,10 @@ function extractLineY(grid: SparseVoxelGrid, ix: number, iz: number, buf: Uint32
     const lx = ix & 3, lz = iz & 3;
     const inHi = lz >= 2;
     const base = lx + (lz & 1) * 16;
+    const types = grid.types;
     for (let by = 0; by < grid.nby; by++) {
         const blockIdx = bx + by * grid.nbx + bz * grid.bStride;
-        const bt = grid.blockType[blockIdx];
+        const bt = (types[blockIdx >>> 4] >>> ((blockIdx & 15) << 1)) & 0x3;
         if (bt === BLOCK_EMPTY) continue;
         let row4: number;
         if (bt === BLOCK_SOLID) {
@@ -167,9 +191,10 @@ function writeLineY(grid: SparseVoxelGrid, ix: number, iz: number, buf: Uint32Ar
 function extractLineZ(grid: SparseVoxelGrid, ix: number, iy: number, buf: Uint32Array): void {
     const bx = ix >> 2, by = iy >> 2;
     const base = (ix & 3) + ((iy & 3) << 2);
+    const types = grid.types;
     for (let bz = 0; bz < grid.nbz; bz++) {
         const blockIdx = bx + by * grid.nbx + bz * grid.bStride;
-        const bt = grid.blockType[blockIdx];
+        const bt = (types[blockIdx >>> 4] >>> ((blockIdx & 15) << 1)) & 0x3;
         if (bt === BLOCK_EMPTY) continue;
         let row4: number;
         if (bt === BLOCK_SOLID) {
@@ -233,7 +258,7 @@ function sparseDilateX(src: SparseVoxelGrid, dst: SparseVoxelGrid, halfExtent: n
     const lineWords = (nx + 31) >>> 5;
     const srcBuf = new Uint32Array(lineWords);
     const dstBuf = new Uint32Array(lineWords);
-    const srcBT = src.blockType;
+    const srcTypes = src.types;
     const activePairs = getActiveYZPairs(src);
     for (const key of activePairs) {
         const by = key % nby;
@@ -242,7 +267,8 @@ function sparseDilateX(src: SparseVoxelGrid, dst: SparseVoxelGrid, halfExtent: n
         const lineBase = by * nbx + bz * bStride;
         let allSolid = true;
         for (let bx = 0; bx < nbx; bx++) {
-            if (srcBT[lineBase + bx] !== BLOCK_SOLID) {
+            const idx = lineBase + bx;
+            if (((srcTypes[idx >>> 4] >>> ((idx & 15) << 1)) & 0x3) !== BLOCK_SOLID) {
                 allSolid = false;
                 break;
             }
@@ -275,7 +301,7 @@ function sparseDilateZ(src: SparseVoxelGrid, dst: SparseVoxelGrid, halfExtent: n
     const lineWords = (nz + 31) >>> 5;
     const srcBuf = new Uint32Array(lineWords);
     const dstBuf = new Uint32Array(lineWords);
-    const srcBT = src.blockType;
+    const srcTypes = src.types;
     const activePairs = getActiveXYPairs(src);
     for (const key of activePairs) {
         const bx = key % nbx;
@@ -284,7 +310,8 @@ function sparseDilateZ(src: SparseVoxelGrid, dst: SparseVoxelGrid, halfExtent: n
         const lineStart = bx + by * nbx;
         let allSolid = true;
         for (let bz = 0; bz < nbz; bz++) {
-            if (srcBT[lineStart + bz * bStride] !== BLOCK_SOLID) {
+            const idx = lineStart + bz * bStride;
+            if (((srcTypes[idx >>> 4] >>> ((idx & 15) << 1)) & 0x3) !== BLOCK_SOLID) {
                 allSolid = false;
                 break;
             }
@@ -317,7 +344,7 @@ function sparseDilateY(src: SparseVoxelGrid, dst: SparseVoxelGrid, halfExtent: n
     const lineWords = (ny + 31) >>> 5;
     const srcBuf = new Uint32Array(lineWords);
     const dstBuf = new Uint32Array(lineWords);
-    const srcBT = src.blockType;
+    const srcTypes = src.types;
     const activePairs = getActiveXZPairs(src);
     for (const key of activePairs) {
         const bx = key % nbx;
@@ -326,7 +353,8 @@ function sparseDilateY(src: SparseVoxelGrid, dst: SparseVoxelGrid, halfExtent: n
         const lineStart = bx + bz * bStride;
         let allSolid = true;
         for (let by = 0; by < nby; by++) {
-            if (srcBT[lineStart + by * nbx] !== BLOCK_SOLID) {
+            const idx = lineStart + by * nbx;
+            if (((srcTypes[idx >>> 4] >>> ((idx & 15) << 1)) & 0x3) !== BLOCK_SOLID) {
                 allSolid = false;
                 break;
             }
@@ -384,9 +412,6 @@ function sparseDilate3(
     const bar = logger.bar('Dilating', 3);
     sparseDilateX(src, a, halfExtentXZ);
     bar.tick();
-    // Reuse src as the Z-dilation target when allowed. After dilateX,
-    // src is no longer read by anyone in this function, so its storage
-    // is free to repurpose.
     let b: SparseVoxelGrid;
     if (consumeSrc) {
         src.clear();

--- a/src/lib/voxel/dilation.ts
+++ b/src/lib/voxel/dilation.ts
@@ -354,17 +354,46 @@ function sparseDilateY(src: SparseVoxelGrid, dst: SparseVoxelGrid, halfExtent: n
     }
 }
 
+/**
+ * 3D dilation by separable 1D passes (X then Z then Y).
+ *
+ * Allocates one fresh working grid (`a`) and uses one more (`b`) for the
+ * intermediate. When `consumeSrc` is true the caller relinquishes `src`
+ * — it gets cleared and reused as the second working grid, saving one
+ * full SparseVoxelGrid allocation per call. After the function returns
+ * with `consumeSrc=true`, `src` references an empty grid and must not
+ * be read by the caller.
+ *
+ * @param src - Input grid. Read-only when `consumeSrc=false`; consumed
+ * (cleared and used as scratch) when `consumeSrc=true`.
+ * @param halfExtentXZ - Dilation half-extent in voxels along X and Z.
+ * @param halfExtentY - Dilation half-extent in voxels along Y.
+ * @param consumeSrc - If true, the function may reuse `src`'s memory as
+ * a working buffer. Saves ~one full grid's worth of allocation. The
+ * caller must not read `src` after the call.
+ * @returns Newly allocated dilated grid.
+ */
 function sparseDilate3(
     src: SparseVoxelGrid,
     halfExtentXZ: number,
-    halfExtentY: number
+    halfExtentY: number,
+    consumeSrc: boolean = false
 ): SparseVoxelGrid {
     const { nx, ny, nz } = src;
     const a = new SparseVoxelGrid(nx, ny, nz);
     const bar = logger.bar('Dilating', 3);
     sparseDilateX(src, a, halfExtentXZ);
     bar.tick();
-    const b = new SparseVoxelGrid(nx, ny, nz);
+    // Reuse src as the Z-dilation target when allowed. After dilateX,
+    // src is no longer read by anyone in this function, so its storage
+    // is free to repurpose.
+    let b: SparseVoxelGrid;
+    if (consumeSrc) {
+        src.clear();
+        b = src;
+    } else {
+        b = new SparseVoxelGrid(nx, ny, nz);
+    }
     sparseDilateZ(a, b, halfExtentXZ);
     a.clear();
     bar.tick();

--- a/src/lib/voxel/dilation.ts
+++ b/src/lib/voxel/dilation.ts
@@ -5,7 +5,8 @@ import {
     EVEN_BITS,
     SOLID_HI,
     SOLID_LO,
-    SparseVoxelGrid
+    SparseVoxelGrid,
+    readBlockType
 } from './sparse-voxel-grid';
 import { logger } from '../utils';
 
@@ -92,8 +93,9 @@ function getActiveXYPairs(grid: SparseVoxelGrid): Set<number> {
 // ============================================================================
 // Line Extraction / Write-back
 //
-// `getType` reads a packed 2-bit block type. V8 should JIT this into a few
-// inline ops per call; small overhead vs the old direct Uint8Array read.
+// `readBlockType` reads a packed 2-bit block type. As a module-level arrow
+// function it inlines under V8's JIT, matching the perf of the previous
+// direct Uint8Array read modulo the bit math.
 // ============================================================================
 
 function extractLineX(grid: SparseVoxelGrid, iy: number, iz: number, buf: Uint32Array): void {
@@ -105,7 +107,7 @@ function extractLineX(grid: SparseVoxelGrid, iy: number, iz: number, buf: Uint32
     const types = grid.types;
     for (let bx = 0; bx < grid.nbx; bx++) {
         const blockIdx = lineBase + bx;
-        const bt = (types[blockIdx >>> 4] >>> ((blockIdx & 15) << 1)) & 0x3;
+        const bt = readBlockType(types, blockIdx);
         if (bt === BLOCK_EMPTY) continue;
         let row4: number;
         if (bt === BLOCK_SOLID) {
@@ -147,7 +149,7 @@ function extractLineY(grid: SparseVoxelGrid, ix: number, iz: number, buf: Uint32
     const types = grid.types;
     for (let by = 0; by < grid.nby; by++) {
         const blockIdx = bx + by * grid.nbx + bz * grid.bStride;
-        const bt = (types[blockIdx >>> 4] >>> ((blockIdx & 15) << 1)) & 0x3;
+        const bt = readBlockType(types, blockIdx);
         if (bt === BLOCK_EMPTY) continue;
         let row4: number;
         if (bt === BLOCK_SOLID) {
@@ -194,7 +196,7 @@ function extractLineZ(grid: SparseVoxelGrid, ix: number, iy: number, buf: Uint32
     const types = grid.types;
     for (let bz = 0; bz < grid.nbz; bz++) {
         const blockIdx = bx + by * grid.nbx + bz * grid.bStride;
-        const bt = (types[blockIdx >>> 4] >>> ((blockIdx & 15) << 1)) & 0x3;
+        const bt = readBlockType(types, blockIdx);
         if (bt === BLOCK_EMPTY) continue;
         let row4: number;
         if (bt === BLOCK_SOLID) {
@@ -268,7 +270,7 @@ function sparseDilateX(src: SparseVoxelGrid, dst: SparseVoxelGrid, halfExtent: n
         let allSolid = true;
         for (let bx = 0; bx < nbx; bx++) {
             const idx = lineBase + bx;
-            if (((srcTypes[idx >>> 4] >>> ((idx & 15) << 1)) & 0x3) !== BLOCK_SOLID) {
+            if (readBlockType(srcTypes, idx) !== BLOCK_SOLID) {
                 allSolid = false;
                 break;
             }
@@ -311,7 +313,7 @@ function sparseDilateZ(src: SparseVoxelGrid, dst: SparseVoxelGrid, halfExtent: n
         let allSolid = true;
         for (let bz = 0; bz < nbz; bz++) {
             const idx = lineStart + bz * bStride;
-            if (((srcTypes[idx >>> 4] >>> ((idx & 15) << 1)) & 0x3) !== BLOCK_SOLID) {
+            if (readBlockType(srcTypes, idx) !== BLOCK_SOLID) {
                 allSolid = false;
                 break;
             }
@@ -354,7 +356,7 @@ function sparseDilateY(src: SparseVoxelGrid, dst: SparseVoxelGrid, halfExtent: n
         let allSolid = true;
         for (let by = 0; by < nby; by++) {
             const idx = lineStart + by * nbx;
-            if (((srcTypes[idx >>> 4] >>> ((idx & 15) << 1)) & 0x3) !== BLOCK_SOLID) {
+            if (readBlockType(srcTypes, idx) !== BLOCK_SOLID) {
                 allSolid = false;
                 break;
             }

--- a/src/lib/voxel/fill-exterior.ts
+++ b/src/lib/voxel/fill-exterior.ts
@@ -67,7 +67,7 @@ const fillExterior = (
     const faceVoxelSeeds: { ix: number; iy: number; iz: number }[] = [];
 
     const seedBoundaryBlock = (blockIdx: number, bx: number, by: number, bz: number, face: number): void => {
-        const bt = dilated.blockType[blockIdx];
+        const bt = dilated.getBlockType(blockIdx);
         if (bt === BLOCK_SOLID) return;
         if (bt === BLOCK_MIXED) {
             const ms = dilated.masks.slot(blockIdx);
@@ -158,7 +158,7 @@ const fillExterior = (
         for (let by = 0; by < nby; by++) {
             for (let bx = 0; bx < nbx; bx++) {
                 const blockIdx = bx + by * nbx + bz * combined.bStride;
-                const bt = combined.blockType[blockIdx];
+                const bt = combined.getBlockType(blockIdx);
                 if (bt === BLOCK_SOLID) continue;
                 if (bt === BLOCK_MIXED) {
                     const cs = combined.masks.slot(blockIdx);

--- a/src/lib/voxel/fill-floor.ts
+++ b/src/lib/voxel/fill-floor.ts
@@ -155,10 +155,21 @@ const fillFloor = (
 
     if (r > 0) dilatedSolid.clear();
 
-    const dilatedFound = r > 0 ? sparseDilate3(foundEmpty, r, 0) : foundEmpty;
-    if (r > 0) foundEmpty.clear();
+    // foundEmpty is no longer read after this point — pass consumeSrc=true
+    // so sparseDilate3 reuses its memory as the Z-pass working buffer
+    // instead of allocating a fresh full grid. Saves one
+    // SparseVoxelGrid (blockType + occupancy + masks) at peak.
+    // sparseDilate3 also clears foundEmpty on its way out, so no
+    // separate clear() is needed. (When r === 0, dilatedFound IS
+    // foundEmpty; the previous `foundEmpty.clear()` was correctly
+    // skipped on that branch and the same logic applies here.)
+    const dilatedFound = r > 0 ? sparseDilate3(foundEmpty, r, 0, true) : foundEmpty;
 
-    const combined = sparseOrGrids(grid, dilatedFound);
+    // grid is the original voxelization; not read after this OR. Pass
+    // consumeA=true so sparseOrGrids mutates it in place rather than
+    // cloning — saves a full SparseVoxelGrid clone right at the end of
+    // the fill-floor phase.
+    const combined = sparseOrGrids(grid, dilatedFound, true);
     const result = combined.toBuffer(0, 0, 0, nbx, nby, nbz);
 
     return { buffer: result, gridBounds };

--- a/src/lib/voxel/fill-floor.ts
+++ b/src/lib/voxel/fill-floor.ts
@@ -84,13 +84,14 @@ const fillFloor = (
 
     const foundEmpty = new SparseVoxelGrid(nx, ny, nz);
 
+    const dilatedTypes = dilatedSolid.types;
     for (let bz = 0; bz < nbz; bz++) {
         for (let bx = 0; bx < nbx; bx++) {
             let walking = 0xFFFF;
 
             for (let by = 0; by < nby && walking; by++) {
                 const blockIdx = bx + by * nbx + bz * bStride;
-                const bt = dilatedSolid.blockType[blockIdx];
+                const bt = (dilatedTypes[blockIdx >>> 4] >>> ((blockIdx & 15) << 1)) & 0x3;
 
                 if (bt === BLOCK_SOLID) {
                     break;

--- a/src/lib/voxel/fill-floor.ts
+++ b/src/lib/voxel/fill-floor.ts
@@ -9,7 +9,8 @@ import {
     BLOCK_SOLID,
     SOLID_HI,
     SOLID_LO,
-    SparseVoxelGrid
+    SparseVoxelGrid,
+    readBlockType
 } from './sparse-voxel-grid';
 import { logger } from '../utils';
 
@@ -91,7 +92,7 @@ const fillFloor = (
 
             for (let by = 0; by < nby && walking; by++) {
                 const blockIdx = bx + by * nbx + bz * bStride;
-                const bt = (dilatedTypes[blockIdx >>> 4] >>> ((blockIdx & 15) << 1)) & 0x3;
+                const bt = readBlockType(dilatedTypes, blockIdx);
 
                 if (bt === BLOCK_SOLID) {
                     break;

--- a/src/lib/voxel/filter-cluster.ts
+++ b/src/lib/voxel/filter-cluster.ts
@@ -42,30 +42,33 @@ const buildInvertedGrid = (
 ): SparseVoxelGrid => {
     const grid = new SparseVoxelGrid(nx, ny, nz);
 
-    // Default blockType is BLOCK_EMPTY (0). For the inverted grid,
-    // non-occupied blocks must be BLOCK_SOLID (fully blocked).
-    grid.blockType.fill(BLOCK_SOLID);
-    grid.occupancy.fill(0xFFFFFFFF >>> 0);
+    // Inverted grid: every block defaults to SOLID (fully blocked).
+    // SOLID = 0b01 in each 2-bit lane, so the SOLID-everywhere word is
+    // 0x55555555. Then we clear the lanes corresponding to originally-
+    // occupied (i.e. unblocked-in-the-inverted-world) blocks.
+    grid.types.fill(0x55555555 >>> 0);
+    // Trim the final word so the trailing lanes (past totalBlocks) read
+    // back as EMPTY rather than SOLID.
     const totalBlocks = grid.nbx * grid.nby * grid.nbz;
-    const lastWord = totalBlocks >>> 5;
-    const remainder = totalBlocks & 31;
-    if (remainder > 0) {
-        grid.occupancy[lastWord] = ((1 << remainder) - 1) >>> 0;
+    const lastWord = grid.types.length - 1;
+    const lastLanes = totalBlocks - lastWord * 16;
+    if (lastLanes < 16) {
+        const validBits = (1 << (lastLanes * 2)) - 1;
+        grid.types[lastWord] = (grid.types[lastWord] & validBits) >>> 0;
     }
 
     const solidMortons = buffer.getSolidBlocks();
     for (let i = 0; i < solidMortons.length; i++) {
         const [bx, by, bz] = mortonToXYZ(solidMortons[i]);
         const blockIdx = bx + by * grid.nbx + bz * grid.bStride;
-        grid.blockType[blockIdx] = BLOCK_EMPTY;
-        grid.occupancy[blockIdx >>> 5] &= ~(1 << (blockIdx & 31));
+        grid.setBlockType(blockIdx, BLOCK_EMPTY);
     }
 
     const mixed = buffer.getMixedBlocks();
     for (let i = 0; i < mixed.morton.length; i++) {
         const [bx, by, bz] = mortonToXYZ(mixed.morton[i]);
         const blockIdx = bx + by * grid.nbx + bz * grid.bStride;
-        grid.blockType[blockIdx] = BLOCK_MIXED;
+        grid.setBlockType(blockIdx, BLOCK_MIXED);
         grid.masks.set(blockIdx, (~mixed.masks[i * 2]) >>> 0, (~mixed.masks[i * 2 + 1]) >>> 0);
     }
 
@@ -110,7 +113,7 @@ const findClusterVoxelFlood = (
     }
 
     const seedBlockIdx = (seedIx >> 2) + (seedIy >> 2) * nbx + (seedIz >> 2) * bStride;
-    const seedBt = blocked.blockType[seedBlockIdx];
+    const seedBt = blocked.getBlockType(seedBlockIdx);
     const blockSeeds = seedBt === BLOCK_EMPTY ? [seedBlockIdx] : [];
     const voxelSeeds = seedBt === BLOCK_EMPTY ? [] : [{ ix: seedIx, iy: seedIy, iz: seedIz }];
 
@@ -118,15 +121,20 @@ const findClusterVoxelFlood = (
 
     const ccSet = new Set<number>();
     const totalBlocks = nbx * (ny >> 2) * (nz >> 2);
-    for (let w = 0; w < visited.occupancy.length; w++) {
-        let bits = visited.occupancy[w];
-        while (bits) {
-            const bitPos = 31 - Math.clz32(bits & -bits);
-            const blockIdx = w * 32 + bitPos;
+    const visitedTypes = visited.types;
+    const EVEN = 0x55555555 >>> 0;
+    for (let w = 0; w < visitedTypes.length; w++) {
+        const word = visitedTypes[w];
+        if (word === 0) continue;
+        let nonEmpty = ((word & EVEN) | ((word >>> 1) & EVEN)) >>> 0;
+        const baseIdx = w * 16;
+        while (nonEmpty) {
+            const bp = 31 - Math.clz32(nonEmpty & -nonEmpty);
+            const blockIdx = baseIdx + (bp >>> 1);
             if (blockIdx < totalBlocks) {
                 ccSet.add(blockIdx);
             }
-            bits &= bits - 1;
+            nonEmpty &= nonEmpty - 1;
         }
     }
 

--- a/src/lib/voxel/filter-cluster.ts
+++ b/src/lib/voxel/filter-cluster.ts
@@ -13,6 +13,8 @@ import {
     BLOCK_EMPTY,
     BLOCK_MIXED,
     BLOCK_SOLID,
+    BLOCKS_PER_WORD,
+    EVEN_BITS,
     SparseVoxelGrid
 } from './sparse-voxel-grid';
 import {
@@ -122,12 +124,11 @@ const findClusterVoxelFlood = (
     const ccSet = new Set<number>();
     const totalBlocks = nbx * (ny >> 2) * (nz >> 2);
     const visitedTypes = visited.types;
-    const EVEN = 0x55555555 >>> 0;
     for (let w = 0; w < visitedTypes.length; w++) {
         const word = visitedTypes[w];
         if (word === 0) continue;
-        let nonEmpty = ((word & EVEN) | ((word >>> 1) & EVEN)) >>> 0;
-        const baseIdx = w * 16;
+        let nonEmpty = ((word & EVEN_BITS) | ((word >>> 1) & EVEN_BITS)) >>> 0;
+        const baseIdx = w * BLOCKS_PER_WORD;
         while (nonEmpty) {
             const bp = 31 - Math.clz32(nonEmpty & -nonEmpty);
             const blockIdx = baseIdx + (bp >>> 1);

--- a/src/lib/voxel/filter-cluster.ts
+++ b/src/lib/voxel/filter-cluster.ts
@@ -15,6 +15,7 @@ import {
     BLOCK_SOLID,
     BLOCKS_PER_WORD,
     EVEN_BITS,
+    SOLID_WORD,
     SparseVoxelGrid
 } from './sparse-voxel-grid';
 import {
@@ -44,17 +45,17 @@ const buildInvertedGrid = (
 ): SparseVoxelGrid => {
     const grid = new SparseVoxelGrid(nx, ny, nz);
 
-    // Inverted grid: every block defaults to SOLID (fully blocked).
-    // SOLID = 0b01 in each 2-bit lane, so the SOLID-everywhere word is
-    // 0x55555555. Then we clear the lanes corresponding to originally-
-    // occupied (i.e. unblocked-in-the-inverted-world) blocks.
-    grid.types.fill(0x55555555 >>> 0);
+    // Inverted grid: every block defaults to SOLID (fully blocked). SOLID is
+    // 0b01 in each 2-bit lane, so the SOLID-everywhere word is `SOLID_WORD`
+    // (0x55555555). Subsequent code clears the lanes corresponding to
+    // originally-occupied (i.e. unblocked-in-the-inverted-world) blocks.
+    grid.types.fill(SOLID_WORD);
     // Trim the final word so the trailing lanes (past totalBlocks) read
     // back as EMPTY rather than SOLID.
     const totalBlocks = grid.nbx * grid.nby * grid.nbz;
     const lastWord = grid.types.length - 1;
-    const lastLanes = totalBlocks - lastWord * 16;
-    if (lastLanes < 16) {
+    const lastLanes = totalBlocks - lastWord * BLOCKS_PER_WORD;
+    if (lastLanes < BLOCKS_PER_WORD) {
         const validBits = (1 << (lastLanes * 2)) - 1;
         grid.types[lastWord] = (grid.types[lastWord] & validBits) >>> 0;
     }

--- a/src/lib/voxel/flood-fill.ts
+++ b/src/lib/voxel/flood-fill.ts
@@ -6,7 +6,8 @@ import {
     FACE_MASKS_LO,
     SOLID_HI,
     SOLID_LO,
-    SparseVoxelGrid
+    SparseVoxelGrid,
+    TYPE_MASK
 } from './sparse-voxel-grid';
 
 /**
@@ -44,11 +45,22 @@ function twoLevelBFS(
     const nbz = nz >> 2;
     const bStride = nbx * nby;
 
-    const blockedBT = blocked.blockType;
+    const blockedTypes = blocked.types;
     const bMasks = blocked.masks;
-    const visitedBT = visited.blockType;
+    const visitedTypes = visited.types;
     const vMasks = visited.masks;
-    const visitedOcc = visited.occupancy;
+
+    // Inline helpers for the 2-bit packed type array. V8 should JIT
+    // these into the same native operations as the previous direct
+    // Uint8Array accesses, modulo the bit math.
+    const readType = (typesArr: Uint32Array, idx: number): number => {
+        return (typesArr[idx >>> 4] >>> ((idx & 15) << 1)) & TYPE_MASK;
+    };
+    const writeType = (typesArr: Uint32Array, idx: number, value: number): void => {
+        const w = idx >>> 4;
+        const shift = (idx & 15) << 1;
+        typesArr[w] = ((typesArr[w] & ~(TYPE_MASK << shift)) | ((value & TYPE_MASK) << shift)) >>> 0;
+    };
 
     // Block queue (ring buffer of block indices)
     let bqCap = 1 << 14;
@@ -109,10 +121,9 @@ function twoLevelBFS(
     };
 
     const tryFillBlock = (blockIdx: number): boolean => {
-        if (blockedBT[blockIdx] !== BLOCK_EMPTY) return false;
-        if (visitedBT[blockIdx] !== BLOCK_EMPTY) return false;
-        visitedBT[blockIdx] = BLOCK_SOLID;
-        visitedOcc[blockIdx >>> 5] |= (1 << (blockIdx & 31));
+        if (readType(blockedTypes, blockIdx) !== BLOCK_EMPTY) return false;
+        if (readType(visitedTypes, blockIdx) !== BLOCK_EMPTY) return false;
+        writeType(visitedTypes, blockIdx, BLOCK_SOLID);
         if (bqSize >= bqCap) growBlockQueue();
         bqBuf[bqTail] = blockIdx;
         bqTail = (bqTail + 1) & bqMask;
@@ -121,7 +132,7 @@ function twoLevelBFS(
     };
 
     const enqueueFaceVoxels = (nBlockIdx: number, face: number, nBx: number, nBy: number, nBz: number): void => {
-        const vbt = visitedBT[nBlockIdx];
+        const vbt = readType(visitedTypes, nBlockIdx);
         if (vbt === BLOCK_SOLID) return;
 
         const bs = bMasks.slot(nBlockIdx);
@@ -138,15 +149,14 @@ function twoLevelBFS(
         if (freeLo === 0 && freeHi === 0) return;
 
         if (vbt === BLOCK_EMPTY) {
-            visitedBT[nBlockIdx] = BLOCK_MIXED;
-            visitedOcc[nBlockIdx >>> 5] |= (1 << (nBlockIdx & 31));
+            writeType(visitedTypes, nBlockIdx, BLOCK_MIXED);
             vMasks.set(nBlockIdx, freeLo, freeHi);
         } else {
             vMasks.lo[vs] = (vMasks.lo[vs] | freeLo) >>> 0;
             vMasks.hi[vs] = (vMasks.hi[vs] | freeHi) >>> 0;
             if (vMasks.lo[vs] === SOLID_LO && vMasks.hi[vs] === SOLID_HI) {
                 vMasks.removeAt(vs);
-                visitedBT[nBlockIdx] = BLOCK_SOLID;
+                writeType(visitedTypes, nBlockIdx, BLOCK_SOLID);
             }
         }
 
@@ -177,37 +187,37 @@ function twoLevelBFS(
 
         if (bx > 0) {
             const ni = blockIdx - 1;
-            const nbt = blockedBT[ni];
+            const nbt = readType(blockedTypes, ni);
             if (nbt === BLOCK_EMPTY) tryFillBlock(ni);
             else if (nbt === BLOCK_MIXED) enqueueFaceVoxels(ni, 1, bx - 1, by, bz);
         }
         if (bx < nbx - 1) {
             const ni = blockIdx + 1;
-            const nbt = blockedBT[ni];
+            const nbt = readType(blockedTypes, ni);
             if (nbt === BLOCK_EMPTY) tryFillBlock(ni);
             else if (nbt === BLOCK_MIXED) enqueueFaceVoxels(ni, 0, bx + 1, by, bz);
         }
         if (by > 0) {
             const ni = blockIdx - nbx;
-            const nbt = blockedBT[ni];
+            const nbt = readType(blockedTypes, ni);
             if (nbt === BLOCK_EMPTY) tryFillBlock(ni);
             else if (nbt === BLOCK_MIXED) enqueueFaceVoxels(ni, 3, bx, by - 1, bz);
         }
         if (by < nby - 1) {
             const ni = blockIdx + nbx;
-            const nbt = blockedBT[ni];
+            const nbt = readType(blockedTypes, ni);
             if (nbt === BLOCK_EMPTY) tryFillBlock(ni);
             else if (nbt === BLOCK_MIXED) enqueueFaceVoxels(ni, 2, bx, by + 1, bz);
         }
         if (bz > 0) {
             const ni = blockIdx - bStride;
-            const nbt = blockedBT[ni];
+            const nbt = readType(blockedTypes, ni);
             if (nbt === BLOCK_EMPTY) tryFillBlock(ni);
             else if (nbt === BLOCK_MIXED) enqueueFaceVoxels(ni, 5, bx, by, bz - 1);
         }
         if (bz < nbz - 1) {
             const ni = blockIdx + bStride;
-            const nbt = blockedBT[ni];
+            const nbt = readType(blockedTypes, ni);
             if (nbt === BLOCK_EMPTY) tryFillBlock(ni);
             else if (nbt === BLOCK_MIXED) enqueueFaceVoxels(ni, 4, bx, by, bz + 1);
         }
@@ -216,7 +226,7 @@ function twoLevelBFS(
     const tryEnqueueVoxel = (ix: number, iy: number, iz: number): void => {
         const blockIdx = (ix >> 2) + (iy >> 2) * nbx + (iz >> 2) * bStride;
 
-        const bbt = blockedBT[blockIdx];
+        const bbt = readType(blockedTypes, blockIdx);
         if (bbt === BLOCK_SOLID) return;
         if (bbt === BLOCK_EMPTY) {
             tryFillBlock(blockIdx);
@@ -227,7 +237,7 @@ function twoLevelBFS(
         const bitIdx = (ix & 3) + ((iy & 3) << 2) + ((iz & 3) << 4);
         if (bitIdx < 32 ? (bMasks.lo[bs] >>> bitIdx) & 1 : (bMasks.hi[bs] >>> (bitIdx - 32)) & 1) return;
 
-        const vbt = visitedBT[blockIdx];
+        const vbt = readType(visitedTypes, blockIdx);
         if (vbt === BLOCK_SOLID) return;
         if (vbt === BLOCK_MIXED) {
             const vs = vMasks.slot(blockIdx);
@@ -236,11 +246,10 @@ function twoLevelBFS(
             else vMasks.hi[vs] = (vMasks.hi[vs] | (1 << (bitIdx - 32))) >>> 0;
             if (vMasks.lo[vs] === SOLID_LO && vMasks.hi[vs] === SOLID_HI) {
                 vMasks.removeAt(vs);
-                visitedBT[blockIdx] = BLOCK_SOLID;
+                writeType(visitedTypes, blockIdx, BLOCK_SOLID);
             }
         } else {
-            visitedBT[blockIdx] = BLOCK_MIXED;
-            visitedOcc[blockIdx >>> 5] |= (1 << (blockIdx & 31));
+            writeType(visitedTypes, blockIdx, BLOCK_MIXED);
             vMasks.set(blockIdx,
                 bitIdx < 32 ? (1 << bitIdx) >>> 0 : 0,
                 bitIdx >= 32 ? (1 << (bitIdx - 32)) >>> 0 : 0

--- a/src/lib/voxel/flood-fill.ts
+++ b/src/lib/voxel/flood-fill.ts
@@ -7,7 +7,8 @@ import {
     SOLID_HI,
     SOLID_LO,
     SparseVoxelGrid,
-    TYPE_MASK
+    readBlockType,
+    writeBlockType
 } from './sparse-voxel-grid';
 
 /**
@@ -49,18 +50,6 @@ function twoLevelBFS(
     const bMasks = blocked.masks;
     const visitedTypes = visited.types;
     const vMasks = visited.masks;
-
-    // Inline helpers for the 2-bit packed type array. V8 should JIT
-    // these into the same native operations as the previous direct
-    // Uint8Array accesses, modulo the bit math.
-    const readType = (typesArr: Uint32Array, idx: number): number => {
-        return (typesArr[idx >>> 4] >>> ((idx & 15) << 1)) & TYPE_MASK;
-    };
-    const writeType = (typesArr: Uint32Array, idx: number, value: number): void => {
-        const w = idx >>> 4;
-        const shift = (idx & 15) << 1;
-        typesArr[w] = ((typesArr[w] & ~(TYPE_MASK << shift)) | ((value & TYPE_MASK) << shift)) >>> 0;
-    };
 
     // Block queue (ring buffer of block indices)
     let bqCap = 1 << 14;
@@ -121,9 +110,9 @@ function twoLevelBFS(
     };
 
     const tryFillBlock = (blockIdx: number): boolean => {
-        if (readType(blockedTypes, blockIdx) !== BLOCK_EMPTY) return false;
-        if (readType(visitedTypes, blockIdx) !== BLOCK_EMPTY) return false;
-        writeType(visitedTypes, blockIdx, BLOCK_SOLID);
+        if (readBlockType(blockedTypes, blockIdx) !== BLOCK_EMPTY) return false;
+        if (readBlockType(visitedTypes, blockIdx) !== BLOCK_EMPTY) return false;
+        writeBlockType(visitedTypes, blockIdx, BLOCK_SOLID);
         if (bqSize >= bqCap) growBlockQueue();
         bqBuf[bqTail] = blockIdx;
         bqTail = (bqTail + 1) & bqMask;
@@ -132,7 +121,7 @@ function twoLevelBFS(
     };
 
     const enqueueFaceVoxels = (nBlockIdx: number, face: number, nBx: number, nBy: number, nBz: number): void => {
-        const vbt = readType(visitedTypes, nBlockIdx);
+        const vbt = readBlockType(visitedTypes, nBlockIdx);
         if (vbt === BLOCK_SOLID) return;
 
         const bs = bMasks.slot(nBlockIdx);
@@ -149,14 +138,14 @@ function twoLevelBFS(
         if (freeLo === 0 && freeHi === 0) return;
 
         if (vbt === BLOCK_EMPTY) {
-            writeType(visitedTypes, nBlockIdx, BLOCK_MIXED);
+            writeBlockType(visitedTypes, nBlockIdx, BLOCK_MIXED);
             vMasks.set(nBlockIdx, freeLo, freeHi);
         } else {
             vMasks.lo[vs] = (vMasks.lo[vs] | freeLo) >>> 0;
             vMasks.hi[vs] = (vMasks.hi[vs] | freeHi) >>> 0;
             if (vMasks.lo[vs] === SOLID_LO && vMasks.hi[vs] === SOLID_HI) {
                 vMasks.removeAt(vs);
-                writeType(visitedTypes, nBlockIdx, BLOCK_SOLID);
+                writeBlockType(visitedTypes, nBlockIdx, BLOCK_SOLID);
             }
         }
 
@@ -187,37 +176,37 @@ function twoLevelBFS(
 
         if (bx > 0) {
             const ni = blockIdx - 1;
-            const nbt = readType(blockedTypes, ni);
+            const nbt = readBlockType(blockedTypes, ni);
             if (nbt === BLOCK_EMPTY) tryFillBlock(ni);
             else if (nbt === BLOCK_MIXED) enqueueFaceVoxels(ni, 1, bx - 1, by, bz);
         }
         if (bx < nbx - 1) {
             const ni = blockIdx + 1;
-            const nbt = readType(blockedTypes, ni);
+            const nbt = readBlockType(blockedTypes, ni);
             if (nbt === BLOCK_EMPTY) tryFillBlock(ni);
             else if (nbt === BLOCK_MIXED) enqueueFaceVoxels(ni, 0, bx + 1, by, bz);
         }
         if (by > 0) {
             const ni = blockIdx - nbx;
-            const nbt = readType(blockedTypes, ni);
+            const nbt = readBlockType(blockedTypes, ni);
             if (nbt === BLOCK_EMPTY) tryFillBlock(ni);
             else if (nbt === BLOCK_MIXED) enqueueFaceVoxels(ni, 3, bx, by - 1, bz);
         }
         if (by < nby - 1) {
             const ni = blockIdx + nbx;
-            const nbt = readType(blockedTypes, ni);
+            const nbt = readBlockType(blockedTypes, ni);
             if (nbt === BLOCK_EMPTY) tryFillBlock(ni);
             else if (nbt === BLOCK_MIXED) enqueueFaceVoxels(ni, 2, bx, by + 1, bz);
         }
         if (bz > 0) {
             const ni = blockIdx - bStride;
-            const nbt = readType(blockedTypes, ni);
+            const nbt = readBlockType(blockedTypes, ni);
             if (nbt === BLOCK_EMPTY) tryFillBlock(ni);
             else if (nbt === BLOCK_MIXED) enqueueFaceVoxels(ni, 5, bx, by, bz - 1);
         }
         if (bz < nbz - 1) {
             const ni = blockIdx + bStride;
-            const nbt = readType(blockedTypes, ni);
+            const nbt = readBlockType(blockedTypes, ni);
             if (nbt === BLOCK_EMPTY) tryFillBlock(ni);
             else if (nbt === BLOCK_MIXED) enqueueFaceVoxels(ni, 4, bx, by, bz + 1);
         }
@@ -226,7 +215,7 @@ function twoLevelBFS(
     const tryEnqueueVoxel = (ix: number, iy: number, iz: number): void => {
         const blockIdx = (ix >> 2) + (iy >> 2) * nbx + (iz >> 2) * bStride;
 
-        const bbt = readType(blockedTypes, blockIdx);
+        const bbt = readBlockType(blockedTypes, blockIdx);
         if (bbt === BLOCK_SOLID) return;
         if (bbt === BLOCK_EMPTY) {
             tryFillBlock(blockIdx);
@@ -237,7 +226,7 @@ function twoLevelBFS(
         const bitIdx = (ix & 3) + ((iy & 3) << 2) + ((iz & 3) << 4);
         if (bitIdx < 32 ? (bMasks.lo[bs] >>> bitIdx) & 1 : (bMasks.hi[bs] >>> (bitIdx - 32)) & 1) return;
 
-        const vbt = readType(visitedTypes, blockIdx);
+        const vbt = readBlockType(visitedTypes, blockIdx);
         if (vbt === BLOCK_SOLID) return;
         if (vbt === BLOCK_MIXED) {
             const vs = vMasks.slot(blockIdx);
@@ -246,10 +235,10 @@ function twoLevelBFS(
             else vMasks.hi[vs] = (vMasks.hi[vs] | (1 << (bitIdx - 32))) >>> 0;
             if (vMasks.lo[vs] === SOLID_LO && vMasks.hi[vs] === SOLID_HI) {
                 vMasks.removeAt(vs);
-                writeType(visitedTypes, blockIdx, BLOCK_SOLID);
+                writeBlockType(visitedTypes, blockIdx, BLOCK_SOLID);
             }
         } else {
-            writeType(visitedTypes, blockIdx, BLOCK_MIXED);
+            writeBlockType(visitedTypes, blockIdx, BLOCK_MIXED);
             vMasks.set(blockIdx,
                 bitIdx < 32 ? (1 << bitIdx) >>> 0 : 0,
                 bitIdx >= 32 ? (1 << (bitIdx - 32)) >>> 0 : 0

--- a/src/lib/voxel/grid-ops.ts
+++ b/src/lib/voxel/grid-ops.ts
@@ -1,10 +1,12 @@
 import {
     BLOCK_EMPTY,
-    BLOCK_MIXED,
     BLOCK_SOLID,
+    BLOCKS_PER_WORD,
+    EVEN_BITS,
     SOLID_HI,
     SOLID_LO,
-    SparseVoxelGrid
+    SparseVoxelGrid,
+    TYPE_MASK
 } from './sparse-voxel-grid';
 
 /**
@@ -18,13 +20,22 @@ import {
 function computeEmptyGrid(visited: SparseVoxelGrid, blocked: SparseVoxelGrid): SparseVoxelGrid {
     const empty = new SparseVoxelGrid(visited.nx, visited.ny, visited.nz);
     const totalBlocks = visited.nbx * visited.nby * visited.nbz;
-    for (let w = 0; w < visited.occupancy.length; w++) {
-        let bits = visited.occupancy[w];
-        while (bits) {
-            const bitPos = 31 - Math.clz32(bits & -bits);
-            const blockIdx = w * 32 + bitPos;
-            if (blockIdx >= totalBlocks) break;
-            const vbt = visited.blockType[blockIdx];
+    const visitedTypes = visited.types;
+    const blockedTypes = blocked.types;
+    for (let w = 0; w < visitedTypes.length; w++) {
+        const word = visitedTypes[w];
+        if (word === 0) continue;
+        let nonEmpty = ((word & EVEN_BITS) | ((word >>> 1) & EVEN_BITS)) >>> 0;
+        const baseIdx = w * BLOCKS_PER_WORD;
+        while (nonEmpty) {
+            const bp = 31 - Math.clz32(nonEmpty & -nonEmpty);
+            const lane = bp >>> 1;
+            const blockIdx = baseIdx + lane;
+            if (blockIdx >= totalBlocks) {
+                nonEmpty = 0;
+                break;
+            }
+            const vbt = (word >>> (lane << 1)) & TYPE_MASK;
             let vLo: number, vHi: number;
             if (vbt === BLOCK_SOLID) {
                 vLo = SOLID_LO;
@@ -34,7 +45,7 @@ function computeEmptyGrid(visited: SparseVoxelGrid, blocked: SparseVoxelGrid): S
                 vLo = visited.masks.lo[vs];
                 vHi = visited.masks.hi[vs];
             }
-            const bbt = blocked.blockType[blockIdx];
+            const bbt = (blockedTypes[blockIdx >>> 4] >>> ((blockIdx & 15) << 1)) & TYPE_MASK;
             let lo: number, hi: number;
             if (bbt === BLOCK_EMPTY) {
                 lo = vLo;
@@ -50,7 +61,7 @@ function computeEmptyGrid(visited: SparseVoxelGrid, blocked: SparseVoxelGrid): S
             if (lo || hi) {
                 empty.orBlock(blockIdx, lo, hi);
             }
-            bits &= bits - 1;
+            nonEmpty &= nonEmpty - 1;
         }
     }
     return empty;
@@ -76,20 +87,28 @@ function sparseOrGrids(
 ): SparseVoxelGrid {
     const result = consumeA ? a : a.clone();
     const totalBlocks = b.nbx * b.nby * b.nbz;
-    for (let w = 0; w < b.occupancy.length; w++) {
-        let bits = b.occupancy[w];
-        while (bits) {
-            const bitPos = 31 - Math.clz32(bits & -bits);
-            const blockIdx = w * 32 + bitPos;
-            if (blockIdx >= totalBlocks) break;
-            const bt = b.blockType[blockIdx];
+    const bTypes = b.types;
+    for (let w = 0; w < bTypes.length; w++) {
+        const word = bTypes[w];
+        if (word === 0) continue;
+        let nonEmpty = ((word & EVEN_BITS) | ((word >>> 1) & EVEN_BITS)) >>> 0;
+        const baseIdx = w * BLOCKS_PER_WORD;
+        while (nonEmpty) {
+            const bp = 31 - Math.clz32(nonEmpty & -nonEmpty);
+            const lane = bp >>> 1;
+            const blockIdx = baseIdx + lane;
+            if (blockIdx >= totalBlocks) {
+                nonEmpty = 0;
+                break;
+            }
+            const bt = (word >>> (lane << 1)) & TYPE_MASK;
             if (bt === BLOCK_SOLID) {
                 result.orBlock(blockIdx, SOLID_LO, SOLID_HI);
             } else {
                 const s = b.masks.slot(blockIdx);
                 result.orBlock(blockIdx, b.masks.lo[s], b.masks.hi[s]);
             }
-            bits &= bits - 1;
+            nonEmpty &= nonEmpty - 1;
         }
     }
     return result;

--- a/src/lib/voxel/grid-ops.ts
+++ b/src/lib/voxel/grid-ops.ts
@@ -6,7 +6,8 @@ import {
     SOLID_HI,
     SOLID_LO,
     SparseVoxelGrid,
-    TYPE_MASK
+    TYPE_MASK,
+    readBlockType
 } from './sparse-voxel-grid';
 
 /**
@@ -45,7 +46,7 @@ function computeEmptyGrid(visited: SparseVoxelGrid, blocked: SparseVoxelGrid): S
                 vLo = visited.masks.lo[vs];
                 vHi = visited.masks.hi[vs];
             }
-            const bbt = (blockedTypes[blockIdx >>> 4] >>> ((blockIdx & 15) << 1)) & TYPE_MASK;
+            const bbt = readBlockType(blockedTypes, blockIdx);
             let lo: number, hi: number;
             if (bbt === BLOCK_EMPTY) {
                 lo = vLo;

--- a/src/lib/voxel/grid-ops.ts
+++ b/src/lib/voxel/grid-ops.ts
@@ -59,12 +59,22 @@ function computeEmptyGrid(visited: SparseVoxelGrid, blocked: SparseVoxelGrid): S
 /**
  * Compute the union of two sparse voxel grids (bitwise OR).
  *
- * @param a - First grid (cloned as the base).
- * @param b - Second grid (OR'd into the clone of a).
- * @returns New grid containing the union of both inputs.
+ * @param a - First grid. By default a fresh clone is taken as the base;
+ * with `consumeA=true` it is mutated in place and returned, saving one
+ * full grid's worth of clone allocation.
+ * @param b - Second grid (OR'd into the result).
+ * @param consumeA - If true, `a` is mutated in place and returned. The
+ * caller must not subsequently read `a` as an independent value
+ * (the returned grid IS `a`).
+ * @returns Grid containing the union of both inputs. Equal to `a` when
+ * `consumeA=true`, otherwise a freshly cloned grid.
  */
-function sparseOrGrids(a: SparseVoxelGrid, b: SparseVoxelGrid): SparseVoxelGrid {
-    const result = a.clone();
+function sparseOrGrids(
+    a: SparseVoxelGrid,
+    b: SparseVoxelGrid,
+    consumeA: boolean = false
+): SparseVoxelGrid {
+    const result = consumeA ? a : a.clone();
     const totalBlocks = b.nbx * b.nby * b.nbz;
     for (let w = 0; w < b.occupancy.length; w++) {
         let bits = b.occupancy[w];

--- a/src/lib/voxel/sparse-voxel-grid.ts
+++ b/src/lib/voxel/sparse-voxel-grid.ts
@@ -65,6 +65,35 @@ const SOLID_WORD = 0x55555555 >>> 0;             // 16 lanes, each = SOLID
 // const MIXED_WORD = 0xAAAAAAAA >>> 0;          // 16 lanes, each = MIXED (unused so far)
 const EVEN_BITS = 0x55555555 >>> 0;              // mask for even bit positions
 
+/**
+ * Read the 2-bit block type directly from a packed `types` Uint32Array.
+ * Module-level so V8 can inline it into hot loops without method dispatch.
+ * Equivalent to `grid.getBlockType(blockIdx)` when `types === grid.types`.
+ *
+ * @param types - Packed types array (16 blocks per word).
+ * @param blockIdx - Linear block index.
+ * @returns Block type: `BLOCK_EMPTY`, `BLOCK_SOLID`, or `BLOCK_MIXED`.
+ */
+const readBlockType = (types: Uint32Array, blockIdx: number): number => {
+    return (types[blockIdx >>> 4] >>> ((blockIdx & 15) << 1)) & TYPE_MASK;
+};
+
+/**
+ * Write the 2-bit block type directly into a packed `types` Uint32Array.
+ * Module-level so V8 can inline it into hot loops without method dispatch.
+ * Caller is responsible for keeping the grid's `masks` consistent (only
+ * `MIXED` blocks should have a mask entry).
+ *
+ * @param types - Packed types array (16 blocks per word).
+ * @param blockIdx - Linear block index.
+ * @param value - Block type to set.
+ */
+const writeBlockType = (types: Uint32Array, blockIdx: number, value: number): void => {
+    const w = blockIdx >>> 4;
+    const shift = (blockIdx & 15) << 1;
+    types[w] = ((types[w] & ~(TYPE_MASK << shift)) | ((value & TYPE_MASK) << shift)) >>> 0;
+};
+
 class SparseVoxelGrid {
     readonly nx: number;
     readonly ny: number;
@@ -103,7 +132,7 @@ class SparseVoxelGrid {
      * @returns Block type: `BLOCK_EMPTY`, `BLOCK_SOLID`, or `BLOCK_MIXED`.
      */
     getBlockType(blockIdx: number): number {
-        return (this.types[blockIdx >>> 4] >>> ((blockIdx & 15) << 1)) & TYPE_MASK;
+        return readBlockType(this.types, blockIdx);
     }
 
     /**
@@ -115,9 +144,7 @@ class SparseVoxelGrid {
      * @param value - Block type to set.
      */
     setBlockType(blockIdx: number, value: number): void {
-        const w = blockIdx >>> 4;
-        const shift = (blockIdx & 15) << 1;
-        this.types[w] = ((this.types[w] & ~(TYPE_MASK << shift)) | ((value & TYPE_MASK) << shift)) >>> 0;
+        writeBlockType(this.types, blockIdx, value);
     }
 
     getVoxel(ix: number, iy: number, iz: number): number {
@@ -422,5 +449,7 @@ export {
     SOLID_LO,
     SOLID_WORD,
     SparseVoxelGrid,
-    TYPE_MASK
+    TYPE_MASK,
+    readBlockType,
+    writeBlockType
 };

--- a/src/lib/voxel/sparse-voxel-grid.ts
+++ b/src/lib/voxel/sparse-voxel-grid.ts
@@ -30,19 +30,40 @@ const FACE_MASKS_HI = [
 ];
 
 // ============================================================================
-// SparseVoxelGrid
+// SparseVoxelGrid (packed 2-bit types)
 //
 // Stores voxel data at 4x4x4 block granularity with exact voxel-level
-// precision. Memory is proportional to the number of non-empty blocks.
+// precision. The per-block type {EMPTY=0, SOLID=1, MIXED=2} is packed into
+// a single Uint32Array at 2 bits per block (16 blocks per word):
 //
-// Each block has a type stored in blockType[blockIdx]:
-//   0 (EMPTY):  no voxels set
-//   1 (SOLID):  all 64 voxels set, no mask entry
-//   2 (MIXED):  partial voxels, lo/hi mask in BlockMaskMap
+//   block i  -> word index = i >>> 4, bit shift = (i & 15) << 1
+//   read     -> (types[w] >>> shift) & 0x3
+//   write    -> types[w] = (types[w] & ~(0x3 << shift)) | (value << shift)
 //
-// An occupancy bitfield is maintained in parallel for fast scanning
-// of occupied blocks (used by active-pair computation in dilation).
+// Per-word patterns:
+//   0x55555555 = all 16 lanes SOLID  (0b01 in each pair)
+//   0xAAAAAAAA = all 16 lanes MIXED  (0b10 in each pair)
+//
+// "Find non-empty blocks" iteration uses the trick:
+//   nonEmpty = (word & 0x55555555) | ((word >>> 1) & 0x55555555);
+// which sets bit 2k in `nonEmpty` whenever lane k is non-zero. Iterating
+// the set bits with `clz32(nonEmpty & -nonEmpty)` then yields lane indices
+// the same way the old occupancy bitfield did.
+//
+// MIXED blocks store their lo/hi voxel mask in `masks` keyed on the
+// global block index (bx + by*nbx + bz*bStride).
+//
+// Memory: 2 bits per block, vs 1 byte (blockType) + 1 bit (occupancy)
+// = 9 bits per block in the previous design. ~4.5x reduction on this
+// component.
 // ============================================================================
+
+const TYPE_BITS_PER_BLOCK = 2;
+const BLOCKS_PER_WORD = 32 / TYPE_BITS_PER_BLOCK; // 16
+const TYPE_MASK = (1 << TYPE_BITS_PER_BLOCK) - 1; // 0b11
+const SOLID_WORD = 0x55555555 >>> 0;             // 16 lanes, each = SOLID
+// const MIXED_WORD = 0xAAAAAAAA >>> 0;          // 16 lanes, each = MIXED (unused so far)
+const EVEN_BITS = 0x55555555 >>> 0;              // mask for even bit positions
 
 class SparseVoxelGrid {
     readonly nx: number;
@@ -53,8 +74,13 @@ class SparseVoxelGrid {
     readonly nbz: number;
     readonly bStride: number;
 
-    blockType: Uint8Array;
-    occupancy: Uint32Array;
+    /**
+     * Packed block types: 2 bits per block, 16 blocks per Uint32 word.
+     * Length = ceil(totalBlocks / 16).
+     */
+    types: Uint32Array;
+
+    /** Voxel masks for MIXED blocks, keyed on global block index. */
     masks: BlockMaskMap;
 
     constructor(nx: number, ny: number, nz: number) {
@@ -66,14 +92,37 @@ class SparseVoxelGrid {
         this.nbz = nz >> 2;
         this.bStride = this.nbx * this.nby;
         const totalBlocks = this.nbx * this.nby * this.nbz;
-        this.blockType = new Uint8Array(totalBlocks);
-        this.occupancy = new Uint32Array(((totalBlocks) + 31) >>> 5);
+        this.types = new Uint32Array((totalBlocks + BLOCKS_PER_WORD - 1) >>> 4);
         this.masks = new BlockMaskMap();
+    }
+
+    /**
+     * Read the 2-bit block type at the given block index.
+     *
+     * @param blockIdx - Linear block index (`bx + by*nbx + bz*bStride`).
+     * @returns Block type: `BLOCK_EMPTY`, `BLOCK_SOLID`, or `BLOCK_MIXED`.
+     */
+    getBlockType(blockIdx: number): number {
+        return (this.types[blockIdx >>> 4] >>> ((blockIdx & 15) << 1)) & TYPE_MASK;
+    }
+
+    /**
+     * Write the 2-bit block type at the given block index. Caller is
+     * responsible for keeping `masks` consistent (only `MIXED` blocks
+     * should have a mask entry; `EMPTY`/`SOLID` should not).
+     *
+     * @param blockIdx - Linear block index.
+     * @param value - Block type to set.
+     */
+    setBlockType(blockIdx: number, value: number): void {
+        const w = blockIdx >>> 4;
+        const shift = (blockIdx & 15) << 1;
+        this.types[w] = ((this.types[w] & ~(TYPE_MASK << shift)) | ((value & TYPE_MASK) << shift)) >>> 0;
     }
 
     getVoxel(ix: number, iy: number, iz: number): number {
         const blockIdx = (ix >> 2) + (iy >> 2) * this.nbx + (iz >> 2) * this.bStride;
-        const bt = this.blockType[blockIdx];
+        const bt = this.getBlockType(blockIdx);
         if (bt === BLOCK_EMPTY) return 0;
         if (bt === BLOCK_SOLID) return 1;
         const s = this.masks.slot(blockIdx);
@@ -83,7 +132,7 @@ class SparseVoxelGrid {
 
     setVoxel(ix: number, iy: number, iz: number): void {
         const blockIdx = (ix >> 2) + (iy >> 2) * this.nbx + (iz >> 2) * this.bStride;
-        const bt = this.blockType[blockIdx];
+        const bt = this.getBlockType(blockIdx);
         if (bt === BLOCK_SOLID) return;
         const bitIdx = (ix & 3) + ((iy & 3) << 2) + ((iz & 3) << 4);
         if (bt === BLOCK_MIXED) {
@@ -92,11 +141,10 @@ class SparseVoxelGrid {
             else this.masks.hi[s] = (this.masks.hi[s] | (1 << (bitIdx - 32))) >>> 0;
             if (this.masks.lo[s] === SOLID_LO && this.masks.hi[s] === SOLID_HI) {
                 this.masks.removeAt(s);
-                this.blockType[blockIdx] = BLOCK_SOLID;
+                this.setBlockType(blockIdx, BLOCK_SOLID);
             }
         } else {
-            this.blockType[blockIdx] = BLOCK_MIXED;
-            this.occupancy[blockIdx >>> 5] |= (1 << (blockIdx & 31));
+            this.setBlockType(blockIdx, BLOCK_MIXED);
             this.masks.set(blockIdx,
                 bitIdx < 32 ? (1 << bitIdx) >>> 0 : 0,
                 bitIdx >= 32 ? (1 << (bitIdx - 32)) >>> 0 : 0
@@ -106,7 +154,7 @@ class SparseVoxelGrid {
 
     orBlock(blockIdx: number, lo: number, hi: number): void {
         if (lo === 0 && hi === 0) return;
-        const bt = this.blockType[blockIdx];
+        const bt = this.getBlockType(blockIdx);
         if (bt === BLOCK_SOLID) return;
         if (bt === BLOCK_MIXED) {
             const s = this.masks.slot(blockIdx);
@@ -114,29 +162,26 @@ class SparseVoxelGrid {
             this.masks.hi[s] = (this.masks.hi[s] | hi) >>> 0;
             if (this.masks.lo[s] === SOLID_LO && this.masks.hi[s] === SOLID_HI) {
                 this.masks.removeAt(s);
-                this.blockType[blockIdx] = BLOCK_SOLID;
+                this.setBlockType(blockIdx, BLOCK_SOLID);
             }
         } else {
-            this.occupancy[blockIdx >>> 5] |= (1 << (blockIdx & 31));
             if ((lo >>> 0) === SOLID_LO && (hi >>> 0) === SOLID_HI) {
-                this.blockType[blockIdx] = BLOCK_SOLID;
+                this.setBlockType(blockIdx, BLOCK_SOLID);
             } else {
-                this.blockType[blockIdx] = BLOCK_MIXED;
+                this.setBlockType(blockIdx, BLOCK_MIXED);
                 this.masks.set(blockIdx, lo >>> 0, hi >>> 0);
             }
         }
     }
 
     clear(): void {
-        this.blockType.fill(0);
-        this.occupancy.fill(0);
+        this.types.fill(0);
         this.masks.clear();
     }
 
     clone(): SparseVoxelGrid {
         const g = new SparseVoxelGrid(this.nx, this.ny, this.nz);
-        g.blockType.set(this.blockType);
-        g.occupancy.set(this.occupancy);
+        g.types.set(this.types);
         g.masks = this.masks.clone();
         return g;
     }
@@ -147,15 +192,13 @@ class SparseVoxelGrid {
         for (let i = 0; i < solidMortons.length; i++) {
             const [bx, by, bz] = mortonToXYZ(solidMortons[i]);
             const blockIdx = bx + by * g.nbx + bz * g.bStride;
-            g.blockType[blockIdx] = BLOCK_SOLID;
-            g.occupancy[blockIdx >>> 5] |= (1 << (blockIdx & 31));
+            g.setBlockType(blockIdx, BLOCK_SOLID);
         }
         const mixed = acc.getMixedBlocks();
         for (let i = 0; i < mixed.morton.length; i++) {
             const [bx, by, bz] = mortonToXYZ(mixed.morton[i]);
             const blockIdx = bx + by * g.nbx + bz * g.bStride;
-            g.blockType[blockIdx] = BLOCK_MIXED;
-            g.occupancy[blockIdx >>> 5] |= (1 << (blockIdx & 31));
+            g.setBlockType(blockIdx, BLOCK_MIXED);
             g.masks.set(blockIdx, mixed.masks[i * 2], mixed.masks[i * 2 + 1]);
         }
         return g;
@@ -171,7 +214,7 @@ class SparseVoxelGrid {
             for (let by = cropMinBy; by < cropMaxBy; by++) {
                 for (let bx = cropMinBx; bx < cropMaxBx; bx++) {
                     const blockIdx = bx + by * this.nbx + bz * this.bStride;
-                    const bt = this.blockType[blockIdx];
+                    const bt = this.getBlockType(blockIdx);
                     let lo: number, hi: number;
                     if (bt === BLOCK_SOLID) {
                         lo = SOLID_LO;
@@ -207,7 +250,7 @@ class SparseVoxelGrid {
             for (let by = cropMinBy; by < cropMaxBy; by++) {
                 for (let bx = cropMinBx; bx < cropMaxBx; bx++) {
                     const blockIdx = bx + by * this.nbx + bz * this.bStride;
-                    const bt = this.blockType[blockIdx];
+                    const bt = this.getBlockType(blockIdx);
                     let lo: number, hi: number;
                     if (bt === BLOCK_SOLID) {
                         continue;
@@ -244,12 +287,20 @@ class SparseVoxelGrid {
         const totalBlocks = this.nbx * this.nby * this.nbz;
         let minBx = nbx, minBy = nby, minBz = this.nbz;
         let maxBx = 0, maxBy = 0, maxBz = 0;
-        for (let w = 0; w < this.occupancy.length; w++) {
-            let bits = this.occupancy[w];
-            while (bits) {
-                const bitPos = 31 - Math.clz32(bits & -bits);
-                const blockIdx = w * 32 + bitPos;
-                if (blockIdx >= totalBlocks) break;
+        let found = false;
+        for (let w = 0; w < this.types.length; w++) {
+            const word = this.types[w];
+            if (word === 0) continue;
+            // Set bit at even position 2k iff lane k is non-empty.
+            let nonEmpty = ((word & EVEN_BITS) | ((word >>> 1) & EVEN_BITS)) >>> 0;
+            while (nonEmpty) {
+                const bp = 31 - Math.clz32(nonEmpty & -nonEmpty);
+                const lane = bp >>> 1;
+                const blockIdx = w * BLOCKS_PER_WORD + lane;
+                if (blockIdx >= totalBlocks) {
+                    nonEmpty = 0;
+                    break;
+                }
                 const bx = blockIdx % nbx;
                 const byBz = (blockIdx / nbx) | 0;
                 const by = byBz % nby;
@@ -260,10 +311,11 @@ class SparseVoxelGrid {
                 if (by > maxBy) maxBy = by;
                 if (bz < minBz) minBz = bz;
                 if (bz > maxBz) maxBz = bz;
-                bits &= bits - 1;
+                found = true;
+                nonEmpty &= nonEmpty - 1;
             }
         }
-        return minBx <= maxBx ? { minBx, minBy, minBz, maxBx, maxBy, maxBz } : null;
+        return found ? { minBx, minBy, minBz, maxBx, maxBy, maxBz } : null;
     }
 
     /**
@@ -280,42 +332,32 @@ class SparseVoxelGrid {
     } | null {
         const { nbx, nby } = this;
         const totalBlocks = this.nbx * this.nby * this.nbz;
-        const words = (totalBlocks + 31) >>> 5;
-        const remainder = totalBlocks & 31;
-        const lastMask = remainder === 0 ? 0xFFFFFFFF >>> 0 : (((1 << remainder) - 1) >>> 0);
+        // Mask of valid lanes in the last word (in terms of even bit positions).
+        const lastWordIdx = this.types.length - 1;
+        const lastLanes = totalBlocks - lastWordIdx * BLOCKS_PER_WORD;
+        // navMask in the last word: only the first `lastLanes` lanes are valid;
+        // each lane occupies 2 bits, so the valid even-bit mask spans
+        // 2 * lastLanes bits.
+        const lastNonEmptyMask = lastLanes >= BLOCKS_PER_WORD ?
+            EVEN_BITS :
+            (((1 << (lastLanes * 2)) - 1) >>> 0) & EVEN_BITS;
 
         let minBx = nbx, minBy = nby, minBz = this.nbz;
         let maxBx = -1, maxBy = 0, maxBz = 0;
 
-        for (let w = 0; w < words; w++) {
-            // Build a bitmask of SOLID blocks in this 32-block word. SOLID
-            // requires occupancy bit set AND blockType === BLOCK_SOLID.
-            // nonSolid is then the inverse of that mask, so it includes any
-            // block not marked solid here, including both EMPTY and MIXED blocks.
-            const baseIdx = w * 32;
-            const upper = Math.min(32, totalBlocks - baseIdx);
-            const occWord = this.occupancy[w];
-            let solid = 0 >>> 0;
-            let occBits = occWord;
-            while (occBits) {
-                const bitPos = 31 - Math.clz32(occBits & -occBits);
-                if (this.blockType[baseIdx + bitPos] === BLOCK_SOLID) {
-                    solid |= (1 << bitPos);
-                }
-                occBits &= occBits - 1;
-            }
-            let nonSolid = (~solid) >>> 0;
-            if (w === words - 1 && remainder > 0) nonSolid &= lastMask;
-            // Trim bits past totalBlocks for any partial last word (already
-            // handled above, but guard against upper < 32 in non-last words
-            // which shouldn't happen).
-            if (upper < 32 && w < words - 1) {
-                nonSolid &= ((1 << upper) - 1) >>> 0;
-            }
+        for (let w = 0; w < this.types.length; w++) {
+            const word = this.types[w];
+            // Lane is non-SOLID iff its 2 bits aren't (1, 0) i.e. iff
+            // word ^ SOLID_WORD has any bit set in that pair.
+            const flipped = (word ^ SOLID_WORD) >>> 0;
+            let navMask = ((flipped & EVEN_BITS) | ((flipped >>> 1) & EVEN_BITS)) >>> 0;
+            // For the final (possibly partial) word, drop lanes past totalBlocks.
+            if (w === lastWordIdx) navMask &= lastNonEmptyMask;
 
-            while (nonSolid) {
-                const bitPos = 31 - Math.clz32(nonSolid & -nonSolid);
-                const blockIdx = baseIdx + bitPos;
+            while (navMask) {
+                const bp = 31 - Math.clz32(navMask & -navMask);
+                const lane = bp >>> 1;
+                const blockIdx = w * BLOCKS_PER_WORD + lane;
                 const bx = blockIdx % nbx;
                 const byBz = (blockIdx / nbx) | 0;
                 const by = byBz % nby;
@@ -326,7 +368,7 @@ class SparseVoxelGrid {
                 if (by > maxBy) maxBy = by;
                 if (bz < minBz) minBz = bz;
                 if (bz > maxBz) maxBz = bz;
-                nonSolid &= nonSolid - 1;
+                navMask &= navMask - 1;
             }
         }
 
@@ -372,9 +414,13 @@ export {
     BLOCK_EMPTY,
     BLOCK_MIXED,
     BLOCK_SOLID,
+    BLOCKS_PER_WORD,
+    EVEN_BITS,
     FACE_MASKS_HI,
     FACE_MASKS_LO,
     SOLID_HI,
     SOLID_LO,
-    SparseVoxelGrid
+    SOLID_WORD,
+    SparseVoxelGrid,
+    TYPE_MASK
 };

--- a/src/lib/voxel/voxel-query.ts
+++ b/src/lib/voxel/voxel-query.ts
@@ -12,7 +12,7 @@ import {
 interface BlockLookup {
     solidSet: Set<number>;
     mixedMap: Map<number, number>;
-    masks: number[];
+    masks: Uint32Array;
 }
 
 /**

--- a/src/lib/writers/sparse-octree.ts
+++ b/src/lib/writers/sparse-octree.ts
@@ -317,13 +317,6 @@ function buildSparseOctree(
     const solid = buffer.getSolidBlocks();
     const totalBlocks = mixed.morton.length + solid.length;
 
-    const memProbe = (label: string): void => {
-        const u = process.memoryUsage();
-        const live = u.heapUsed + u.external;
-        logger.info(`mem [octree: ${label}]: ${(live / 1e9).toFixed(3)}GB  (heap ${(u.heapUsed / 1e9).toFixed(3)}GB + ext ${(u.external / 1e9).toFixed(3)}GB)`);
-    };
-    memProbe(`entry (mixed=${mixed.morton.length} solid=${solid.length} total=${totalBlocks})`);
-
     // --- Phase 1: Sort the buffer's existing typed arrays in place ---
     // Level 0 (leaves) is represented as TWO sorted streams — solid mortons
     // and mixed mortons (with paired masks). Sorting in place avoids
@@ -348,8 +341,6 @@ function buildSparseOctree(
 
     if (nSolid > 1) solidStream.sort();
     if (nMixed > 1) sortMixedByMorton(mixedStream, mixedMasks, nMixed);
-
-    memProbe('after Phase 1 (in-place sort, no SoA copy)');
 
     const tSort = performance.now();
 
@@ -540,15 +531,11 @@ function buildSparseOctree(
 
     const tBuild = performance.now();
 
-    memProbe(`after Phase 2 (built ${levels.length} levels)`);
-
     // --- Phase 3: Flatten tree to Laine-Karras format ---
     const result = flattenTreeFromLevels(
         levels, solidStream, mixedStream, mixedMasks, nSolid, nMixed,
         gridBounds, sceneBounds, voxelResolution, actualDepth
     );
-
-    memProbe('after Phase 3 (flattenTreeFromLevels)');
 
     const tFlatten = performance.now();
 

--- a/src/lib/writers/sparse-octree.ts
+++ b/src/lib/writers/sparse-octree.ts
@@ -86,6 +86,10 @@ interface LevelData {
  * Avoids `TypedArray.prototype.sort(comparefn)` so we are not bounded by
  * FixedArray::kMaxLength (~134M elements with V8 pointer compression).
  *
+ * **Sibling: {@link sortMixedByMorton} shares this exact partition/stack
+ * scaffold but with a different swap shape (Float64 + Uint32×2). Keep the
+ * two implementations in lockstep — fixes here should be mirrored there.**
+ *
  * @param mortons - Morton codes; sort key.
  * @param types - Block type per entry; permuted alongside mortons.
  * @param maskIndices - Mask index per entry; permuted alongside mortons.
@@ -182,6 +186,11 @@ function sortParallelByMorton(
  * `sortParallelByMorton`, but tailored to the (Float64 morton, Uint32×2 mask)
  * layout used by `BlockMaskBuffer` so the buffer's typed arrays can serve as
  * the sorted data directly — no SoA copy required.
+ *
+ * **Sibling: {@link sortParallelByMorton} shares this exact partition/stack
+ * scaffold but with a different swap shape (Float64 + Uint8 + Int32). Keep
+ * the two implementations in lockstep — fixes here should be mirrored
+ * there.**
  *
  * @param mortons - Morton codes; sort key.
  * @param masks - Interleaved [lo, hi] mask pairs (length = 2 * n).
@@ -299,7 +308,15 @@ function lowerBoundF64(arr: Float64Array, target: number, n: number): number {
  * Uses Structure-of-Arrays (SoA) representation and linear scans on sorted
  * Morton codes instead of Maps and per-node objects for performance.
  *
- * @param buffer - BlockMaskBuffer containing voxelized blocks
+ * **Mutates `buffer` in place.** Phase 1 sorts the buffer's solid-morton,
+ * mixed-morton, and mixed-mask typed arrays directly (no SoA copy) to keep
+ * peak memory low on very large grids. After this call the buffer's blocks
+ * are still semantically equivalent — same morton/mask pairs — but reordered
+ * by morton ascending. Callers must not rely on insertion order being
+ * preserved across this call.
+ *
+ * @param buffer - BlockMaskBuffer containing voxelized blocks. Mutated:
+ * solid mortons, mixed mortons, and mixed masks are sorted in place.
  * @param gridBounds - Grid bounds aligned to block boundaries
  * @param sceneBounds - Original scene bounds
  * @param voxelResolution - Size of each voxel in world units
@@ -350,10 +367,10 @@ function buildSparseOctree(
     // levels (2, 3, ...) are built from JS-array level data via the same
     // single-array linear scan as before.
     //
-    // `levels[]` holds INTERIOR levels only (no level 0). `levels[0]` is the
-    // first interior level (= original "level 1"); `levels[length-1]` is the
-    // root. Phase 3 special-cases level 0 access via a wave-entry sentinel
-    // (`li === -1`).
+    // `interiorLevels[]` holds INTERIOR levels only (no level 0).
+    // `interiorLevels[0]` is the first interior level (= original "level 1");
+    // `interiorLevels[length-1]` is the root. Phase 3 special-cases level 0
+    // access via a wave-entry sentinel (`li === -1`).
 
     const bar = logger.bar('Building tree', 10);
     let octreeStep = 0;
@@ -372,22 +389,25 @@ function buildSparseOctree(
     );
     const treeDepth = Math.max(1, Math.ceil(Math.log2(blocksPerAxis)));
 
-    const levels: LevelData[] = [];
+    const interiorLevels: LevelData[] = [];
 
     // === Build level 1 from dual-stream level 0 ===
     // Two-pointer merge: at each step, the smaller-morton stream is the next
     // child to process. Group children with the same `floor(morton/8)` parent.
     // childMask records which octants are present; allSolid tracks whether we
     // can collapse this parent into a SOLID leaf at level 1.
+    // All interior levels (level 1 and up) carry a real childMasks array; the
+    // `LevelData.childMasks: number[] | null` shape exists only to model the
+    // never-pushed leaf level, so we can use a non-nullable type here.
     let curMortons: number[] = [];
     let curTypes: number[] = [];
     let curMaskIndices: number[] = [];
-    let curChildMasks: number[] | null = [];
+    let curChildMasks: number[] = [];
 
     {
         let sI = 0;
         let mI = 0;
-        const nextChildMasks = curChildMasks!;
+        const nextChildMasks = curChildMasks;
         while (sI < nSolid || mI < nMixed) {
             const sM0 = sI < nSolid ? solidStream[sI] : Number.POSITIVE_INFINITY;
             const mM0 = mI < nMixed ? mixedStream[mI] : Number.POSITIVE_INFINITY;
@@ -437,12 +457,12 @@ function buildSparseOctree(
     // Same logic as before — single-array linear scan. We push each level
     // before building the next, then push the final root after the loop.
     if (curMortons.length === 0) {
-        // Empty input: nothing to push. levels stays empty.
+        // Empty input: nothing to push. interiorLevels stays empty.
         actualDepth = 1;
     } else if (curMortons.length === 1 && curMortons[0] === 0) {
         // Level 1 IS the root.
         actualDepth = 1;
-        levels.push({
+        interiorLevels.push({
             mortons: curMortons,
             types: curTypes,
             maskIndices: curMaskIndices,
@@ -457,7 +477,7 @@ function buildSparseOctree(
             }
 
             // Push current level before building one above it
-            levels.push({
+            interiorLevels.push({
                 mortons: curMortons,
                 types: curTypes,
                 maskIndices: curMaskIndices,
@@ -506,22 +526,22 @@ function buildSparseOctree(
             curMaskIndices = nextMaskIndices;
             curChildMasks = nextChildMasks;
 
-            if (curMortons.length === 0 ||
-                (curMortons.length === 1 && curMortons[0] === 0)) {
+            // Each iteration consumes n >= 1 entries and produces ceil(n/8) >= 1
+            // parents, so curMortons.length stays >= 1 here; we only need to
+            // check for convergence to a single root at morton 0.
+            if (curMortons.length === 1 && curMortons[0] === 0) {
                 actualDepth = level + 1;
                 break;
             }
         }
 
-        // Save root
-        if (curMortons.length > 0) {
-            levels.push({
-                mortons: curMortons,
-                types: curTypes,
-                maskIndices: curMaskIndices,
-                childMasks: curChildMasks
-            });
-        }
+        // Save root. By the invariant above, curMortons.length >= 1 always.
+        interiorLevels.push({
+            mortons: curMortons,
+            types: curTypes,
+            maskIndices: curMaskIndices,
+            childMasks: curChildMasks
+        });
     }
 
     while (octreeStep < 9) {
@@ -533,7 +553,7 @@ function buildSparseOctree(
 
     // --- Phase 3: Flatten tree to Laine-Karras format ---
     const result = flattenTreeFromLevels(
-        levels, solidStream, mixedStream, mixedMasks, nSolid, nMixed,
+        interiorLevels, solidStream, mixedStream, mixedMasks, nSolid, nMixed,
         gridBounds, sceneBounds, voxelResolution, actualDepth
     );
 
@@ -556,10 +576,10 @@ function buildSparseOctree(
  * indicates a mixed leaf at `mixedStream[ii]`, while `ii >= nMixed`
  * indicates a solid leaf at `solidStream[ii - nMixed]`.
  *
- * `levels[i]` (for `i >= 0`) holds the i-th INTERIOR level (= original
- * "level i+1"), built bottom-up. `levels[length-1]` is the root.
+ * `interiorLevels[i]` (for `i >= 0`) holds the i-th INTERIOR level (= original
+ * "level i+1"), built bottom-up. `interiorLevels[length-1]` is the root.
  *
- * @param levels - Interior level data (index 0 = first interior level
+ * @param interiorLevels - Interior level data (index 0 = first interior level
  * above leaves, last = root).
  * @param solidStream - Sorted Float64 mortons for solid leaves.
  * @param mixedStream - Sorted Float64 mortons for mixed leaves (paired with
@@ -575,7 +595,7 @@ function buildSparseOctree(
  * @returns Sparse octree structure in Laine-Karras format.
  */
 function flattenTreeFromLevels(
-    levels: LevelData[],
+    interiorLevels: LevelData[],
     solidStream: Float64Array,
     mixedStream: Float64Array,
     mixedMasks: Uint32Array,
@@ -586,7 +606,7 @@ function flattenTreeFromLevels(
     voxelResolution: number,
     treeDepth: number
 ): SparseOctree {
-    if (levels.length === 0) {
+    if (interiorLevels.length === 0) {
         // Empty tree (no leaves and no interior levels).
         return {
             gridBounds,
@@ -601,12 +621,12 @@ function flattenTreeFromLevels(
         };
     }
 
-    const rootLevel = levels[levels.length - 1];
+    const rootLevel = interiorLevels[interiorLevels.length - 1];
 
     // Upper bound on total nodes (not all may be reachable if solids collapsed)
     let maxNodes = nSolid + nMixed;
-    for (let l = 0; l < levels.length; l++) {
-        maxNodes += levels[l].mortons.length;
+    for (let l = 0; l < interiorLevels.length; l++) {
+        maxNodes += interiorLevels[l].mortons.length;
     }
 
     const nodes = new Uint32Array(maxNodes);
@@ -622,7 +642,7 @@ function flattenTreeFromLevels(
     let waveIi: number[] = [];
 
     // Initialize wave with root level entries.
-    const rootLi = levels.length - 1;
+    const rootLi = interiorLevels.length - 1;
     for (let i = 0; i < rootLevel.mortons.length; i++) {
         waveLi.push(rootLi);
         waveIi.push(i);
@@ -662,7 +682,7 @@ function flattenTreeFromLevels(
                 continue;
             }
 
-            const level = levels[li];
+            const level = interiorLevels[li];
             const type = level.types[ii];
 
             // A node is a leaf if it's Solid (at any level, collapsed or original).
@@ -696,7 +716,7 @@ function flattenTreeFromLevels(
             nodes[intPos[j]] = ((childMask & 0xFF) << 24) | (nextChildStart & 0x00FFFFFF);
 
             const myLi = intLi[j];
-            const myMorton = levels[myLi].mortons[intIi[j]];
+            const myMorton = interiorLevels[myLi].mortons[intIi[j]];
             const childMortonBase = myMorton * 8;
             const childMortonEnd = childMortonBase + 8;
 
@@ -727,7 +747,7 @@ function flattenTreeFromLevels(
             } else {
                 // Children are at an interior level → single-array binary search.
                 const childLi = myLi - 1;
-                const childLevel = levels[childLi];
+                const childLevel = interiorLevels[childLi];
                 const childMortons = childLevel.mortons;
 
                 let lo = 0;

--- a/src/lib/writers/sparse-octree.ts
+++ b/src/lib/writers/sparse-octree.ts
@@ -12,6 +12,13 @@ import { xyzToMorton, mortonToXYZ, popcount, getChildOffset } from '../voxel/mor
  */
 const SOLID_LEAF_MARKER = 0xFF000000 >>> 0;
 
+/**
+ * Maximum value encodable in the low 24 bits of a Laine-Karras node word.
+ * Both the interior `baseOffset` (child node index) and the mixed-leaf
+ * `leafDataIndex` share this ceiling. 16,777,215 nodes / mixed leaves.
+ */
+const MAX_24BIT_OFFSET = 0x00FFFFFF;
+
 // ============================================================================
 // Sparse Octree Types
 // ============================================================================
@@ -62,135 +69,36 @@ const enum BlockType {
 /**
  * Per-level data stored during bottom-up construction.
  * Uses Structure-of-Arrays layout to avoid per-node object allocation.
+ *
+ * After the dual-stream refactor, level 0 is held outside `interiorLevels`
+ * (in `solidStream` + `mixedStream` + `mixedMasks`), so every entry stored
+ * here is an interior node and `childMasks` is always non-null.
  */
 interface LevelData {
     /** Sorted Morton codes for nodes at this level */
-    mortons: Float64Array | number[];
+    mortons: number[];
     /** Block type for each node (Solid or Mixed) */
-    types: Uint8Array | number[];
-    /** For level-0 Mixed nodes: index into mixed.masks. Otherwise -1. */
-    maskIndices: Int32Array | number[];
-    /** For interior nodes (Mixed at level > 0): 8-bit child presence mask. Null for leaf level. */
-    childMasks: number[] | null;
+    types: number[];
+    /** 8-bit child presence mask for each node */
+    childMasks: number[];
 }
 
 // ============================================================================
-// Parallel Sort
+// Mixed-stream Sort
 // ============================================================================
 
 /**
- * Iterative quicksort with median-of-three pivot and an insertion-sort fallback
- * for small partitions. Sorts three parallel typed arrays in place, ordering
- * entries by `mortons` ascending.
+ * Iterative quicksort that sorts mixed-block mortons in place, permuting the
+ * paired interleaved [lo, hi] mask pairs alongside. Median-of-three pivot,
+ * insertion-sort fallback for small partitions.
  *
  * Avoids `TypedArray.prototype.sort(comparefn)` so we are not bounded by
  * FixedArray::kMaxLength (~134M elements with V8 pointer compression).
  *
- * **Sibling: {@link sortMixedByMorton} shares this exact partition/stack
- * scaffold but with a different swap shape (Float64 + Uint32×2). Keep the
- * two implementations in lockstep — fixes here should be mirrored there.**
- *
- * @param mortons - Morton codes; sort key.
- * @param types - Block type per entry; permuted alongside mortons.
- * @param maskIndices - Mask index per entry; permuted alongside mortons.
- * @param n - Number of valid entries to sort (from index 0).
- */
-function sortParallelByMorton(
-    mortons: Float64Array,
-    types: Uint8Array,
-    maskIndices: Int32Array,
-    n: number
-): void {
-    if (n < 2) return;
-
-    const swap = (a: number, b: number): void => {
-        const tm = mortons[a]; mortons[a] = mortons[b]; mortons[b] = tm;
-        const tt = types[a]; types[a] = types[b]; types[b] = tt;
-        const ti = maskIndices[a]; maskIndices[a] = maskIndices[b]; maskIndices[b] = ti;
-    };
-
-    // Stack holds [lo, hi] pairs. Always pushing the larger partition first
-    // bounds depth to O(log n); 64 entries (32 frames) covers n up to 2^32.
-    const stack = new Int32Array(64);
-    let sp = 0;
-    stack[sp++] = 0;
-    stack[sp++] = n - 1;
-
-    while (sp > 0) {
-        const hi = stack[--sp];
-        const lo = stack[--sp];
-
-        if (hi - lo < 16) {
-            // Insertion sort
-            for (let i = lo + 1; i <= hi; i++) {
-                const km = mortons[i], kt = types[i], ki = maskIndices[i];
-                let j = i - 1;
-                while (j >= lo && mortons[j] > km) {
-                    mortons[j + 1] = mortons[j];
-                    types[j + 1] = types[j];
-                    maskIndices[j + 1] = maskIndices[j];
-                    j--;
-                }
-                mortons[j + 1] = km;
-                types[j + 1] = kt;
-                maskIndices[j + 1] = ki;
-            }
-            continue;
-        }
-
-        // Median-of-three: order mortons[lo] <= mortons[mid] <= mortons[hi],
-        // then stash the pivot at hi-1 so the inner loop has sentinels at both ends.
-        const mid = (lo + hi) >>> 1;
-        if (mortons[lo] > mortons[mid]) swap(lo, mid);
-        if (mortons[lo] > mortons[hi]) swap(lo, hi);
-        if (mortons[mid] > mortons[hi]) swap(mid, hi);
-        swap(mid, hi - 1);
-        const pivot = mortons[hi - 1];
-
-        let i = lo;
-        let j = hi - 1;
-        while (true) {
-            while (mortons[++i] < pivot) { /* sentinel at hi */ }
-            while (mortons[--j] > pivot) { /* sentinel at lo */ }
-            if (i >= j) break;
-            swap(i, j);
-        }
-        swap(i, hi - 1);
-
-        // Push larger partition first so the smaller is processed next.
-        const leftSize = i - 1 - lo;
-        const rightSize = hi - (i + 1);
-        if (leftSize > rightSize) {
-            stack[sp++] = lo;
-            stack[sp++] = i - 1;
-            if (rightSize > 0) {
-                stack[sp++] = i + 1;
-                stack[sp++] = hi;
-            }
-        } else {
-            if (rightSize > 0) {
-                stack[sp++] = i + 1;
-                stack[sp++] = hi;
-            }
-            if (leftSize > 0) {
-                stack[sp++] = lo;
-                stack[sp++] = i - 1;
-            }
-        }
-    }
-}
-
-/**
- * Iterative quicksort that sorts mixed-block mortons in place, permuting the
- * paired interleaved [lo, hi] mask pairs alongside. Same shape as
- * `sortParallelByMorton`, but tailored to the (Float64 morton, Uint32×2 mask)
- * layout used by `BlockMaskBuffer` so the buffer's typed arrays can serve as
- * the sorted data directly — no SoA copy required.
- *
- * **Sibling: {@link sortParallelByMorton} shares this exact partition/stack
- * scaffold but with a different swap shape (Float64 + Uint8 + Int32). Keep
- * the two implementations in lockstep — fixes here should be mirrored
- * there.**
+ * Tailored to the (Float64 morton, Uint32×2 mask) layout used by
+ * `BlockMaskBuffer` so the buffer's typed arrays can serve as the sorted
+ * data directly — no SoA copy required. The solid stream uses the native
+ * `Float64Array.sort()` (no comparefn) and doesn't need a custom path.
  *
  * @param mortons - Morton codes; sort key.
  * @param masks - Interleaved [lo, hi] mask pairs (length = 2 * n).
@@ -332,23 +240,20 @@ function buildSparseOctree(
 
     const mixed = buffer.getMixedBlocks();
     const solid = buffer.getSolidBlocks();
-    const totalBlocks = mixed.morton.length + solid.length;
 
     // --- Phase 1: Sort the buffer's existing typed arrays in place ---
     // Level 0 (leaves) is represented as TWO sorted streams — solid mortons
     // and mixed mortons (with paired masks). Sorting in place avoids
-    // allocating SoA copies (Float64Array+Uint8Array+Int32Array, all sized to
-    // totalBlocks); for a buffer with N_solid solid + N_mixed mixed entries,
-    // that's ~13 * (N_solid + N_mixed) bytes saved.
+    // allocating SoA copies (Float64Array+Uint8Array+Int32Array, all sized
+    // to N_solid + N_mixed); ~13 bytes per block saved at peak.
     //
     // We avoid `comparefn` typed-array sort because V8 routes it through a
     // regular-array path bounded by FixedArray::kMaxLength (~134M with
     // pointer compression) and throws past it. Instead:
     //   - Native `Float64Array.sort()` (no comparefn) on the solid stream:
     //     numeric sort, no fallback path, no size limit.
-    //   - Custom `sortMixedByMorton` for the mixed stream: same iterative
-    //     quicksort as `sortParallelByMorton` but tailored to the
-    //     (Float64 morton, Uint32×2 mask) layout.
+    //   - Custom `sortMixedByMorton` for the mixed stream: iterative
+    //     quicksort tailored to the (Float64 morton, Uint32×2 mask) layout.
 
     const solidStream = solid;
     const mixedStream = mixed.morton;
@@ -396,18 +301,13 @@ function buildSparseOctree(
     // child to process. Group children with the same `floor(morton/8)` parent.
     // childMask records which octants are present; allSolid tracks whether we
     // can collapse this parent into a SOLID leaf at level 1.
-    // All interior levels (level 1 and up) carry a real childMasks array; the
-    // `LevelData.childMasks: number[] | null` shape exists only to model the
-    // never-pushed leaf level, so we can use a non-nullable type here.
     let curMortons: number[] = [];
     let curTypes: number[] = [];
-    let curMaskIndices: number[] = [];
     let curChildMasks: number[] = [];
 
     {
         let sI = 0;
         let mI = 0;
-        const nextChildMasks = curChildMasks;
         while (sI < nSolid || mI < nMixed) {
             const sM0 = sI < nSolid ? solidStream[sI] : Number.POSITIVE_INFINITY;
             const mM0 = mI < nMixed ? mixedStream[mI] : Number.POSITIVE_INFINITY;
@@ -432,16 +332,13 @@ function buildSparseOctree(
                 }
             }
 
+            curMortons.push(parentMorton);
             if (allSolid && childCount === 8) {
-                curMortons.push(parentMorton);
                 curTypes.push(BlockType.Solid);
-                curMaskIndices.push(-1);
-                nextChildMasks.push(0);
+                curChildMasks.push(0);
             } else {
-                curMortons.push(parentMorton);
                 curTypes.push(BlockType.Mixed);
-                curMaskIndices.push(-1);
-                nextChildMasks.push(childMask);
+                curChildMasks.push(childMask);
             }
         }
     }
@@ -465,7 +362,6 @@ function buildSparseOctree(
         interiorLevels.push({
             mortons: curMortons,
             types: curTypes,
-            maskIndices: curMaskIndices,
             childMasks: curChildMasks
         });
     } else {
@@ -480,7 +376,6 @@ function buildSparseOctree(
             interiorLevels.push({
                 mortons: curMortons,
                 types: curTypes,
-                maskIndices: curMaskIndices,
                 childMasks: curChildMasks
             });
 
@@ -488,7 +383,6 @@ function buildSparseOctree(
             const n = curMortons.length;
             const nextMortons: number[] = [];
             const nextTypes: number[] = [];
-            const nextMaskIndices: number[] = [];
             const nextChildMasks: number[] = [];
 
             let i = 0;
@@ -508,22 +402,18 @@ function buildSparseOctree(
                     i++;
                 }
 
+                nextMortons.push(parentMorton);
                 if (allSolid && childCount === 8) {
-                    nextMortons.push(parentMorton);
                     nextTypes.push(BlockType.Solid);
-                    nextMaskIndices.push(-1);
                     nextChildMasks.push(0);
                 } else {
-                    nextMortons.push(parentMorton);
                     nextTypes.push(BlockType.Mixed);
-                    nextMaskIndices.push(-1);
                     nextChildMasks.push(childMask);
                 }
             }
 
             curMortons = nextMortons;
             curTypes = nextTypes;
-            curMaskIndices = nextMaskIndices;
             curChildMasks = nextChildMasks;
 
             // Each iteration consumes n >= 1 entries and produces ceil(n/8) >= 1
@@ -539,7 +429,6 @@ function buildSparseOctree(
         interiorLevels.push({
             mortons: curMortons,
             types: curTypes,
-            maskIndices: curMaskIndices,
             childMasks: curChildMasks
         });
     }
@@ -670,9 +559,16 @@ function flattenTreeFromLevels(
                 if (ii < nMixed) {
                     // Mixed leaf
                     const leafDataIndex = leafDataLen >> 1;
+                    if (leafDataIndex > MAX_24BIT_OFFSET) {
+                        throw new Error(
+                            `Sparse octree mixed-leaf count (${leafDataIndex + 1}) exceeds the ` +
+                            `Laine-Karras 24-bit baseOffset limit (${MAX_24BIT_OFFSET + 1}). ` +
+                            'Reduce the grid size or split the scene.'
+                        );
+                    }
                     leafData[leafDataLen++] = mixedMasks[ii * 2];
                     leafData[leafDataLen++] = mixedMasks[ii * 2 + 1];
-                    nodes[emitPos] = leafDataIndex & 0x00FFFFFF;
+                    nodes[emitPos] = leafDataIndex;
                     numMixedLeaves++;
                 } else {
                     // Solid leaf
@@ -697,7 +593,7 @@ function flattenTreeFromLevels(
                 intPos.push(emitPos);
                 intLi.push(li);
                 intIi.push(ii);
-                intMask.push(level.childMasks![ii]);
+                intMask.push(level.childMasks[ii]);
                 numInteriorNodes++;
                 nodes[emitPos] = 0;
             }
@@ -713,7 +609,14 @@ function flattenTreeFromLevels(
             const childMask = intMask[j];
             const childCount = popcount(childMask);
 
-            nodes[intPos[j]] = ((childMask & 0xFF) << 24) | (nextChildStart & 0x00FFFFFF);
+            if (nextChildStart > MAX_24BIT_OFFSET) {
+                throw new Error(
+                    `Sparse octree node count (${nextChildStart + 1}) exceeds the ` +
+                    `Laine-Karras 24-bit baseOffset limit (${MAX_24BIT_OFFSET + 1}). ` +
+                    'Reduce the grid size or split the scene.'
+                );
+            }
+            nodes[intPos[j]] = ((childMask & 0xFF) << 24) | nextChildStart;
 
             const myLi = intLi[j];
             const myMorton = interiorLevels[myLi].mortons[intIi[j]];

--- a/src/lib/writers/sparse-octree.ts
+++ b/src/lib/writers/sparse-octree.ts
@@ -15,7 +15,10 @@ const SOLID_LEAF_MARKER = 0xFF000000 >>> 0;
 /**
  * Maximum value encodable in the low 24 bits of a Laine-Karras node word.
  * Both the interior `baseOffset` (child node index) and the mixed-leaf
- * `leafDataIndex` share this ceiling. 16,777,215 nodes / mixed leaves.
+ * `leafDataIndex` share this ceiling: indices range 0..MAX_24BIT_OFFSET
+ * (= 0xFFFFFF = 16,777,215), giving up to 16,777,216 distinct encodable
+ * values. (Interior nodes additionally reserve baseOffset=0 for
+ * `SOLID_LEAF_MARKER`, so the practical interior cap is 16,777,215.)
  */
 const MAX_24BIT_OFFSET = 0x00FFFFFF;
 

--- a/src/lib/writers/sparse-octree.ts
+++ b/src/lib/writers/sparse-octree.ts
@@ -75,6 +75,108 @@ interface LevelData {
 }
 
 // ============================================================================
+// Parallel Sort
+// ============================================================================
+
+/**
+ * Iterative quicksort with median-of-three pivot and an insertion-sort fallback
+ * for small partitions. Sorts three parallel typed arrays in place, ordering
+ * entries by `mortons` ascending.
+ *
+ * Avoids `TypedArray.prototype.sort(comparefn)` so we are not bounded by
+ * FixedArray::kMaxLength (~134M elements with V8 pointer compression).
+ *
+ * @param mortons - Morton codes; sort key.
+ * @param types - Block type per entry; permuted alongside mortons.
+ * @param maskIndices - Mask index per entry; permuted alongside mortons.
+ * @param n - Number of valid entries to sort (from index 0).
+ */
+function sortParallelByMorton(
+    mortons: Float64Array,
+    types: Uint8Array,
+    maskIndices: Int32Array,
+    n: number
+): void {
+    if (n < 2) return;
+
+    const swap = (a: number, b: number): void => {
+        const tm = mortons[a]; mortons[a] = mortons[b]; mortons[b] = tm;
+        const tt = types[a]; types[a] = types[b]; types[b] = tt;
+        const ti = maskIndices[a]; maskIndices[a] = maskIndices[b]; maskIndices[b] = ti;
+    };
+
+    // Stack holds [lo, hi] pairs. Always pushing the larger partition first
+    // bounds depth to O(log n); 64 entries (32 frames) covers n up to 2^32.
+    const stack = new Int32Array(64);
+    let sp = 0;
+    stack[sp++] = 0;
+    stack[sp++] = n - 1;
+
+    while (sp > 0) {
+        const hi = stack[--sp];
+        const lo = stack[--sp];
+
+        if (hi - lo < 16) {
+            // Insertion sort
+            for (let i = lo + 1; i <= hi; i++) {
+                const km = mortons[i], kt = types[i], ki = maskIndices[i];
+                let j = i - 1;
+                while (j >= lo && mortons[j] > km) {
+                    mortons[j + 1] = mortons[j];
+                    types[j + 1] = types[j];
+                    maskIndices[j + 1] = maskIndices[j];
+                    j--;
+                }
+                mortons[j + 1] = km;
+                types[j + 1] = kt;
+                maskIndices[j + 1] = ki;
+            }
+            continue;
+        }
+
+        // Median-of-three: order mortons[lo] <= mortons[mid] <= mortons[hi],
+        // then stash the pivot at hi-1 so the inner loop has sentinels at both ends.
+        const mid = (lo + hi) >>> 1;
+        if (mortons[lo] > mortons[mid]) swap(lo, mid);
+        if (mortons[lo] > mortons[hi]) swap(lo, hi);
+        if (mortons[mid] > mortons[hi]) swap(mid, hi);
+        swap(mid, hi - 1);
+        const pivot = mortons[hi - 1];
+
+        let i = lo;
+        let j = hi - 1;
+        while (true) {
+            while (mortons[++i] < pivot) { /* sentinel at hi */ }
+            while (mortons[--j] > pivot) { /* sentinel at lo */ }
+            if (i >= j) break;
+            swap(i, j);
+        }
+        swap(i, hi - 1);
+
+        // Push larger partition first so the smaller is processed next.
+        const leftSize = i - 1 - lo;
+        const rightSize = hi - (i + 1);
+        if (leftSize > rightSize) {
+            stack[sp++] = lo;
+            stack[sp++] = i - 1;
+            if (rightSize > 0) {
+                stack[sp++] = i + 1;
+                stack[sp++] = hi;
+            }
+        } else {
+            if (rightSize > 0) {
+                stack[sp++] = i + 1;
+                stack[sp++] = hi;
+            }
+            if (leftSize > 0) {
+                stack[sp++] = lo;
+                stack[sp++] = i - 1;
+            }
+        }
+    }
+}
+
+// ============================================================================
 // Octree Construction
 // ============================================================================
 
@@ -103,45 +205,31 @@ function buildSparseOctree(
     const totalBlocks = mixed.morton.length + solid.length;
 
     // --- Phase 1: Combine blocks into SoA arrays and sort by Morton code ---
-    // Uses typed arrays to reduce per-element memory overhead. The block scope
-    // allows the unsorted intermediates (mortons, types, maskIndices, sortOrder)
-    // to be GC'd before Phase 2 begins.
+    // Sort the three parallel typed arrays in place. We avoid
+    // TypedArray.prototype.sort with a comparefn because V8 routes that
+    // through a regular-array path bounded by FixedArray::kMaxLength
+    // (~134M with pointer compression) and throws
+    // `Custom comparefn not supported for huge TypedArrays` past it.
 
-    let sortedMortons!: Float64Array;
-    let sortedTypes!: Uint8Array;
-    let sortedMaskIndices!: Int32Array;
+    const sortedMortons = new Float64Array(totalBlocks);
+    const sortedTypes = new Uint8Array(totalBlocks);
+    const sortedMaskIndices = new Int32Array(totalBlocks);
     {
-        const mortons = new Float64Array(totalBlocks);
-        const types = new Uint8Array(totalBlocks);
-        const maskIndices = new Int32Array(totalBlocks);
-
         let idx = 0;
         for (let i = 0; i < mixed.morton.length; i++) {
-            mortons[idx] = mixed.morton[i];
-            types[idx] = BlockType.Mixed;
-            maskIndices[idx] = i;
+            sortedMortons[idx] = mixed.morton[i];
+            sortedTypes[idx] = BlockType.Mixed;
+            sortedMaskIndices[idx] = i;
             idx++;
         }
         for (let i = 0; i < solid.length; i++) {
-            mortons[idx] = solid[i];
-            types[idx] = BlockType.Solid;
-            maskIndices[idx] = -1;
+            sortedMortons[idx] = solid[i];
+            sortedTypes[idx] = BlockType.Solid;
+            sortedMaskIndices[idx] = -1;
             idx++;
         }
 
-        const sortOrder = new Uint32Array(totalBlocks);
-        for (let i = 0; i < totalBlocks; i++) sortOrder[i] = i;
-        sortOrder.sort((a: number, b: number) => mortons[a] - mortons[b]);
-
-        sortedMortons = new Float64Array(totalBlocks);
-        sortedTypes = new Uint8Array(totalBlocks);
-        sortedMaskIndices = new Int32Array(totalBlocks);
-        for (let i = 0; i < totalBlocks; i++) {
-            const si = sortOrder[i];
-            sortedMortons[i] = mortons[si];
-            sortedTypes[i] = types[si];
-            sortedMaskIndices[i] = maskIndices[si];
-        }
+        sortParallelByMorton(sortedMortons, sortedTypes, sortedMaskIndices, totalBlocks);
     }
 
     const tSort = performance.now();
@@ -279,7 +367,7 @@ function buildSparseOctree(
     // Uses wave-based BFS on level arrays, avoiding BuildNode objects
     // and the O(n²) queue.shift() of the original approach.
     const result = flattenTreeFromLevels(
-        levels, mixed.masks, gridBounds, sceneBounds, voxelResolution, actualDepth
+        levels, mixed.masks, mixed.morton.length, gridBounds, sceneBounds, voxelResolution, actualDepth
     );
 
     const tFlatten = performance.now();
@@ -300,6 +388,7 @@ function buildSparseOctree(
  *
  * @param levels - Array of per-level SoA data (index 0 = leaves, last = root).
  * @param mixedMasks - Interleaved voxel masks for mixed leaf blocks.
+ * @param mixedCount - Number of mixed leaf blocks (upper bound on emitted leaves).
  * @param gridBounds - Grid bounds aligned to block boundaries.
  * @param sceneBounds - Original Gaussian scene bounds.
  * @param voxelResolution - Size of each voxel in world units.
@@ -308,7 +397,8 @@ function buildSparseOctree(
  */
 function flattenTreeFromLevels(
     levels: LevelData[],
-    mixedMasks: number[],
+    mixedMasks: Uint32Array,
+    mixedCount: number,
     gridBounds: Bounds,
     sceneBounds: Bounds,
     voxelResolution: number,
@@ -338,7 +428,12 @@ function flattenTreeFromLevels(
     }
 
     const nodes = new Uint32Array(maxNodes);
-    const leafDataList: number[] = [];
+    // Pre-size leafData to its upper bound (2 entries per mixed leaf). All
+    // mixed leaves originate from level 0, so mixedCount bounds the count
+    // tightly. Avoids unbounded growth of a regular JS array, which hits
+    // V8's backing-store limit on very large grids.
+    const leafData = new Uint32Array(mixedCount * 2);
+    let leafDataLen = 0;
     let numInteriorNodes = 0;
     let numMixedLeaves = 0;
     let emitPos = 0;
@@ -384,9 +479,9 @@ function flattenTreeFromLevels(
                 } else {
                     // Mixed leaf — store index into leafData
                     const maskIdx = level.maskIndices[ii];
-                    const leafDataIndex = leafDataList.length >> 1;
-                    leafDataList.push(mixedMasks[maskIdx * 2]);
-                    leafDataList.push(mixedMasks[maskIdx * 2 + 1]);
+                    const leafDataIndex = leafDataLen >> 1;
+                    leafData[leafDataLen++] = mixedMasks[maskIdx * 2];
+                    leafData[leafDataLen++] = mixedMasks[maskIdx * 2 + 1];
                     nodes[emitPos] = leafDataIndex & 0x00FFFFFF;
                     numMixedLeaves++;
                 }
@@ -457,7 +552,7 @@ function flattenTreeFromLevels(
         numInteriorNodes,
         numMixedLeaves,
         nodes: emitPos === maxNodes ? nodes : nodes.slice(0, emitPos),
-        leafData: new Uint32Array(leafDataList)
+        leafData: leafDataLen === leafData.length ? leafData : leafData.slice(0, leafDataLen)
     };
 }
 

--- a/src/lib/writers/sparse-octree.ts
+++ b/src/lib/writers/sparse-octree.ts
@@ -176,6 +176,119 @@ function sortParallelByMorton(
     }
 }
 
+/**
+ * Iterative quicksort that sorts mixed-block mortons in place, permuting the
+ * paired interleaved [lo, hi] mask pairs alongside. Same shape as
+ * `sortParallelByMorton`, but tailored to the (Float64 morton, Uint32×2 mask)
+ * layout used by `BlockMaskBuffer` so the buffer's typed arrays can serve as
+ * the sorted data directly — no SoA copy required.
+ *
+ * @param mortons - Morton codes; sort key.
+ * @param masks - Interleaved [lo, hi] mask pairs (length = 2 * n).
+ * @param n - Number of mixed entries to sort.
+ */
+function sortMixedByMorton(
+    mortons: Float64Array,
+    masks: Uint32Array,
+    n: number
+): void {
+    if (n < 2) return;
+
+    const swap = (a: number, b: number): void => {
+        const tm = mortons[a]; mortons[a] = mortons[b]; mortons[b] = tm;
+        const a2 = a * 2, b2 = b * 2;
+        const tlo = masks[a2]; masks[a2] = masks[b2]; masks[b2] = tlo;
+        const thi = masks[a2 + 1]; masks[a2 + 1] = masks[b2 + 1]; masks[b2 + 1] = thi;
+    };
+
+    const stack = new Int32Array(64);
+    let sp = 0;
+    stack[sp++] = 0;
+    stack[sp++] = n - 1;
+
+    while (sp > 0) {
+        const hi = stack[--sp];
+        const lo = stack[--sp];
+
+        if (hi - lo < 16) {
+            // Insertion sort
+            for (let i = lo + 1; i <= hi; i++) {
+                const km = mortons[i];
+                const kl = masks[i * 2];
+                const kh = masks[i * 2 + 1];
+                let j = i - 1;
+                while (j >= lo && mortons[j] > km) {
+                    mortons[j + 1] = mortons[j];
+                    masks[(j + 1) * 2] = masks[j * 2];
+                    masks[(j + 1) * 2 + 1] = masks[j * 2 + 1];
+                    j--;
+                }
+                mortons[j + 1] = km;
+                masks[(j + 1) * 2] = kl;
+                masks[(j + 1) * 2 + 1] = kh;
+            }
+            continue;
+        }
+
+        const mid = (lo + hi) >>> 1;
+        if (mortons[lo] > mortons[mid]) swap(lo, mid);
+        if (mortons[lo] > mortons[hi]) swap(lo, hi);
+        if (mortons[mid] > mortons[hi]) swap(mid, hi);
+        swap(mid, hi - 1);
+        const pivot = mortons[hi - 1];
+
+        let i = lo;
+        let j = hi - 1;
+        while (true) {
+            while (mortons[++i] < pivot) { /* sentinel at hi */ }
+            while (mortons[--j] > pivot) { /* sentinel at lo */ }
+            if (i >= j) break;
+            swap(i, j);
+        }
+        swap(i, hi - 1);
+
+        const leftSize = i - 1 - lo;
+        const rightSize = hi - (i + 1);
+        if (leftSize > rightSize) {
+            stack[sp++] = lo;
+            stack[sp++] = i - 1;
+            if (rightSize > 0) {
+                stack[sp++] = i + 1;
+                stack[sp++] = hi;
+            }
+        } else {
+            if (rightSize > 0) {
+                stack[sp++] = i + 1;
+                stack[sp++] = hi;
+            }
+            if (leftSize > 0) {
+                stack[sp++] = lo;
+                stack[sp++] = i - 1;
+            }
+        }
+    }
+}
+
+/**
+ * Binary-search lowest index i in `arr[0..n)` such that `arr[i] >= target`.
+ * Returns `n` if all entries are less than `target`.
+ *
+ * @param arr - Sorted Float64Array.
+ * @param target - Value to search for.
+ * @param n - Upper bound of the search range (exclusive).
+ * @returns Smallest index `i` with `arr[i] >= target`, or `n`.
+ */
+function lowerBoundF64(arr: Float64Array, target: number, n: number): number {
+    let lo = 0;
+    let hi = n;
+    while (lo < hi) {
+        const mid = (lo + hi) >>> 1;
+        if (arr[mid] < target) lo = mid + 1;
+        else hi = mid;
+    }
+    return lo;
+}
+
 // ============================================================================
 // Octree Construction
 // ============================================================================
@@ -204,41 +317,52 @@ function buildSparseOctree(
     const solid = buffer.getSolidBlocks();
     const totalBlocks = mixed.morton.length + solid.length;
 
-    // --- Phase 1: Combine blocks into SoA arrays and sort by Morton code ---
-    // Sort the three parallel typed arrays in place. We avoid
-    // TypedArray.prototype.sort with a comparefn because V8 routes that
-    // through a regular-array path bounded by FixedArray::kMaxLength
-    // (~134M with pointer compression) and throws
-    // `Custom comparefn not supported for huge TypedArrays` past it.
+    const memProbe = (label: string): void => {
+        const u = process.memoryUsage();
+        const live = u.heapUsed + u.external;
+        logger.info(`mem [octree: ${label}]: ${(live / 1e9).toFixed(3)}GB  (heap ${(u.heapUsed / 1e9).toFixed(3)}GB + ext ${(u.external / 1e9).toFixed(3)}GB)`);
+    };
+    memProbe(`entry (mixed=${mixed.morton.length} solid=${solid.length} total=${totalBlocks})`);
 
-    const sortedMortons = new Float64Array(totalBlocks);
-    const sortedTypes = new Uint8Array(totalBlocks);
-    const sortedMaskIndices = new Int32Array(totalBlocks);
-    {
-        let idx = 0;
-        for (let i = 0; i < mixed.morton.length; i++) {
-            sortedMortons[idx] = mixed.morton[i];
-            sortedTypes[idx] = BlockType.Mixed;
-            sortedMaskIndices[idx] = i;
-            idx++;
-        }
-        for (let i = 0; i < solid.length; i++) {
-            sortedMortons[idx] = solid[i];
-            sortedTypes[idx] = BlockType.Solid;
-            sortedMaskIndices[idx] = -1;
-            idx++;
-        }
+    // --- Phase 1: Sort the buffer's existing typed arrays in place ---
+    // Level 0 (leaves) is represented as TWO sorted streams — solid mortons
+    // and mixed mortons (with paired masks). Sorting in place avoids
+    // allocating SoA copies (Float64Array+Uint8Array+Int32Array, all sized to
+    // totalBlocks); for a buffer with N_solid solid + N_mixed mixed entries,
+    // that's ~13 * (N_solid + N_mixed) bytes saved.
+    //
+    // We avoid `comparefn` typed-array sort because V8 routes it through a
+    // regular-array path bounded by FixedArray::kMaxLength (~134M with
+    // pointer compression) and throws past it. Instead:
+    //   - Native `Float64Array.sort()` (no comparefn) on the solid stream:
+    //     numeric sort, no fallback path, no size limit.
+    //   - Custom `sortMixedByMorton` for the mixed stream: same iterative
+    //     quicksort as `sortParallelByMorton` but tailored to the
+    //     (Float64 morton, Uint32×2 mask) layout.
 
-        sortParallelByMorton(sortedMortons, sortedTypes, sortedMaskIndices, totalBlocks);
-    }
+    const solidStream = solid;
+    const mixedStream = mixed.morton;
+    const mixedMasks = mixed.masks;
+    const nSolid = solid.length;
+    const nMixed = mixed.morton.length;
+
+    if (nSolid > 1) solidStream.sort();
+    if (nMixed > 1) sortMixedByMorton(mixedStream, mixedMasks, nMixed);
+
+    memProbe('after Phase 1 (in-place sort, no SoA copy)');
 
     const tSort = performance.now();
 
     // --- Phase 2: Build tree bottom-up level by level using linear scan ---
-    // Instead of Map<number, BuildNode> per level, we use sorted parallel
-    // arrays and exploit the fact that sorted Morton codes make parent
-    // grouping a simple linear scan (consecutive entries with the same
-    // floor(morton/8) share a parent).
+    // Level 0 lives in `solidStream` + `mixedStream` (dual streams, sorted).
+    // We build level 1 by a two-pointer merge of these streams; subsequent
+    // levels (2, 3, ...) are built from JS-array level data via the same
+    // single-array linear scan as before.
+    //
+    // `levels[]` holds INTERIOR levels only (no level 0). `levels[0]` is the
+    // first interior level (= original "level 1"); `levels[length-1]` is the
+    // root. Phase 3 special-cases level 0 access via a wave-entry sentinel
+    // (`li === -1`).
 
     const bar = logger.bar('Building tree', 10);
     let octreeStep = 0;
@@ -257,105 +381,158 @@ function buildSparseOctree(
     );
     const treeDepth = Math.max(1, Math.ceil(Math.log2(blocksPerAxis)));
 
-    // Store level data for each tree level (level 0 = leaves, higher = toward root)
     const levels: LevelData[] = [];
 
-    // Current level data starts as the sorted leaf blocks
-    let curMortons: Float64Array | number[] = sortedMortons;
-    let curTypes: Uint8Array | number[] = sortedTypes;
-    let curMaskIndices: Int32Array | number[] = sortedMaskIndices;
-    let curChildMasks: number[] | null = null;
+    // === Build level 1 from dual-stream level 0 ===
+    // Two-pointer merge: at each step, the smaller-morton stream is the next
+    // child to process. Group children with the same `floor(morton/8)` parent.
+    // childMask records which octants are present; allSolid tracks whether we
+    // can collapse this parent into a SOLID leaf at level 1.
+    let curMortons: number[] = [];
+    let curTypes: number[] = [];
+    let curMaskIndices: number[] = [];
+    let curChildMasks: number[] | null = [];
 
-    // 1 step for init
+    {
+        let sI = 0;
+        let mI = 0;
+        const nextChildMasks = curChildMasks!;
+        while (sI < nSolid || mI < nMixed) {
+            const sM0 = sI < nSolid ? solidStream[sI] : Number.POSITIVE_INFINITY;
+            const mM0 = mI < nMixed ? mixedStream[mI] : Number.POSITIVE_INFINITY;
+            const minMorton = sM0 < mM0 ? sM0 : mM0;
+            const parentMorton = Math.floor(minMorton / 8);
+            let childMask = 0;
+            let allSolid = true;
+            let childCount = 0;
+
+            while (true) {
+                const sM = sI < nSolid ? solidStream[sI] : Number.POSITIVE_INFINITY;
+                const mM = mI < nMixed ? mixedStream[mI] : Number.POSITIVE_INFINITY;
+                const cur = sM < mM ? sM : mM;
+                if (!isFinite(cur) || Math.floor(cur / 8) !== parentMorton) break;
+                childMask |= 1 << (cur % 8);
+                childCount++;
+                if (sM < mM) {
+                    sI++;
+                } else {
+                    allSolid = false;
+                    mI++;
+                }
+            }
+
+            if (allSolid && childCount === 8) {
+                curMortons.push(parentMorton);
+                curTypes.push(BlockType.Solid);
+                curMaskIndices.push(-1);
+                nextChildMasks.push(0);
+            } else {
+                curMortons.push(parentMorton);
+                curTypes.push(BlockType.Mixed);
+                curMaskIndices.push(-1);
+                nextChildMasks.push(childMask);
+            }
+        }
+    }
+
+    // 1 step for init / level-1 build
     bar.tick();
     octreeStep++;
 
-    // Build up level by level
     let actualDepth = treeDepth;
     const levelSteps = 8;
 
-    for (let level = 0; level < treeDepth; level++) {
-        // Report inner progress scaled to levelSteps
-        const targetStep = 1 + Math.min(levelSteps, Math.floor((level + 1) / treeDepth * levelSteps));
-        while (octreeStep < targetStep) {
-            bar.tick();
-            octreeStep++;
-        }
-
-        // Save current level before building the next one above
+    // === Build levels 2..treeDepth from level 1 upward ===
+    // Same logic as before — single-array linear scan. We push each level
+    // before building the next, then push the final root after the loop.
+    if (curMortons.length === 0) {
+        // Empty input: nothing to push. levels stays empty.
+        actualDepth = 1;
+    } else if (curMortons.length === 1 && curMortons[0] === 0) {
+        // Level 1 IS the root.
+        actualDepth = 1;
         levels.push({
             mortons: curMortons,
             types: curTypes,
             maskIndices: curMaskIndices,
             childMasks: curChildMasks
         });
-
-        // Build next level using linear scan on sorted data.
-        // Since curMortons is sorted, entries sharing the same parent
-        // (floor(morton/8)) are contiguous — no Map needed.
-        const n = curMortons.length;
-        const nextMortons: number[] = [];
-        const nextTypes: number[] = [];
-        const nextMaskIndices: number[] = [];
-        const nextChildMasks: number[] = [];
-
-        let i = 0;
-        while (i < n) {
-            const parentMorton = Math.floor(curMortons[i] / 8);
-            let childMask = 0;
-            let allSolid = true;
-            let childCount = 0;
-
-            // Scan all consecutive entries that share this parent
-            while (i < n && Math.floor(curMortons[i] / 8) === parentMorton) {
-                const octant = curMortons[i] % 8;
-                childMask |= (1 << octant);
-                if (curTypes[i] !== BlockType.Solid) {
-                    allSolid = false;
-                }
-                childCount++;
-                i++;
+    } else {
+        for (let level = 1; level < treeDepth; level++) {
+            const targetStep = 1 + Math.min(levelSteps, Math.floor((level + 1) / treeDepth * levelSteps));
+            while (octreeStep < targetStep) {
+                bar.tick();
+                octreeStep++;
             }
 
-            if (allSolid && childCount === 8) {
-                // All 8 children are solid — collapse to solid parent
-                nextMortons.push(parentMorton);
-                nextTypes.push(BlockType.Solid);
-                nextMaskIndices.push(-1);
-                nextChildMasks.push(0);
-            } else {
-                // Interior node with sparse children
-                nextMortons.push(parentMorton);
-                nextTypes.push(BlockType.Mixed);
-                nextMaskIndices.push(-1);
-                nextChildMasks.push(childMask);
+            // Push current level before building one above it
+            levels.push({
+                mortons: curMortons,
+                types: curTypes,
+                maskIndices: curMaskIndices,
+                childMasks: curChildMasks
+            });
+
+            // Build next level using linear scan on sorted data.
+            const n = curMortons.length;
+            const nextMortons: number[] = [];
+            const nextTypes: number[] = [];
+            const nextMaskIndices: number[] = [];
+            const nextChildMasks: number[] = [];
+
+            let i = 0;
+            while (i < n) {
+                const parentMorton = Math.floor(curMortons[i] / 8);
+                let childMask = 0;
+                let allSolid = true;
+                let childCount = 0;
+
+                while (i < n && Math.floor(curMortons[i] / 8) === parentMorton) {
+                    const octant = curMortons[i] % 8;
+                    childMask |= (1 << octant);
+                    if (curTypes[i] !== BlockType.Solid) {
+                        allSolid = false;
+                    }
+                    childCount++;
+                    i++;
+                }
+
+                if (allSolid && childCount === 8) {
+                    nextMortons.push(parentMorton);
+                    nextTypes.push(BlockType.Solid);
+                    nextMaskIndices.push(-1);
+                    nextChildMasks.push(0);
+                } else {
+                    nextMortons.push(parentMorton);
+                    nextTypes.push(BlockType.Mixed);
+                    nextMaskIndices.push(-1);
+                    nextChildMasks.push(childMask);
+                }
+            }
+
+            curMortons = nextMortons;
+            curTypes = nextTypes;
+            curMaskIndices = nextMaskIndices;
+            curChildMasks = nextChildMasks;
+
+            if (curMortons.length === 0 ||
+                (curMortons.length === 1 && curMortons[0] === 0)) {
+                actualDepth = level + 1;
+                break;
             }
         }
 
-        curMortons = nextMortons;
-        curTypes = nextTypes;
-        curMaskIndices = nextMaskIndices;
-        curChildMasks = nextChildMasks;
-
-        // Break when the tree is empty or has converged to a single root at Morton 0.
-        // We must NOT break early if the single remaining node has a non-zero Morton,
-        // because the reader reconstructs Morton codes starting from root Morton 0.
-        if (curMortons.length === 0 ||
-            (curMortons.length === 1 && curMortons[0] === 0)) {
-            actualDepth = level + 1;
-            break;
+        // Save root
+        if (curMortons.length > 0) {
+            levels.push({
+                mortons: curMortons,
+                types: curTypes,
+                maskIndices: curMaskIndices,
+                childMasks: curChildMasks
+            });
         }
     }
 
-    // Save the root level
-    levels.push({
-        mortons: curMortons,
-        types: curTypes,
-        maskIndices: curMaskIndices,
-        childMasks: curChildMasks
-    });
-
-    // Flush remaining level steps
     while (octreeStep < 9) {
         bar.tick();
         octreeStep++;
@@ -363,16 +540,18 @@ function buildSparseOctree(
 
     const tBuild = performance.now();
 
+    memProbe(`after Phase 2 (built ${levels.length} levels)`);
+
     // --- Phase 3: Flatten tree to Laine-Karras format ---
-    // Uses wave-based BFS on level arrays, avoiding BuildNode objects
-    // and the O(n²) queue.shift() of the original approach.
     const result = flattenTreeFromLevels(
-        levels, mixed.masks, mixed.morton.length, gridBounds, sceneBounds, voxelResolution, actualDepth
+        levels, solidStream, mixedStream, mixedMasks, nSolid, nMixed,
+        gridBounds, sceneBounds, voxelResolution, actualDepth
     );
+
+    memProbe('after Phase 3 (flattenTreeFromLevels)');
 
     const tFlatten = performance.now();
 
-    // Final step (10th)
     bar.tick();
     bar.end();
 
@@ -383,12 +562,25 @@ function buildSparseOctree(
  * Flatten the level-based tree into Laine-Karras format arrays using
  * wave-based BFS traversal from root down through levels.
  *
- * Uses parallel arrays for BFS waves (no per-node object allocation)
- * and binary search on sorted level mortons to locate children.
+ * Level 0 (leaves) is represented as TWO sorted streams: `solidStream` (one
+ * Float64 morton per solid leaf, no per-leaf data) and `mixedStream` (one
+ * Float64 morton per mixed leaf, paired with `mixedMasks` at the same
+ * index). Wave entries with `li === -1` refer to leaves: `ii < nMixed`
+ * indicates a mixed leaf at `mixedStream[ii]`, while `ii >= nMixed`
+ * indicates a solid leaf at `solidStream[ii - nMixed]`.
  *
- * @param levels - Array of per-level SoA data (index 0 = leaves, last = root).
- * @param mixedMasks - Interleaved voxel masks for mixed leaf blocks.
- * @param mixedCount - Number of mixed leaf blocks (upper bound on emitted leaves).
+ * `levels[i]` (for `i >= 0`) holds the i-th INTERIOR level (= original
+ * "level i+1"), built bottom-up. `levels[length-1]` is the root.
+ *
+ * @param levels - Interior level data (index 0 = first interior level
+ * above leaves, last = root).
+ * @param solidStream - Sorted Float64 mortons for solid leaves.
+ * @param mixedStream - Sorted Float64 mortons for mixed leaves (paired with
+ * `mixedMasks` at the same index).
+ * @param mixedMasks - Interleaved voxel masks for mixed leaves.
+ * @param nSolid - Count of valid entries in `solidStream`.
+ * @param nMixed - Count of valid entries in `mixedStream` (and pairs in
+ * `mixedMasks`).
  * @param gridBounds - Grid bounds aligned to block boundaries.
  * @param sceneBounds - Original Gaussian scene bounds.
  * @param voxelResolution - Size of each voxel in world units.
@@ -397,17 +589,18 @@ function buildSparseOctree(
  */
 function flattenTreeFromLevels(
     levels: LevelData[],
+    solidStream: Float64Array,
+    mixedStream: Float64Array,
     mixedMasks: Uint32Array,
-    mixedCount: number,
+    nSolid: number,
+    nMixed: number,
     gridBounds: Bounds,
     sceneBounds: Bounds,
     voxelResolution: number,
     treeDepth: number
 ): SparseOctree {
-    const rootLevel = levels[levels.length - 1];
-
-    if (rootLevel.mortons.length === 0) {
-        // Empty tree
+    if (levels.length === 0) {
+        // Empty tree (no leaves and no interior levels).
         return {
             gridBounds,
             sceneBounds,
@@ -421,18 +614,17 @@ function flattenTreeFromLevels(
         };
     }
 
+    const rootLevel = levels[levels.length - 1];
+
     // Upper bound on total nodes (not all may be reachable if solids collapsed)
-    let maxNodes = 0;
+    let maxNodes = nSolid + nMixed;
     for (let l = 0; l < levels.length; l++) {
         maxNodes += levels[l].mortons.length;
     }
 
     const nodes = new Uint32Array(maxNodes);
-    // Pre-size leafData to its upper bound (2 entries per mixed leaf). All
-    // mixed leaves originate from level 0, so mixedCount bounds the count
-    // tightly. Avoids unbounded growth of a regular JS array, which hits
-    // V8's backing-store limit on very large grids.
-    const leafData = new Uint32Array(mixedCount * 2);
+    // Pre-size leafData to its upper bound (2 entries per mixed leaf).
+    const leafData = new Uint32Array(nMixed * 2);
     let leafDataLen = 0;
     let numInteriorNodes = 0;
     let numMixedLeaves = 0;
@@ -442,7 +634,7 @@ function flattenTreeFromLevels(
     let waveLi: number[] = [];
     let waveIi: number[] = [];
 
-    // Initialize wave with root level entries
+    // Initialize wave with root level entries.
     const rootLi = levels.length - 1;
     for (let i = 0; i < rootLevel.mortons.length; i++) {
         waveLi.push(rootLi);
@@ -456,35 +648,43 @@ function flattenTreeFromLevels(
     const intMask: number[] = [];
 
     while (waveLi.length > 0) {
-        // Clear interior tracking arrays
         intPos.length = 0;
         intLi.length = 0;
         intIi.length = 0;
         intMask.length = 0;
 
-        // Emit all nodes in this wave
+        // --- Emit all nodes in this wave ---
         for (let w = 0; w < waveLi.length; w++) {
             const li = waveLi[w];
             const ii = waveIi[w];
+
+            if (li === -1) {
+                // Level-0 leaf via dual-stream encoding.
+                if (ii < nMixed) {
+                    // Mixed leaf
+                    const leafDataIndex = leafDataLen >> 1;
+                    leafData[leafDataLen++] = mixedMasks[ii * 2];
+                    leafData[leafDataLen++] = mixedMasks[ii * 2 + 1];
+                    nodes[emitPos] = leafDataIndex & 0x00FFFFFF;
+                    numMixedLeaves++;
+                } else {
+                    // Solid leaf
+                    nodes[emitPos] = SOLID_LEAF_MARKER;
+                }
+                emitPos++;
+                continue;
+            }
+
             const level = levels[li];
             const type = level.types[ii];
 
-            // A node is a leaf if it's Solid (at any level, collapsed or original)
-            // or if it's at level 0 (the leaf block level).
-            const isLeaf = (type === BlockType.Solid) || (li === 0);
+            // A node is a leaf if it's Solid (at any level, collapsed or original).
+            // (Originally was also "or li === 0"; with the dual-stream split,
+            // level 0 leaves are handled via the li === -1 sentinel above.)
+            const isLeaf = type === BlockType.Solid;
 
             if (isLeaf) {
-                if (type === BlockType.Solid) {
-                    nodes[emitPos] = SOLID_LEAF_MARKER;
-                } else {
-                    // Mixed leaf — store index into leafData
-                    const maskIdx = level.maskIndices[ii];
-                    const leafDataIndex = leafDataLen >> 1;
-                    leafData[leafDataLen++] = mixedMasks[maskIdx * 2];
-                    leafData[leafDataLen++] = mixedMasks[maskIdx * 2 + 1];
-                    nodes[emitPos] = leafDataIndex & 0x00FFFFFF;
-                    numMixedLeaves++;
-                }
+                nodes[emitPos] = SOLID_LEAF_MARKER;
             } else {
                 // Interior node — record position for backfill after wave
                 intPos.push(emitPos);
@@ -492,14 +692,12 @@ function flattenTreeFromLevels(
                 intIi.push(ii);
                 intMask.push(level.childMasks![ii]);
                 numInteriorNodes++;
-                // Placeholder (will be filled below)
                 nodes[emitPos] = 0;
             }
             emitPos++;
         }
 
-        // Build next wave from children of interior nodes.
-        // Backfill interior node encodings with correct baseOffset.
+        // --- Build next wave from children of interior nodes ---
         const nextWaveLi: number[] = [];
         const nextWaveIi: number[] = [];
         let nextChildStart = emitPos;
@@ -508,32 +706,56 @@ function flattenTreeFromLevels(
             const childMask = intMask[j];
             const childCount = popcount(childMask);
 
-            // Encode interior node: mask in high byte, baseOffset in low 24 bits
             nodes[intPos[j]] = ((childMask & 0xFF) << 24) | (nextChildStart & 0x00FFFFFF);
 
-            // Find children in the level below using binary search.
-            // Since each level's mortons are sorted, this is O(log n) per lookup.
-            const childLi = intLi[j] - 1;
-            const childLevel = levels[childLi];
-            const myMorton = levels[intLi[j]].mortons[intIi[j]];
+            const myLi = intLi[j];
+            const myMorton = levels[myLi].mortons[intIi[j]];
             const childMortonBase = myMorton * 8;
             const childMortonEnd = childMortonBase + 8;
-            const childMortons = childLevel.mortons;
 
-            // Binary search for first child with morton >= childMortonBase
-            let lo = 0;
-            let hi = childMortons.length;
-            while (lo < hi) {
-                const mid = (lo + hi) >> 1;
-                if (childMortons[mid] < childMortonBase) lo = mid + 1;
-                else hi = mid;
-            }
+            if (myLi === 0) {
+                // Children are at level 0 → dual-stream binary search.
+                // Walk both streams from their respective lower bounds in
+                // morton order, emitting wave entries with `li === -1` and
+                // `ii` encoded as: ii < nMixed for mixed leaves, ii >= nMixed
+                // (= nMixed + solidIdx) for solid leaves.
+                let sIdx = lowerBoundF64(solidStream, childMortonBase, nSolid);
+                let mIdx = lowerBoundF64(mixedStream, childMortonBase, nMixed);
+                while (true) {
+                    const sM = sIdx < nSolid && solidStream[sIdx] < childMortonEnd ?
+                        solidStream[sIdx] : Number.POSITIVE_INFINITY;
+                    const mM = mIdx < nMixed && mixedStream[mIdx] < childMortonEnd ?
+                        mixedStream[mIdx] : Number.POSITIVE_INFINITY;
+                    if (!isFinite(sM) && !isFinite(mM)) break;
+                    if (sM < mM) {
+                        nextWaveLi.push(-1);
+                        nextWaveIi.push(nMixed + sIdx);
+                        sIdx++;
+                    } else {
+                        nextWaveLi.push(-1);
+                        nextWaveIi.push(mIdx);
+                        mIdx++;
+                    }
+                }
+            } else {
+                // Children are at an interior level → single-array binary search.
+                const childLi = myLi - 1;
+                const childLevel = levels[childLi];
+                const childMortons = childLevel.mortons;
 
-            // Collect all children in morton order (they are contiguous in sorted array)
-            while (lo < childMortons.length && childMortons[lo] < childMortonEnd) {
-                nextWaveLi.push(childLi);
-                nextWaveIi.push(lo);
-                lo++;
+                let lo = 0;
+                let hi = childMortons.length;
+                while (lo < hi) {
+                    const mid = (lo + hi) >> 1;
+                    if (childMortons[mid] < childMortonBase) lo = mid + 1;
+                    else hi = mid;
+                }
+
+                while (lo < childMortons.length && childMortons[lo] < childMortonEnd) {
+                    nextWaveLi.push(childLi);
+                    nextWaveIi.push(lo);
+                    lo++;
+                }
             }
 
             nextChildStart += childCount;

--- a/src/lib/writers/write-voxel.ts
+++ b/src/lib/writers/write-voxel.ts
@@ -393,29 +393,16 @@ const writeVoxel = async (options: WriteVoxelOptions, fs: FileSystem): Promise<v
             voxelResolution
         );
 
-        // Force a major GC at phase boundaries when Node was started with
-        // `--expose-gc`. Each phase produces a result buffer/grid that
-        // supersedes the previous one, but V8's old-generation mark-sweep
-        // is lazy and can drift several GB of dead intermediate memory
-        // across the pipeline before reclaiming. With `--expose-gc` this
-        // collapses the carry-over so each phase starts from a clean
-        // baseline. Harmless no-op when `gc` isn't exposed.
-        const forceGc = (): void => {
-            (globalThis as { gc?: () => void }).gc?.();
-        };
-
         let buffer = await voxelizeToBuffer(
             bvh, gpuVoxelization, gridBounds, voxelResolution, opacityCutoff
         );
 
         gpuVoxelization.destroy();
         gpuVoxelization = null;
-        forceGc();
 
         const filterSub = logger.group('Filtering');
         buffer = filterAndFillBlocks(buffer);
         filterSub.end();
-        forceGc();
 
         if (hasFillExterior) {
             const sub = logger.group('Fill exterior');
@@ -426,7 +413,6 @@ const writeVoxel = async (options: WriteVoxelOptions, fs: FileSystem): Promise<v
             buffer = fillResult.buffer;
             gridBounds = fillResult.gridBounds;
             sub.end();
-            forceGc();
         }
 
         if (hasFloorFill) {
@@ -437,7 +423,6 @@ const writeVoxel = async (options: WriteVoxelOptions, fs: FileSystem): Promise<v
             buffer = floorResult.buffer;
             gridBounds = floorResult.gridBounds;
             sub.end();
-            forceGc();
         }
 
         if (hasNav) {
@@ -450,7 +435,6 @@ const writeVoxel = async (options: WriteVoxelOptions, fs: FileSystem): Promise<v
             buffer = navResult.buffer;
             gridBounds = navResult.gridBounds;
             sub.end();
-            forceGc();
         }
 
         const finalCrop = hasFillExterior || hasFloorFill ?
@@ -458,7 +442,6 @@ const writeVoxel = async (options: WriteVoxelOptions, fs: FileSystem): Promise<v
             cropToOccupied(buffer, gridBounds, voxelResolution);
         buffer = finalCrop.buffer;
         gridBounds = finalCrop.gridBounds;
-        forceGc();
 
         const glbBytes = collisionMesh ?
             buildCollisionMesh(buffer, gridBounds, voxelResolution) :

--- a/src/lib/writers/write-voxel.ts
+++ b/src/lib/writers/write-voxel.ts
@@ -8,7 +8,7 @@ import { GpuVoxelization } from '../gpu';
 import { type FileSystem, writeFile } from '../io/write';
 import { GaussianBVH } from '../spatial';
 import type { DeviceCreator } from '../types';
-import { fmtBytes, fmtCount, logger, Transform } from '../utils';
+import { fmtCount, logger, Transform } from '../utils';
 import { buildSparseOctree, type SparseOctree } from './sparse-octree';
 import {
     filterAndFillBlocks,
@@ -202,14 +202,7 @@ const cropToNavigable = (
     const nby = ny >> 2;
     const nbz = nz >> 2;
 
-    logger.info(`mem [cropToNavigable: nx=${nx} ny=${ny} nz=${nz} (nbx*nby*nbz=${nbx * nby * nbz} blocks)]`);
-    const u0 = process.memoryUsage();
-    logger.info(`mem [cropToNavigable: pre-fromBuffer]: ${(u0.heapUsed + u0.external) / 1e9}GB`);
-
     const grid = SparseVoxelGrid.fromBuffer(buffer, nx, ny, nz);
-
-    const u1 = process.memoryUsage();
-    logger.info(`mem [cropToNavigable: post-fromBuffer]: ${(u1.heapUsed + u1.external) / 1e9}GB  (Δ=${((u1.heapUsed + u1.external - u0.heapUsed - u0.external) / 1e9).toFixed(3)}GB)`);
 
     const navBounds = grid.getNavigableBlockBounds();
     if (!navBounds) {
@@ -226,13 +219,7 @@ const cropToNavigable = (
         return { buffer, gridBounds };
     }
 
-    const u2 = process.memoryUsage();
-    logger.info(`mem [cropToNavigable: pre-toBuffer (crop=${cropMaxBx - minBx}x${cropMaxBy - minBy}x${cropMaxBz - minBz})]: ${(u2.heapUsed + u2.external) / 1e9}GB`);
-
     const croppedBuffer = grid.toBuffer(minBx, minBy, minBz, cropMaxBx, cropMaxBy, cropMaxBz);
-
-    const u3 = process.memoryUsage();
-    logger.info(`mem [cropToNavigable: post-toBuffer]: ${(u3.heapUsed + u3.external) / 1e9}GB  (Δ=${((u3.heapUsed + u3.external - u2.heapUsed - u2.external) / 1e9).toFixed(3)}GB)`);
 
     const blockSize = 4 * voxelResolution;
     const croppedMin = new Vec3(
@@ -406,25 +393,15 @@ const writeVoxel = async (options: WriteVoxelOptions, fs: FileSystem): Promise<v
             voxelResolution
         );
 
-        // Diagnostic: force a major GC at phase boundaries when Node was
-        // started with `--expose-gc`. Without it, V8's old-generation
-        // mark-sweep is lazy: each phase's intermediate grids stay in
-        // old-gen until the next phase's allocations cross the GC
-        // heuristic, which can drift several GB of dead memory across the
-        // pipeline. With `--expose-gc` this collapses the carry-over and
-        // makes per-phase memory readings reflect each phase's actual
-        // working set. Harmless no-op when `gc` isn't exposed.
+        // Force a major GC at phase boundaries when Node was started with
+        // `--expose-gc`. Each phase produces a result buffer/grid that
+        // supersedes the previous one, but V8's old-generation mark-sweep
+        // is lazy and can drift several GB of dead intermediate memory
+        // across the pipeline before reclaiming. With `--expose-gc` this
+        // collapses the carry-over so each phase starts from a clean
+        // baseline. Harmless no-op when `gc` isn't exposed.
         const forceGc = (): void => {
             (globalThis as { gc?: () => void }).gc?.();
-        };
-
-        // Sub-phase memory probe. Logs heapUsed + external (= V8's
-        // currently-live memory, the same `live` figure the --mem
-        // overlay shows). Used to localize which sub-step inside a
-        // bar window is allocating.
-        const memProbe = (label: string): void => {
-            const u = process.memoryUsage();
-            logger.info(`mem [${label}]: ${fmtBytes(u.heapUsed + u.external)}  (heap ${fmtBytes(u.heapUsed)} + ext ${fmtBytes(u.external)})`);
         };
 
         let buffer = await voxelizeToBuffer(
@@ -476,15 +453,12 @@ const writeVoxel = async (options: WriteVoxelOptions, fs: FileSystem): Promise<v
             forceGc();
         }
 
-        memProbe('before finalCrop');
         const finalCrop = hasFillExterior || hasFloorFill ?
             cropToNavigable(buffer, gridBounds, voxelResolution) :
             cropToOccupied(buffer, gridBounds, voxelResolution);
         buffer = finalCrop.buffer;
         gridBounds = finalCrop.gridBounds;
-        memProbe('after finalCrop, pre-GC');
         forceGc();
-        memProbe('after finalCrop, post-GC');
 
         const glbBytes = collisionMesh ?
             buildCollisionMesh(buffer, gridBounds, voxelResolution) :
@@ -496,7 +470,6 @@ const writeVoxel = async (options: WriteVoxelOptions, fs: FileSystem): Promise<v
             bounds,
             voxelResolution
         );
-        memProbe('after buildSparseOctree');
         buffer.clear();
 
         logger.info(`octree depth: ${octree.treeDepth}`);

--- a/src/lib/writers/write-voxel.ts
+++ b/src/lib/writers/write-voxel.ts
@@ -8,7 +8,7 @@ import { GpuVoxelization } from '../gpu';
 import { type FileSystem, writeFile } from '../io/write';
 import { GaussianBVH } from '../spatial';
 import type { DeviceCreator } from '../types';
-import { fmtCount, logger, Transform } from '../utils';
+import { fmtBytes, fmtCount, logger, Transform } from '../utils';
 import { buildSparseOctree, type SparseOctree } from './sparse-octree';
 import {
     filterAndFillBlocks,
@@ -202,7 +202,14 @@ const cropToNavigable = (
     const nby = ny >> 2;
     const nbz = nz >> 2;
 
+    logger.info(`mem [cropToNavigable: nx=${nx} ny=${ny} nz=${nz} (nbx*nby*nbz=${nbx * nby * nbz} blocks)]`);
+    const u0 = process.memoryUsage();
+    logger.info(`mem [cropToNavigable: pre-fromBuffer]: ${(u0.heapUsed + u0.external) / 1e9}GB`);
+
     const grid = SparseVoxelGrid.fromBuffer(buffer, nx, ny, nz);
+
+    const u1 = process.memoryUsage();
+    logger.info(`mem [cropToNavigable: post-fromBuffer]: ${(u1.heapUsed + u1.external) / 1e9}GB  (Δ=${((u1.heapUsed + u1.external - u0.heapUsed - u0.external) / 1e9).toFixed(3)}GB)`);
 
     const navBounds = grid.getNavigableBlockBounds();
     if (!navBounds) {
@@ -219,7 +226,13 @@ const cropToNavigable = (
         return { buffer, gridBounds };
     }
 
+    const u2 = process.memoryUsage();
+    logger.info(`mem [cropToNavigable: pre-toBuffer (crop=${cropMaxBx - minBx}x${cropMaxBy - minBy}x${cropMaxBz - minBz})]: ${(u2.heapUsed + u2.external) / 1e9}GB`);
+
     const croppedBuffer = grid.toBuffer(minBx, minBy, minBz, cropMaxBx, cropMaxBy, cropMaxBz);
+
+    const u3 = process.memoryUsage();
+    logger.info(`mem [cropToNavigable: post-toBuffer]: ${(u3.heapUsed + u3.external) / 1e9}GB  (Δ=${((u3.heapUsed + u3.external - u2.heapUsed - u2.external) / 1e9).toFixed(3)}GB)`);
 
     const blockSize = 4 * voxelResolution;
     const croppedMin = new Vec3(
@@ -393,16 +406,39 @@ const writeVoxel = async (options: WriteVoxelOptions, fs: FileSystem): Promise<v
             voxelResolution
         );
 
+        // Diagnostic: force a major GC at phase boundaries when Node was
+        // started with `--expose-gc`. Without it, V8's old-generation
+        // mark-sweep is lazy: each phase's intermediate grids stay in
+        // old-gen until the next phase's allocations cross the GC
+        // heuristic, which can drift several GB of dead memory across the
+        // pipeline. With `--expose-gc` this collapses the carry-over and
+        // makes per-phase memory readings reflect each phase's actual
+        // working set. Harmless no-op when `gc` isn't exposed.
+        const forceGc = (): void => {
+            (globalThis as { gc?: () => void }).gc?.();
+        };
+
+        // Sub-phase memory probe. Logs heapUsed + external (= V8's
+        // currently-live memory, the same `live` figure the --mem
+        // overlay shows). Used to localize which sub-step inside a
+        // bar window is allocating.
+        const memProbe = (label: string): void => {
+            const u = process.memoryUsage();
+            logger.info(`mem [${label}]: ${fmtBytes(u.heapUsed + u.external)}  (heap ${fmtBytes(u.heapUsed)} + ext ${fmtBytes(u.external)})`);
+        };
+
         let buffer = await voxelizeToBuffer(
             bvh, gpuVoxelization, gridBounds, voxelResolution, opacityCutoff
         );
 
         gpuVoxelization.destroy();
         gpuVoxelization = null;
+        forceGc();
 
         const filterSub = logger.group('Filtering');
         buffer = filterAndFillBlocks(buffer);
         filterSub.end();
+        forceGc();
 
         if (hasFillExterior) {
             const sub = logger.group('Fill exterior');
@@ -413,6 +449,7 @@ const writeVoxel = async (options: WriteVoxelOptions, fs: FileSystem): Promise<v
             buffer = fillResult.buffer;
             gridBounds = fillResult.gridBounds;
             sub.end();
+            forceGc();
         }
 
         if (hasFloorFill) {
@@ -423,6 +460,7 @@ const writeVoxel = async (options: WriteVoxelOptions, fs: FileSystem): Promise<v
             buffer = floorResult.buffer;
             gridBounds = floorResult.gridBounds;
             sub.end();
+            forceGc();
         }
 
         if (hasNav) {
@@ -435,13 +473,18 @@ const writeVoxel = async (options: WriteVoxelOptions, fs: FileSystem): Promise<v
             buffer = navResult.buffer;
             gridBounds = navResult.gridBounds;
             sub.end();
+            forceGc();
         }
 
+        memProbe('before finalCrop');
         const finalCrop = hasFillExterior || hasFloorFill ?
             cropToNavigable(buffer, gridBounds, voxelResolution) :
             cropToOccupied(buffer, gridBounds, voxelResolution);
         buffer = finalCrop.buffer;
         gridBounds = finalCrop.gridBounds;
+        memProbe('after finalCrop, pre-GC');
+        forceGc();
+        memProbe('after finalCrop, post-GC');
 
         const glbBytes = collisionMesh ?
             buildCollisionMesh(buffer, gridBounds, voxelResolution) :
@@ -453,6 +496,7 @@ const writeVoxel = async (options: WriteVoxelOptions, fs: FileSystem): Promise<v
             bounds,
             voxelResolution
         );
+        memProbe('after buildSparseOctree');
         buffer.clear();
 
         logger.info(`octree depth: ${octree.treeDepth}`);

--- a/test/dilation-grid-ops.test.mjs
+++ b/test/dilation-grid-ops.test.mjs
@@ -1,0 +1,109 @@
+/**
+ * Tests for the `consumeSrc` / `consumeA` opt-in input-reuse flags on
+ * `sparseDilate3` and `sparseOrGrids`. These tests pin the contract so a
+ * future regression that reads from a consumed input is caught here.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { sparseDilate3 } from '../src/lib/voxel/dilation.js';
+import { sparseOrGrids } from '../src/lib/voxel/grid-ops.js';
+import {
+    BLOCK_EMPTY,
+    BLOCK_SOLID,
+    SparseVoxelGrid
+} from '../src/lib/voxel/sparse-voxel-grid.js';
+
+describe('sparseDilate3 consumeSrc', function () {
+    it('should match non-consumed result and leave src empty', function () {
+        // Build identical 8x8x8 source grids with one solid block.
+        const buildSrc = () => {
+            const g = new SparseVoxelGrid(8, 8, 8);
+            // One voxel near the middle so dilation has somewhere to grow.
+            g.setVoxel(3, 3, 3);
+            return g;
+        };
+
+        const srcA = buildSrc();
+        const srcB = buildSrc();
+
+        const reference = sparseDilate3(srcA, 1, 1, false);
+        const consumed = sparseDilate3(srcB, 1, 1, true);
+
+        // Outputs must agree voxel-for-voxel.
+        for (let z = 0; z < 8; z++) {
+            for (let y = 0; y < 8; y++) {
+                for (let x = 0; x < 8; x++) {
+                    assert.strictEqual(
+                        consumed.getVoxel(x, y, z),
+                        reference.getVoxel(x, y, z),
+                        `voxel (${x},${y},${z}) diverges between consumed/non-consumed`
+                    );
+                }
+            }
+        }
+
+        // Reference srcA must be untouched.
+        assert.strictEqual(srcA.getVoxel(3, 3, 3), 1,
+            'non-consumed src must be unchanged');
+
+        // Consumed srcB must be empty (cleared and reused as scratch).
+        let anyVoxel = false;
+        for (let z = 0; z < 8 && !anyVoxel; z++) {
+            for (let y = 0; y < 8 && !anyVoxel; y++) {
+                for (let x = 0; x < 8 && !anyVoxel; x++) {
+                    if (srcB.getVoxel(x, y, z) !== 0) anyVoxel = true;
+                }
+            }
+        }
+        assert.strictEqual(anyVoxel, false,
+            'consumed src must be empty after the call');
+    });
+});
+
+describe('sparseOrGrids consumeA', function () {
+    it('should match non-consumed result and mutate a in place', function () {
+        const buildA = () => {
+            const g = new SparseVoxelGrid(8, 8, 8);
+            g.setVoxel(0, 0, 0);
+            g.setVoxel(1, 1, 1);
+            return g;
+        };
+        const buildB = () => {
+            const g = new SparseVoxelGrid(8, 8, 8);
+            g.setVoxel(7, 7, 7);
+            g.setVoxel(1, 1, 1); // overlap with a
+            return g;
+        };
+
+        const aRef = buildA();
+        const bRef = buildB();
+        const aMut = buildA();
+        const bMut = buildB();
+
+        const reference = sparseOrGrids(aRef, bRef, false);
+        const consumed = sparseOrGrids(aMut, bMut, true);
+
+        // Reference output must match consumed output voxel-for-voxel.
+        for (let z = 0; z < 8; z++) {
+            for (let y = 0; y < 8; y++) {
+                for (let x = 0; x < 8; x++) {
+                    assert.strictEqual(
+                        consumed.getVoxel(x, y, z),
+                        reference.getVoxel(x, y, z),
+                        `voxel (${x},${y},${z}) diverges between consumed/non-consumed`
+                    );
+                }
+            }
+        }
+
+        // consumeA=true returns the same object as `a`.
+        assert.strictEqual(consumed, aMut,
+            'consumed result must alias the input a');
+
+        // Non-consumed `aRef` must NOT have b's contributions.
+        assert.strictEqual(aRef.getVoxel(7, 7, 7), 0,
+            'non-consumed a must not have b\'s voxels');
+    });
+});

--- a/test/flood-fill-cluster.test.mjs
+++ b/test/flood-fill-cluster.test.mjs
@@ -86,18 +86,22 @@ function verifyVisitedVoxelConnectivity(visited, seedIx, seedIy, seedIz) {
     const visitedVoxels = new Set();
     const voxelKey = (ix, iy, iz) => ix + iy * nx + iz * nx * ny;
 
-    for (let w = 0; w < visited.occupancy.length; w++) {
-        let bits = visited.occupancy[w];
-        while (bits) {
-            const bitPos = 31 - Math.clz32(bits & -bits);
-            const bi = w * 32 + bitPos;
-            bits &= bits - 1;
+    const EVEN = 0x55555555 >>> 0;
+    for (let w = 0; w < visited.types.length; w++) {
+        const word = visited.types[w];
+        if (word === 0) continue;
+        let nonEmpty = ((word & EVEN) | ((word >>> 1) & EVEN)) >>> 0;
+        const baseIdx = w * 16;
+        while (nonEmpty) {
+            const bp = 31 - Math.clz32(nonEmpty & -nonEmpty);
+            const bi = baseIdx + (bp >>> 1);
+            nonEmpty &= nonEmpty - 1;
             if (bi >= nbx * nby * nbz) continue;
             const bx = bi % nbx;
             const byBz = (bi / nbx) | 0;
             const by = byBz % nby;
             const bz = (byBz / nby) | 0;
-            const bt = visited.blockType[bi];
+            const bt = visited.getBlockType(bi);
             if (bt === BLOCK_SOLID) {
                 for (let lz = 0; lz < 4; lz++)
                     for (let ly = 0; ly < 4; ly++)
@@ -151,15 +155,15 @@ function verifyInvertedGrid(buffer, grid, nbx, nby, nbz) {
         const [bx, by, bz] = mortonToXYZ(m);
         const bi = bx + by * nbx + bz * bStride;
         known.add(bi);
-        if (grid.blockType[bi] !== BLOCK_EMPTY) errors.push(`solid(${bx},${by},${bz}) expected EMPTY got ${NAMES[grid.blockType[bi]]}`);
+        if (grid.getBlockType(bi) !== BLOCK_EMPTY) errors.push(`solid(${bx},${by},${bz}) expected EMPTY got ${NAMES[grid.getBlockType(bi)]}`);
     }
     const mixed = buffer.getMixedBlocks();
     for (let i = 0; i < mixed.morton.length; i++) {
         const [bx, by, bz] = mortonToXYZ(mixed.morton[i]);
         const bi = bx + by * nbx + bz * bStride;
         known.add(bi);
-        if (grid.blockType[bi] !== BLOCK_MIXED) {
-            errors.push(`mixed(${bx},${by},${bz}) expected MIXED got ${NAMES[grid.blockType[bi]]}`);
+        if (grid.getBlockType(bi) !== BLOCK_MIXED) {
+            errors.push(`mixed(${bx},${by},${bz}) expected MIXED got ${NAMES[grid.getBlockType(bi)]}`);
         } else {
             const s = grid.masks.slot(bi);
             const elo = (~mixed.masks[i * 2]) >>> 0, ehi = (~mixed.masks[i * 2 + 1]) >>> 0;
@@ -167,7 +171,7 @@ function verifyInvertedGrid(buffer, grid, nbx, nby, nbz) {
         }
     }
     for (let bi = 0; bi < nbx * nby * nbz; bi++) {
-        if (!known.has(bi) && grid.blockType[bi] !== BLOCK_SOLID) errors.push(`block ${bi} expected SOLID`);
+        if (!known.has(bi) && grid.getBlockType(bi) !== BLOCK_SOLID) errors.push(`block ${bi} expected SOLID`);
     }
     return errors;
 }
@@ -183,12 +187,12 @@ describe('buildInvertedGrid', () => {
         const grid = buildInvertedGrid(buffer, nx, ny, nz);
         const nbx = nx >> 2, nby = ny >> 2;
 
-        assert.strictEqual(grid.blockType[blockIdx(0, 0, 0, nbx, nby)], BLOCK_EMPTY);
-        assert.strictEqual(grid.blockType[blockIdx(1, 0, 0, nbx, nby)], BLOCK_EMPTY);
-        assert.strictEqual(grid.blockType[blockIdx(0, 1, 0, nbx, nby)], BLOCK_EMPTY);
+        assert.strictEqual(grid.getBlockType(blockIdx(0, 0, 0, nbx, nby)), BLOCK_EMPTY);
+        assert.strictEqual(grid.getBlockType(blockIdx(1, 0, 0, nbx, nby)), BLOCK_EMPTY);
+        assert.strictEqual(grid.getBlockType(blockIdx(0, 1, 0, nbx, nby)), BLOCK_EMPTY);
 
-        assert.strictEqual(grid.blockType[blockIdx(2, 0, 0, nbx, nby)], BLOCK_SOLID);
-        assert.strictEqual(grid.blockType[blockIdx(0, 2, 0, nbx, nby)], BLOCK_SOLID);
+        assert.strictEqual(grid.getBlockType(blockIdx(2, 0, 0, nbx, nby)), BLOCK_SOLID);
+        assert.strictEqual(grid.getBlockType(blockIdx(0, 2, 0, nbx, nby)), BLOCK_SOLID);
     });
 
     it('should map mixed buffer blocks to BLOCK_MIXED with inverted masks', () => {
@@ -200,7 +204,7 @@ describe('buildInvertedGrid', () => {
         const nbx = nx >> 2, nby = ny >> 2;
         const bi = blockIdx(1, 1, 0, nbx, nby);
 
-        assert.strictEqual(grid.blockType[bi], BLOCK_MIXED);
+        assert.strictEqual(grid.getBlockType(bi), BLOCK_MIXED);
         const s = grid.masks.slot(bi);
         assert.strictEqual(grid.masks.lo[s], (~lo) >>> 0);
         assert.strictEqual(grid.masks.hi[s], (~hi) >>> 0);

--- a/test/sparse-octree.test.mjs
+++ b/test/sparse-octree.test.mjs
@@ -565,6 +565,252 @@ describe('buildSparseOctree', function () {
             );
         });
     });
+
+    // ========================================================================
+    // Dual-stream encoding (post-refactor): exercises level-0 split into
+    // separate solid/mixed streams, the `li === -1` wave-entry sentinel, the
+    // `ii < nMixed` vs `ii >= nMixed` solid-leaf encoding, the dual-stream
+    // child binary search, and the `sortMixedByMorton` paired-mask permutation.
+    // ========================================================================
+
+    /**
+     * Walk a built octree from root, return the set of {morton, isSolid, lo, hi}
+     * for every reachable leaf. Mortons are reconstructed from the BFS path.
+     */
+    function walkLeaves(octree) {
+        const leaves = [];
+        if (octree.nodes.length === 0) return leaves;
+
+        // BFS: each frame holds (nodeIdx, morton). Root morton is 0; child
+        // morton is parent * 8 + octant.
+        const stack = [{ idx: 0, morton: 0 }];
+        while (stack.length > 0) {
+            const { idx, morton } = stack.pop();
+            const node = octree.nodes[idx] >>> 0;
+
+            if (node === 0xFF000000 >>> 0) {
+                // Solid leaf marker
+                leaves.push({ morton, isSolid: true, lo: 0xFFFFFFFF, hi: 0xFFFFFFFF });
+                continue;
+            }
+
+            const childMask = (node >>> 24) & 0xFF;
+            const baseOffset = node & 0x00FFFFFF;
+
+            if (childMask === 0x00) {
+                // Mixed leaf — baseOffset is leafData index
+                const lo = octree.leafData[baseOffset * 2];
+                const hi = octree.leafData[baseOffset * 2 + 1];
+                leaves.push({ morton, isSolid: false, lo, hi });
+                continue;
+            }
+
+            // Interior — walk children in octant order
+            let off = 0;
+            for (let oct = 0; oct < 8; oct++) {
+                if (childMask & (1 << oct)) {
+                    stack.push({
+                        idx: baseOffset + off,
+                        morton: morton * 8 + oct
+                    });
+                    off++;
+                }
+            }
+        }
+        return leaves;
+    }
+
+    describe('dual-stream encoding', function () {
+        it('should round-trip a mixed solid+mixed leaf set through the tree', function () {
+            // Pseudorandom seed: deterministic across runs.
+            let s = 12345;
+            const rand = () => {
+                s = (s * 1664525 + 1013904223) >>> 0;
+                return s;
+            };
+
+            // 4x4x4 of leaf blocks (= 8x8x8 voxels per axis at block scale).
+            // Spread solid + mixed leaves across the volume so the merge logic
+            // sees a non-trivial interleaving of streams.
+            const expected = new Map(); // morton -> {isSolid, lo, hi}
+            const acc = new BlockMaskBuffer();
+
+            for (let z = 0; z < 4; z++) {
+                for (let y = 0; y < 4; y++) {
+                    for (let x = 0; x < 4; x++) {
+                        const r = rand() % 10;
+                        if (r < 4) continue; // empty
+                        const morton = xyzToMorton(x, y, z);
+                        if (r < 7) {
+                            // solid
+                            acc.addBlock(morton, 0xFFFFFFFF, 0xFFFFFFFF);
+                            expected.set(morton, { isSolid: true, lo: 0xFFFFFFFF, hi: 0xFFFFFFFF });
+                        } else {
+                            // mixed — distinctive lo/hi tied to morton so a
+                            // mis-permutation in sortMixedByMorton is visible.
+                            const lo = (morton * 0x01010101 + 0x12345678) >>> 0;
+                            const hi = (morton * 0x02020203 + 0x9ABCDEF0) >>> 0;
+                            acc.addBlock(morton, lo, hi);
+                            expected.set(morton, { isSolid: false, lo, hi });
+                        }
+                    }
+                }
+            }
+
+            assert.ok(expected.size > 0, 'test setup should produce some leaves');
+
+            const gridBounds = {
+                min: new Vec3(0, 0, 0),
+                max: new Vec3(4, 4, 4)
+            };
+            const octree = buildSparseOctree(acc, gridBounds, gridBounds, 0.25);
+            const got = walkLeaves(octree);
+
+            // Every reachable leaf must match an expected entry — UNLESS it's
+            // a solid leaf one level above the leaf grid (i.e. parent of an
+            // 8-solid group, which the builder collapses).
+            const remaining = new Map(expected);
+            for (const leaf of got) {
+                if (remaining.has(leaf.morton)) {
+                    const exp = remaining.get(leaf.morton);
+                    assert.strictEqual(leaf.isSolid, exp.isSolid,
+                        `morton ${leaf.morton}: solidness mismatch`);
+                    if (!leaf.isSolid) {
+                        assert.strictEqual(leaf.lo >>> 0, exp.lo >>> 0,
+                            `morton ${leaf.morton}: lo mismatch`);
+                        assert.strictEqual(leaf.hi >>> 0, exp.hi >>> 0,
+                            `morton ${leaf.morton}: hi mismatch`);
+                    }
+                    remaining.delete(leaf.morton);
+                } else {
+                    // Could be a collapsed-solid parent; verify all 8
+                    // children of this morton were expected solid and remove.
+                    assert.ok(leaf.isSolid,
+                        `unexpected non-solid leaf at morton ${leaf.morton}`);
+                    const baseChild = leaf.morton * 8;
+                    for (let oct = 0; oct < 8; oct++) {
+                        const childMorton = baseChild + oct;
+                        const exp = remaining.get(childMorton);
+                        assert.ok(exp && exp.isSolid,
+                            `collapsed solid covers morton ${childMorton} which was not expected solid`);
+                        remaining.delete(childMorton);
+                    }
+                }
+            }
+            assert.strictEqual(remaining.size, 0,
+                `unreachable leaves: ${[...remaining.keys()]}`);
+        });
+
+        it('should preserve mixed mask pairing under sortMixedByMorton', function () {
+            // Insert mortons in REVERSE order so sort actually permutes; each
+            // mask is a unique signature derived from its morton, so any
+            // mis-pairing after sort is detectable from the buffer state.
+            const acc = new BlockMaskBuffer();
+            const mortons = [];
+            for (let m = 31; m >= 0; m--) {
+                const morton = m * 8 + 1; // arbitrary spread
+                const lo = (morton * 0xDEADBEEF) >>> 0;
+                const hi = (morton * 0xCAFEBABE) >>> 0;
+                acc.addBlock(morton, lo, hi);
+                mortons.push(morton);
+            }
+
+            const gridBounds = {
+                min: new Vec3(0, 0, 0),
+                max: new Vec3(8, 8, 8)
+            };
+            buildSparseOctree(acc, gridBounds, gridBounds, 0.25);
+
+            // After build, the buffer's mixed view is sorted ascending and
+            // each mask still corresponds to its original morton.
+            const mixed = acc.getMixedBlocks();
+            for (let i = 1; i < mixed.morton.length; i++) {
+                assert.ok(mixed.morton[i] > mixed.morton[i - 1],
+                    `mixed mortons must be strictly ascending after sort (i=${i})`);
+            }
+            for (let i = 0; i < mixed.morton.length; i++) {
+                const m = mixed.morton[i];
+                const expectedLo = (m * 0xDEADBEEF) >>> 0;
+                const expectedHi = (m * 0xCAFEBABE) >>> 0;
+                assert.strictEqual(mixed.masks[i * 2] >>> 0, expectedLo,
+                    `mask lo at sorted index ${i} (morton ${m}) does not match its origin`);
+                assert.strictEqual(mixed.masks[i * 2 + 1] >>> 0, expectedHi,
+                    `mask hi at sorted index ${i} (morton ${m}) does not match its origin`);
+            }
+        });
+
+        it('should handle solid-only input (mixed stream empty)', function () {
+            // Exercises the dual-stream merge / search with one stream empty.
+            const acc = new BlockMaskBuffer();
+            const expected = [];
+            for (let i = 0; i < 8; i++) {
+                const x = i & 1, y = (i >> 1) & 1, z = (i >> 2) & 1;
+                // Spread within a 4x4x4 leaf-block space, but skip 1 to
+                // prevent the 8-children collapse so we keep distinct leaves.
+                if (i === 7) continue;
+                const m = xyzToMorton(x, y, z);
+                acc.addBlock(m, 0xFFFFFFFF, 0xFFFFFFFF);
+                expected.push(m);
+            }
+
+            const gridBounds = { min: new Vec3(0, 0, 0), max: new Vec3(2, 2, 2) };
+            const octree = buildSparseOctree(acc, gridBounds, gridBounds, 0.25);
+            const got = walkLeaves(octree).filter(l => l.isSolid).map(l => l.morton);
+
+            assert.deepStrictEqual([...got].sort((a, b) => a - b), expected.sort((a, b) => a - b));
+            assert.strictEqual(octree.numMixedLeaves, 0);
+        });
+
+        it('should handle mixed-only input (solid stream empty)', function () {
+            const acc = new BlockMaskBuffer();
+            const expectedMortons = [];
+            for (let i = 0; i < 5; i++) {
+                const m = i * 3;
+                acc.addBlock(m, 0xAAAA0000 | i, 0x5555FFFF & ~i);
+                expectedMortons.push(m);
+            }
+            assert.strictEqual(acc.solidCount, 0);
+
+            const gridBounds = { min: new Vec3(0, 0, 0), max: new Vec3(4, 4, 4) };
+            const octree = buildSparseOctree(acc, gridBounds, gridBounds, 0.25);
+            const gotMixed = walkLeaves(octree).filter(l => !l.isSolid).map(l => l.morton);
+
+            assert.deepStrictEqual(
+                [...gotMixed].sort((a, b) => a - b),
+                expectedMortons.sort((a, b) => a - b)
+            );
+            assert.strictEqual(octree.numMixedLeaves, expectedMortons.length);
+        });
+    });
+
+    describe('input mutation contract', function () {
+        it('should sort the BlockMaskBuffer in place by morton ascending', function () {
+            const acc = new BlockMaskBuffer();
+            // Insert in non-monotonic order
+            const inputSolids = [12, 3, 17, 1, 9];
+            const inputMixed = [8, 2, 14, 5];
+            for (const m of inputSolids) acc.addBlock(m, 0xFFFFFFFF, 0xFFFFFFFF);
+            for (const m of inputMixed) acc.addBlock(m, m * 17, m * 31);
+
+            const gridBounds = { min: new Vec3(0, 0, 0), max: new Vec3(8, 8, 8) };
+            buildSparseOctree(acc, gridBounds, gridBounds, 0.25);
+
+            const solid = acc.getSolidBlocks();
+            for (let i = 1; i < solid.length; i++) {
+                assert.ok(solid[i] > solid[i - 1],
+                    `solid mortons must be ascending post-build: index ${i}`);
+            }
+            const mixed = acc.getMixedBlocks();
+            for (let i = 1; i < mixed.morton.length; i++) {
+                assert.ok(mixed.morton[i] > mixed.morton[i - 1],
+                    `mixed mortons must be ascending post-build: index ${i}`);
+            }
+            assert.deepStrictEqual(
+                [...solid].sort((a, b) => a - b),
+                inputSolids.slice().sort((a, b) => a - b)
+            );
+        });
+    });
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Reduce peak memory across the voxelizer pipeline (voxelize → fill-floor → carve → octree) so grids that previously OOM'd or hit V8 array-length ceilings now complete.
- Lift two hard ceilings: `TypedArray.prototype.sort(comparefn)` past `FixedArray::kMaxLength` (~134M elements) in the octree builder, and regular-array backing-store limits in `BlockMaskBuffer`.
- Add a `live` memory probe alongside `peak` in the CLI's `--mem` overlay so phase-boundary scratch release is observable.

User-visible pipeline behavior is unchanged — same outputs, same flags. End-to-end run on a 4.21M-gaussian scene with `--voxel-floor-fill --voxel-carve` completes cleanly (octree depth 11, 755K interior nodes, 1.61M mixed leaves).

## What changed

### Packed block types in `SparseVoxelGrid`

The per-block type previously took 1 byte (`blockType: Uint8Array`) plus 1 bit in a parallel `occupancy: Uint32Array` bitfield — 9 bits/block. It's now packed at 2 bits per block in a single `Uint32Array` (16 blocks per word), eliminating `occupancy`. Non-empty-block iteration uses the trick `nonEmpty = (word & 0x55555555) | ((word >>> 1) & 0x55555555)` to derive a per-word mask of non-empty lanes, then walks the set bits via `clz32` exactly as the old occupancy field did. ~4.5× reduction on this component. Module-level `readBlockType` / `writeBlockType` arrow helpers expose the layout once; call sites in dilation, fill-floor, flood-fill, grid-ops, and filter-cluster all funnel through them.

### In-place reuse flags on `sparseDilate3` and `sparseOrGrids`

Both accept an opt-in `consumeSrc` / `consumeA` flag. When set, the function reuses the input grid's storage as a scratch buffer instead of allocating a fresh full-grid working copy. Adopted in `carve` (both dilate calls) and `fill-floor` (trailing dilate + OR). Each adoption saves one full `SparseVoxelGrid` at peak. The semantics are documented and tested.

### Growable typed-array `BlockMaskBuffer`

Migrated from `number[]` arrays to `Float64Array` (mortons; 51 bits needed, exceeds Smi range) and `Uint32Array` (masks). Buffers start at length 0; the first `addBlock` allocates `INITIAL_CAPACITY` and subsequent grows double. This raises the per-buffer ceiling well above V8's regular-array limit so very large grids round-trip without `RangeError: Invalid array length`. `clear()` releases the underlying buffers so a cleared instance retains no allocations.

### Octree builder rework (`sparse-octree.ts`)

Two changes. **(1) Sort buffer typed arrays in place instead of allocating SoA copies.** Phase 1 used to allocate three parallel arrays sized to `totalBlocks` (`Float64Array` + `Uint8Array` + `Int32Array`, ~13 bytes/block) and sort them. Phase 1 now sorts the `BlockMaskBuffer`'s existing typed arrays directly. We avoid `TypedArray.prototype.sort(comparefn)` because V8 routes it through a regular-array path bounded by `FixedArray::kMaxLength` and throws past it. The solid stream uses native `Float64Array.sort()` (no comparefn, no fallback path); the mixed stream uses a custom iterative quicksort (`sortMixedByMorton`) that permutes paired `Uint32×2` masks alongside the `Float64` keys. `buildSparseOctree` mutates its input buffer in place — documented in the docstring.

**(2) Dual-stream level 0 representation.** Level 0 (leaves) is now two sorted streams — solid mortons and mixed mortons (with paired masks) — instead of one merged SoA. Level 1 is built by a two-pointer merge of the streams; levels 2+ use the existing single-array linear scan. `flattenTreeFromLevels` walks both streams via dual-stream binary search for level-0 children, using `li === -1` as a wave-entry sentinel (`ii < nMixed` mixed, `ii >= nMixed` solid). The `interiorLevels` parameter holds only interior levels (level 0 lives in the streams), making the layout self-documenting.

### Live-memory probe in the CLI

The CLI now provides a `getLiveMemory()` callback (`heapUsed + external` from `process.memoryUsage()`) alongside the existing `getPeakMemory()`. The `--mem` overlay becomes `[peak X | live Y]`, where `live` drops between phases as scratch buffers GC, while `peak` remains the monotonic kernel max-RSS. Lets you see at a glance whether each phase actually releases its working set rather than only seeing the high-water mark.

## Test plan

- [x] `npm test` — 475 pass, 0 fail. Added 9 tests covering: octree round-trip via tree walk, mixed-mask permutation correctness under `sortMixedByMorton`, solid-only / mixed-only inputs, the `BlockMaskBuffer` mutation contract, `sparseDilate3(consumeSrc)` parity + post-call src-emptiness, `sparseOrGrids(consumeA)` parity + result aliasing.
- [x] `npm run lint` — clean.
- [x] End-to-end on a 4.21M-gaussian scene (`norwegian-filtered.ply`) with `--voxel-floor-fill --voxel-carve`: pipeline completes (~12 min wall, peak 10.4GB), octree depth 11, 755K interior nodes, 1.61M mixed leaves, 27.8MB `.bin`. The new `live` overlay confirms scratch state releases between phases.
- [ ] Manual sanity check on at least one more scene at a different scale before merge.