### PR TITLE
Reject outlier large gaussians in filter-cluster via occupancy ratio

### DIFF
--- a/src/lib/voxel/filter-cluster.ts
+++ b/src/lib/voxel/filter-cluster.ts
@@ -279,17 +279,13 @@ const filterCluster = async (
         const gaussianCols = buildGaussianColumns(ctx);
         const keepIndices: number[] = [];
 
-        // Gaussians whose AABB exceeds `largeFactor * voxelSize` on any axis must
-        // pass an additional occupancy-ratio check, so that elongated outliers
-        // (spikes whose tails clip a single cluster voxel) are rejected while
-        // structural large gaussians (slabs aligned with surfaces) are kept.
-        const largeFactor = 2.0;
+        // Gaussians whose AABB exceeds `largeThreshold` on any axis must hit
+        // at least `minOccupancyRatio` of the voxels in their AABB to be kept,
+        // rejecting elongated outliers (spikes whose tails clip a single
+        // cluster voxel) while preserving structural large gaussians.
+        const largeThreshold = 2.0 * clampedResolution;
         const minOccupancyRatio = 0.1;
-        const largeThreshold = largeFactor * clampedResolution;
-
-        let largeKept = 0;
-        let largeRejectedByRatio = 0;
-        const stats = { anyHit: false };
+        const invVoxel = 1 / clampedResolution;
 
         for (let i = 0; i < numRows; i++) {
             const px = gaussianCols.posX[i];
@@ -304,18 +300,17 @@ const filterCluster = async (
             const ex = gaussianCols.extentX[i];
             const ey = gaussianCols.extentY[i];
             const ez = gaussianCols.extentZ[i];
-            const isLarge = Math.max(ex, ey, ez) * 2 > largeThreshold;
-            const ratio = isLarge ? minOccupancyRatio : 0;
 
-            if (gaussianContributesToVoxels(i, gaussianCols, grid, lookup, minContribution, undefined, ratio, stats)) {
+            let minHits = 1;
+            if (Math.max(ex, ey, ez) * 2 > largeThreshold) {
+                const aabbVoxels = (2 * ex * invVoxel) * (2 * ey * invVoxel) * (2 * ez * invVoxel);
+                minHits = Math.max(1, Math.ceil(aabbVoxels * minOccupancyRatio));
+            }
+
+            if (gaussianContributesToVoxels(i, gaussianCols, grid, lookup, minContribution, undefined, minHits)) {
                 keepIndices.push(i);
-                if (isLarge) largeKept++;
-            } else if (isLarge && stats.anyHit) {
-                largeRejectedByRatio++;
             }
         }
-
-        logger.info(`large gaussians (>${fmtDistance(largeThreshold)}): ${fmtCount(largeKept)} kept, ${fmtCount(largeRejectedByRatio)} rejected by occupancy ratio (<${(minOccupancyRatio * 100).toFixed(0)}%)`);
 
         if (keepIndices.length === numRows) {
             return finish(dataTable);

--- a/src/lib/voxel/filter-cluster.ts
+++ b/src/lib/voxel/filter-cluster.ts
@@ -279,6 +279,18 @@ const filterCluster = async (
         const gaussianCols = buildGaussianColumns(ctx);
         const keepIndices: number[] = [];
 
+        // Gaussians whose AABB exceeds `largeFactor * voxelSize` on any axis must
+        // pass an additional occupancy-ratio check, so that elongated outliers
+        // (spikes whose tails clip a single cluster voxel) are rejected while
+        // structural large gaussians (slabs aligned with surfaces) are kept.
+        const largeFactor = 2.0;
+        const minOccupancyRatio = 0.1;
+        const largeThreshold = largeFactor * clampedResolution;
+
+        let largeKept = 0;
+        let largeRejectedByRatio = 0;
+        const stats = { anyHit: false };
+
         for (let i = 0; i < numRows; i++) {
             const px = gaussianCols.posX[i];
             const py = gaussianCols.posY[i];
@@ -289,10 +301,21 @@ const filterCluster = async (
                 continue;
             }
 
-            if (gaussianContributesToVoxels(i, gaussianCols, grid, lookup, minContribution)) {
+            const ex = gaussianCols.extentX[i];
+            const ey = gaussianCols.extentY[i];
+            const ez = gaussianCols.extentZ[i];
+            const isLarge = Math.max(ex, ey, ez) * 2 > largeThreshold;
+            const ratio = isLarge ? minOccupancyRatio : 0;
+
+            if (gaussianContributesToVoxels(i, gaussianCols, grid, lookup, minContribution, undefined, ratio, stats)) {
                 keepIndices.push(i);
+                if (isLarge) largeKept++;
+            } else if (isLarge && stats.anyHit) {
+                largeRejectedByRatio++;
             }
         }
+
+        logger.info(`large gaussians (>${fmtDistance(largeThreshold)}): ${fmtCount(largeKept)} kept, ${fmtCount(largeRejectedByRatio)} rejected by occupancy ratio (<${(minOccupancyRatio * 100).toFixed(0)}%)`);
 
         if (keepIndices.length === numRows) {
             return finish(dataTable);

--- a/src/lib/voxel/voxel-query.ts
+++ b/src/lib/voxel/voxel-query.ts
@@ -111,18 +111,15 @@ const isCenterInOccupiedVoxel = (
 };
 
 /**
- * Test whether a Gaussian has meaningful contribution at any occupied voxel
- * center within its AABB range.
+ * Test whether a Gaussian has meaningful contribution at occupied voxel
+ * centers within its AABB range.
  *
  * Iterates over blocks that overlap the Gaussian's AABB, then evaluates the
- * Gaussian's opacity contribution at each occupied voxel center in those blocks.
- *
- * When `minOccupancyRatio` > 0, instead of returning on the first qualifying
- * voxel, count qualifying voxels and require that count divided by the total
- * voxels in the Gaussian's AABB (clipped to the grid) meets the ratio. This
- * is the "support" check used to reject elongated outliers (e.g. spikes) whose
- * tails happen to clip a single cluster voxel: their AABB is huge but their
- * occupancy ratio is tiny.
+ * Gaussian's opacity contribution at each occupied voxel center in those
+ * blocks. Returns true once `minHits` qualifying voxels are found. With the
+ * default `minHits = 1` this short-circuits on the first hit; larger values
+ * let callers reject elongated outliers (e.g. spikes) whose tails clip only
+ * a single cluster voxel.
  *
  * @param gaussianIdx - Index of the Gaussian.
  * @param columns - Gaussian column data arrays.
@@ -130,9 +127,8 @@ const isCenterInOccupiedVoxel = (
  * @param lookup - Block lookup structures.
  * @param minContribution - Minimum contribution threshold.
  * @param blockFilter - Optional set of block indices to restrict the test to.
- * @param minOccupancyRatio - If > 0, require qualifying voxels / AABB voxels >= this. Default 0 (early-exit on first hit).
- * @param stats - Optional out-object that receives `anyHit` so callers can distinguish "rejected by ratio" from "no contribution at all".
- * @returns True if the Gaussian contributes above threshold (per the chosen mode).
+ * @param minHits - Minimum number of qualifying voxels required. Default 1.
+ * @returns True if at least `minHits` qualifying voxels were found.
  */
 const gaussianContributesToVoxels = (
     gaussianIdx: number,
@@ -141,10 +137,8 @@ const gaussianContributesToVoxels = (
     lookup: BlockLookup,
     minContribution: number,
     blockFilter?: Set<number>,
-    minOccupancyRatio: number = 0,
-    stats?: { anyHit: boolean }
+    minHits: number = 1
 ): boolean => {
-    if (stats) stats.anyHit = false;
     const px = columns.posX[gaussianIdx];
     const py = columns.posY[gaussianIdx];
     const pz = columns.posZ[gaussianIdx];
@@ -158,22 +152,6 @@ const gaussianContributesToVoxels = (
     const aabbMaxBy = Math.min(grid.numBlocksY - 1, Math.floor((py + ey - grid.gridMinY) / grid.blockSize));
     const aabbMinBz = Math.max(0, Math.floor((pz - ez - grid.gridMinZ) / grid.blockSize));
     const aabbMaxBz = Math.min(grid.numBlocksZ - 1, Math.floor((pz + ez - grid.gridMinZ) / grid.blockSize));
-
-    let minHits = 1;
-    if (minOccupancyRatio > 0) {
-        const nx = grid.numBlocksX * 4;
-        const ny = grid.numBlocksY * 4;
-        const nz = grid.numBlocksZ * 4;
-        const vMinX = Math.max(0, Math.floor((px - ex - grid.gridMinX) / grid.voxelResolution));
-        const vMaxX = Math.min(nx - 1, Math.floor((px + ex - grid.gridMinX) / grid.voxelResolution));
-        const vMinY = Math.max(0, Math.floor((py - ey - grid.gridMinY) / grid.voxelResolution));
-        const vMaxY = Math.min(ny - 1, Math.floor((py + ey - grid.gridMinY) / grid.voxelResolution));
-        const vMinZ = Math.max(0, Math.floor((pz - ez - grid.gridMinZ) / grid.voxelResolution));
-        const vMaxZ = Math.min(nz - 1, Math.floor((pz + ez - grid.gridMinZ) / grid.voxelResolution));
-        if (vMaxX < vMinX || vMaxY < vMinY || vMaxZ < vMinZ) return false;
-        const aabbVoxelTotal = (vMaxX - vMinX + 1) * (vMaxY - vMinY + 1) * (vMaxZ - vMinZ + 1);
-        minHits = Math.max(1, Math.ceil(aabbVoxelTotal * minOccupancyRatio));
-    }
 
     const g = computeGaussianInverse(
         columns.rotW[gaussianIdx], columns.rotX[gaussianIdx],
@@ -216,7 +194,6 @@ const gaussianContributesToVoxels = (
                             const vx = blockOriginX + (lx + 0.5) * grid.voxelResolution;
 
                             if (evaluateGaussianAt(g, px, py, pz, vx, vy, vz) >= minContribution) {
-                                if (stats) stats.anyHit = true;
                                 if (++hits >= minHits) return true;
                             }
                         }

--- a/src/lib/voxel/voxel-query.ts
+++ b/src/lib/voxel/voxel-query.ts
@@ -112,7 +112,7 @@ const isCenterInOccupiedVoxel = (
 
 /**
  * Test whether a Gaussian has meaningful contribution at occupied voxel
- * centers within its AABB range.
+ * centers in blocks that overlap its AABB.
  *
  * Iterates over blocks that overlap the Gaussian's AABB, then evaluates the
  * Gaussian's opacity contribution at each occupied voxel center in those

--- a/src/lib/voxel/voxel-query.ts
+++ b/src/lib/voxel/voxel-query.ts
@@ -117,13 +117,22 @@ const isCenterInOccupiedVoxel = (
  * Iterates over blocks that overlap the Gaussian's AABB, then evaluates the
  * Gaussian's opacity contribution at each occupied voxel center in those blocks.
  *
+ * When `minOccupancyRatio` > 0, instead of returning on the first qualifying
+ * voxel, count qualifying voxels and require that count divided by the total
+ * voxels in the Gaussian's AABB (clipped to the grid) meets the ratio. This
+ * is the "support" check used to reject elongated outliers (e.g. spikes) whose
+ * tails happen to clip a single cluster voxel: their AABB is huge but their
+ * occupancy ratio is tiny.
+ *
  * @param gaussianIdx - Index of the Gaussian.
  * @param columns - Gaussian column data arrays.
  * @param grid - Block grid parameters.
  * @param lookup - Block lookup structures.
  * @param minContribution - Minimum contribution threshold.
  * @param blockFilter - Optional set of block indices to restrict the test to.
- * @returns True if the Gaussian contributes above threshold at any qualifying voxel.
+ * @param minOccupancyRatio - If > 0, require qualifying voxels / AABB voxels >= this. Default 0 (early-exit on first hit).
+ * @param stats - Optional out-object that receives `anyHit` so callers can distinguish "rejected by ratio" from "no contribution at all".
+ * @returns True if the Gaussian contributes above threshold (per the chosen mode).
  */
 const gaussianContributesToVoxels = (
     gaussianIdx: number,
@@ -131,8 +140,11 @@ const gaussianContributesToVoxels = (
     grid: BlockGridParams,
     lookup: BlockLookup,
     minContribution: number,
-    blockFilter?: Set<number>
+    blockFilter?: Set<number>,
+    minOccupancyRatio: number = 0,
+    stats?: { anyHit: boolean }
 ): boolean => {
+    if (stats) stats.anyHit = false;
     const px = columns.posX[gaussianIdx];
     const py = columns.posY[gaussianIdx];
     const pz = columns.posZ[gaussianIdx];
@@ -147,6 +159,22 @@ const gaussianContributesToVoxels = (
     const aabbMinBz = Math.max(0, Math.floor((pz - ez - grid.gridMinZ) / grid.blockSize));
     const aabbMaxBz = Math.min(grid.numBlocksZ - 1, Math.floor((pz + ez - grid.gridMinZ) / grid.blockSize));
 
+    let minHits = 1;
+    if (minOccupancyRatio > 0) {
+        const nx = grid.numBlocksX * 4;
+        const ny = grid.numBlocksY * 4;
+        const nz = grid.numBlocksZ * 4;
+        const vMinX = Math.max(0, Math.floor((px - ex - grid.gridMinX) / grid.voxelResolution));
+        const vMaxX = Math.min(nx - 1, Math.floor((px + ex - grid.gridMinX) / grid.voxelResolution));
+        const vMinY = Math.max(0, Math.floor((py - ey - grid.gridMinY) / grid.voxelResolution));
+        const vMaxY = Math.min(ny - 1, Math.floor((py + ey - grid.gridMinY) / grid.voxelResolution));
+        const vMinZ = Math.max(0, Math.floor((pz - ez - grid.gridMinZ) / grid.voxelResolution));
+        const vMaxZ = Math.min(nz - 1, Math.floor((pz + ez - grid.gridMinZ) / grid.voxelResolution));
+        if (vMaxX < vMinX || vMaxY < vMinY || vMaxZ < vMinZ) return false;
+        const aabbVoxelTotal = (vMaxX - vMinX + 1) * (vMaxY - vMinY + 1) * (vMaxZ - vMinZ + 1);
+        minHits = Math.max(1, Math.ceil(aabbVoxelTotal * minOccupancyRatio));
+    }
+
     const g = computeGaussianInverse(
         columns.rotW[gaussianIdx], columns.rotX[gaussianIdx],
         columns.rotY[gaussianIdx], columns.rotZ[gaussianIdx],
@@ -154,6 +182,7 @@ const gaussianContributesToVoxels = (
         columns.scaleZ[gaussianIdx], columns.opacity[gaussianIdx]
     );
 
+    let hits = 0;
     for (let bbz = aabbMinBz; bbz <= aabbMaxBz; bbz++) {
         const zOff = bbz * grid.strideZ;
         for (let bby = aabbMinBy; bby <= aabbMaxBy; bby++) {
@@ -187,7 +216,8 @@ const gaussianContributesToVoxels = (
                             const vx = blockOriginX + (lx + 0.5) * grid.voxelResolution;
 
                             if (evaluateGaussianAt(g, px, py, pz, vx, vy, vz) >= minContribution) {
-                                return true;
+                                if (stats) stats.anyHit = true;
+                                if (++hits >= minHits) return true;
                             }
                         }
                     }

--- a/test/voxel-query.test.mjs
+++ b/test/voxel-query.test.mjs
@@ -297,6 +297,71 @@ describe('voxel-query', function () {
             assert.strictEqual(withoutFilter, true, 'Should contribute without filter');
             assert.strictEqual(withEmptyFilter, false, 'Should not contribute with restrictive filter');
         });
+
+        it('should require minHits qualifying voxels when minHits > 1', function () {
+            const buffer = new BlockMaskBuffer();
+            buffer.addBlock(xyzToMorton(0, 0, 0), SOLID_LO, SOLID_HI);
+
+            const voxelRes = 1.0;
+            const grid = makeGrid(2, 2, 2, voxelRes);
+            const lookup = buildBlockLookup(buffer, grid.strideY, grid.strideZ);
+
+            const gaussianCols = {
+                posX: new Float32Array([2.0]),
+                posY: new Float32Array([2.0]),
+                posZ: new Float32Array([2.0]),
+                rotW: new Float32Array([1.0]),
+                rotX: new Float32Array([0.0]),
+                rotY: new Float32Array([0.0]),
+                rotZ: new Float32Array([0.0]),
+                scaleX: new Float32Array([Math.log(2.0)]),
+                scaleY: new Float32Array([Math.log(2.0)]),
+                scaleZ: new Float32Array([Math.log(2.0)]),
+                opacity: new Float32Array([5.0]),
+                extentX: new Float32Array([6.0]),
+                extentY: new Float32Array([6.0]),
+                extentZ: new Float32Array([6.0])
+            };
+
+            // Single solid block has 64 occupied voxels, all of which qualify
+            // for this broad Gaussian at threshold 1e-6.
+            assert.strictEqual(gaussianContributesToVoxels(0, gaussianCols, grid, lookup, 1e-6, undefined, 1), true);
+            assert.strictEqual(gaussianContributesToVoxels(0, gaussianCols, grid, lookup, 1e-6, undefined, 64), true);
+            assert.strictEqual(gaussianContributesToVoxels(0, gaussianCols, grid, lookup, 1e-6, undefined, 65), false);
+        });
+
+        it('should count only filtered hits toward minHits when blockFilter is set', function () {
+            const buffer = new BlockMaskBuffer();
+            buffer.addBlock(xyzToMorton(0, 0, 0), SOLID_LO, SOLID_HI);
+            buffer.addBlock(xyzToMorton(1, 0, 0), SOLID_LO, SOLID_HI);
+
+            const voxelRes = 1.0;
+            const grid = makeGrid(4, 4, 4, voxelRes);
+            const lookup = buildBlockLookup(buffer, grid.strideY, grid.strideZ);
+
+            const gaussianCols = {
+                posX: new Float32Array([4.0]),
+                posY: new Float32Array([2.0]),
+                posZ: new Float32Array([2.0]),
+                rotW: new Float32Array([1.0]),
+                rotX: new Float32Array([0.0]),
+                rotY: new Float32Array([0.0]),
+                rotZ: new Float32Array([0.0]),
+                scaleX: new Float32Array([Math.log(4.0)]),
+                scaleY: new Float32Array([Math.log(4.0)]),
+                scaleZ: new Float32Array([Math.log(4.0)]),
+                opacity: new Float32Array([5.0]),
+                extentX: new Float32Array([12.0]),
+                extentY: new Float32Array([12.0]),
+                extentZ: new Float32Array([12.0])
+            };
+
+            // Two solid blocks (128 voxels) both qualify; filter to one (64 voxels).
+            const filter = new Set([0]);
+            assert.strictEqual(gaussianContributesToVoxels(0, gaussianCols, grid, lookup, 1e-6, undefined, 100), true);
+            assert.strictEqual(gaussianContributesToVoxels(0, gaussianCols, grid, lookup, 1e-6, filter, 64), true);
+            assert.strictEqual(gaussianContributesToVoxels(0, gaussianCols, grid, lookup, 1e-6, filter, 65), false);
+        });
     });
 
     // ====================================================================


### PR DESCRIPTION
filter-cluster previously kept any gaussian that contributed above minContribution at even a single occupied cluster voxel. This let elongated outliers (spikes whose long axis happens to clip one voxel) survive — bloating scene bounds and output size despite contributing almost nothing to the cluster.

For gaussians whose AABB exceeds 2 × voxelSize on its longest axis, we now require the count of qualifying voxels to be at least 10% of the gaussian's AABB voxel volume. Smaller gaussians keep the original early-exit behavior, and structural large gaussians (slabs aligned with surfaces) easily clear the bar — only sparse, swept-through outliers fail.

Validated on the Norwegian scene: 156 outlier gaussians removed, scene Z extent shrunk 93m → 61m (~32m spike), Y extent shrunk 9m → 4m. The other 4.20M kept gaussians are unchanged.