### PR TITLE
Support SPZ Version 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.4",
       "license": "MIT",
       "dependencies": {
+        "fzstd": "^0.1.1",
         "webgpu": "0.4.0"
       },
       "bin": {
@@ -3257,6 +3258,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/fzstd": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz",
+      "integrity": "sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA=="
     },
     "node_modules/generator-function": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "lib/"
   ],
   "dependencies": {
+    "fzstd": "^0.1.1",
     "webgpu": "0.4.0"
   },
   "devDependencies": {

--- a/src/lib/read.ts
+++ b/src/lib/read.ts
@@ -9,7 +9,7 @@ import { Options, Param } from './types';
  * - `ply` - PLY format (standard 3DGS training output)
  * - `splat` - Antimatter15 splat format
  * - `ksplat` - Kevin Kwok's compressed splat format
- * - `spz` - Niantic Labs compressed format
+ * - `spz` - Niantic Spatial compressed format
  * - `sog` - PlayCanvas SOG format (WebP-compressed)
  * - `lcc` - XGrids LCC format
  * - `mjs` - JavaScript module generator

--- a/src/lib/readers/read-spz.ts
+++ b/src/lib/readers/read-spz.ts
@@ -1,4 +1,6 @@
-import { Column, DataTable } from '../data-table';
+import { decompress as decompressZstd } from 'fzstd';
+
+import { Column, DataTable } from '../data-table/data-table';
 import { ReadSource } from '../io/read';
 import { logger, Transform } from '../utils';
 
@@ -33,7 +35,7 @@ function getFixed24(positionsView: DataView, elementIndex: number, memberIndex: 
     return fixed32;
 }
 
-const HARMONICS_COMPONENT_COUNT = [0, 9, 24, 45];
+const HARMONICS_COMPONENT_COUNT = [0, 9, 24, 45, 72];
 
 // Reusable scratch array for smallest-three quaternion decoding (avoids per-splat allocations)
 const tmpQuat = [0.0, 0.0, 0.0, 0.0];
@@ -41,8 +43,8 @@ const tmpQuat = [0.0, 0.0, 0.0, 0.0];
 /**
  * Reads a .spz file containing Niantic Labs compressed Gaussian splat data.
  *
- * The .spz format uses GZIP compression and fixed-point encoding to achieve
- * compact file sizes. Supports version 2 and 3 of the format for SH degrees 0-3.
+ * The .spz format uses either GZIP (v2/v3) or per-stream ZSTD (v4) compression and
+ * fixed-point encoding to achieve compact file sizes. Supports SH degrees 0-4.
  *
  * @see https://github.com/nianticlabs/spz
  *
@@ -54,7 +56,7 @@ const readSpz = async (source: ReadSource): Promise<DataTable> => {
     // Load complete file
     let fileBuffer = await source.read().readAll();
 
-    // Check if file is GZip compressed
+    // Check if file is GZip compressed (legacy v2/v3 format)
     const magicSize = 4;
     let magicView = new DataView(fileBuffer.buffer, fileBuffer.byteOffset, magicSize);
 
@@ -69,21 +71,29 @@ const readSpz = async (source: ReadSource): Promise<DataTable> => {
         throw new Error('invalid file header');
     }
 
-    const HEADER_SIZE = 16;
     const totalSize = fileBuffer.length;
 
+    // v2/v3: 16-byte header, single gzip stream (already decompressed above)
+    // v4 and later:    32-byte plaintext header with ZSTD streams
+    const MIN_SPZ_VERSION = 2;
+    const LATEST_SPZ_VERSION = 4;
+    const SPZ_VERSION_INTRODUCED_ZSTD = 4;
+    const MIN_HEADER_SIZE = 16;
+
+    if (totalSize < MIN_HEADER_SIZE) {
+        throw new Error('File too small to be valid .spz format');
+    }
+    const version = new DataView(fileBuffer.buffer, fileBuffer.byteOffset, MIN_HEADER_SIZE).getUint32(4, true);
+    if (version < MIN_SPZ_VERSION || version > LATEST_SPZ_VERSION) {
+        throw new Error(`Unsupported version ${version}`);
+    }
+
+    const HEADER_SIZE = version >= SPZ_VERSION_INTRODUCED_ZSTD ? 32 : MIN_HEADER_SIZE;
     if (totalSize < HEADER_SIZE) {
         throw new Error('File too small to be valid .spz format');
     }
 
-    // Parse header
     const header = new DataView(fileBuffer.buffer, fileBuffer.byteOffset, HEADER_SIZE);
-
-    const version = header.getUint32(4, true);
-    if (!(version === 2 || version === 3)) {
-        throw new Error(`Unsupported version ${version}`);
-    }
-
     const numSplats = header.getUint32(8, true);
     const shDegree = header.getUint8(12);
     const fractionalBits = header.getUint8(13);
@@ -91,24 +101,98 @@ const readSpz = async (source: ReadSource): Promise<DataTable> => {
         throw new Error(`Unsupported SH degree ${shDegree}`);
     }
 
-    const positionsByteSize = numSplats * 3 * 3; // 3 * 24bit values
-    const alphasByteSize = numSplats; // u8
-    const colorsByteSize = numSplats * 3; // u8 * 3
-    const scalesByteSize = numSplats * 3; // u8 * 3
-    const rotationsByteSize = numSplats * (version === 2 ? 3 : 4);
     const harmonicsComponentCount = HARMONICS_COMPONENT_COUNT[shDegree];
-    const shByteSize = numSplats * harmonicsComponentCount;
-    const requiredSize = HEADER_SIZE + positionsByteSize + alphasByteSize + colorsByteSize + scalesByteSize + rotationsByteSize + shByteSize;
-    if (totalSize < requiredSize) {
-        throw new Error(`File too small for SPZ payload: expected at least ${requiredSize} bytes, got ${totalSize}`);
-    }
 
-    const positionsView = new DataView(fileBuffer.buffer, fileBuffer.byteOffset + HEADER_SIZE, positionsByteSize);
-    const alphasView = new DataView(fileBuffer.buffer, fileBuffer.byteOffset + HEADER_SIZE + positionsByteSize, alphasByteSize);
-    const colorsView = new DataView(fileBuffer.buffer, fileBuffer.byteOffset + HEADER_SIZE + positionsByteSize + alphasByteSize, colorsByteSize);
-    const scalesView = new DataView(fileBuffer.buffer, fileBuffer.byteOffset + HEADER_SIZE + positionsByteSize + alphasByteSize + colorsByteSize, scalesByteSize);
-    const rotationsView = new DataView(fileBuffer.buffer, fileBuffer.byteOffset + HEADER_SIZE + positionsByteSize + alphasByteSize + colorsByteSize + scalesByteSize, rotationsByteSize);
-    const shView = new DataView(fileBuffer.buffer, fileBuffer.byteOffset + HEADER_SIZE + positionsByteSize + alphasByteSize + colorsByteSize + scalesByteSize + rotationsByteSize, shByteSize);
+    // Byte sizes of each attribute block
+    const positionsByteSize = numSplats * 9;                      // 3 × uint24
+    const alphasByteSize = numSplats;                             // u8
+    const colorsByteSize = numSplats * 3;                        // u8 × 3
+    const scalesByteSize = numSplats * 3;                        // u8 × 3
+    const rotationsByteSize = numSplats * (version === MIN_SPZ_VERSION ? 3 : 4);
+    const shByteSize = numSplats * harmonicsComponentCount;
+
+    let positionsView: DataView;
+    let alphasView: DataView;
+    let colorsView: DataView;
+    let scalesView: DataView;
+    let rotationsView: DataView;
+    let shView: DataView;
+
+    if (version >= SPZ_VERSION_INTRODUCED_ZSTD && version <= LATEST_SPZ_VERSION) {
+        // 32-byte plaintext header, followed by optional extensions, then TOC, then ZSTD streams.
+        const numStreams = header.getUint8(15);
+        const tocByteOffset = header.getUint32(16, true);
+
+        const expectedNumStreams = shDegree === 0 ? 5 : 6;
+        if (numStreams !== expectedNumStreams) {
+            throw new Error(`Unexpected stream count for shDegree ${shDegree}: expected ${expectedNumStreams}, got ${numStreams}`);
+        }
+
+        if (tocByteOffset < HEADER_SIZE) {
+            throw new Error(`Invalid tocByteOffset ${tocByteOffset}: must be >= ${HEADER_SIZE}`);
+        }
+
+        const tocSize = numStreams * 16;
+        const dataStart = tocByteOffset + tocSize;
+        if (dataStart > totalSize) {
+            throw new Error('File too small: TOC exceeds file bounds');
+        }
+
+        const expectedSizes = [positionsByteSize, alphasByteSize, colorsByteSize, scalesByteSize, rotationsByteSize];
+        if (shDegree > 0) {
+            expectedSizes.push(shByteSize);
+        }
+
+        const streams: DataView[] = [];
+        let dataOffset = dataStart;
+        for (let i = 0; i < numStreams; i++) {
+            const tocBase = tocByteOffset + i * 16;
+            const tocView = new DataView(fileBuffer.buffer, fileBuffer.byteOffset + tocBase, 16);
+            const compressedSizeBig = tocView.getBigUint64(0, true);
+            const uncompressedSizeBig = tocView.getBigUint64(8, true);
+            if (compressedSizeBig > BigInt(Number.MAX_SAFE_INTEGER) || uncompressedSizeBig > BigInt(Number.MAX_SAFE_INTEGER)) {
+                throw new Error(`Stream ${i} size exceeds Number.MAX_SAFE_INTEGER`);
+            }
+            const compressedSize = Number(compressedSizeBig);
+            const uncompressedSize = Number(uncompressedSizeBig);
+
+            if (uncompressedSize !== expectedSizes[i]) {
+                throw new Error(`Stream ${i} uncompressed size mismatch: expected ${expectedSizes[i]}, got ${uncompressedSize}`);
+            }
+            if (dataOffset + compressedSize > totalSize) {
+                throw new Error(`Stream ${i} extends past end of file (offset ${dataOffset} + ${compressedSize} > ${totalSize})`);
+            }
+
+            const compressed = fileBuffer.subarray(dataOffset, dataOffset + compressedSize);
+            const decompressed = decompressZstd(compressed);
+            if (decompressed.byteLength !== uncompressedSize) {
+                throw new Error(`Stream ${i} decompressed size mismatch: expected ${uncompressedSize}, got ${decompressed.byteLength}`);
+            }
+            streams.push(new DataView(decompressed.buffer, decompressed.byteOffset, decompressed.byteLength));
+            dataOffset += compressedSize;
+        }
+
+        positionsView = streams[0];
+        alphasView = streams[1];
+        colorsView = streams[2];
+        scalesView = streams[3];
+        rotationsView = streams[4];
+        shView = numStreams > 5 ? streams[5] : new DataView(new ArrayBuffer(0));
+    } else {
+        // v2/v3: single buffer already decompressed from gzip, attributes laid out sequentially.
+        const requiredSize = HEADER_SIZE + positionsByteSize + alphasByteSize + colorsByteSize + scalesByteSize + rotationsByteSize + shByteSize;
+        if (totalSize < requiredSize) {
+            throw new Error(`File too small for SPZ payload: expected at least ${requiredSize} bytes, got ${totalSize}`);
+        }
+
+        let offset = fileBuffer.byteOffset + HEADER_SIZE;
+        positionsView = new DataView(fileBuffer.buffer, offset, positionsByteSize); offset += positionsByteSize;
+        alphasView = new DataView(fileBuffer.buffer, offset, alphasByteSize); offset += alphasByteSize;
+        colorsView = new DataView(fileBuffer.buffer, offset, colorsByteSize); offset += colorsByteSize;
+        scalesView = new DataView(fileBuffer.buffer, offset, scalesByteSize); offset += scalesByteSize;
+        rotationsView = new DataView(fileBuffer.buffer, offset, rotationsByteSize); offset += rotationsByteSize;
+        shView = new DataView(fileBuffer.buffer, offset, shByteSize);
+    }
 
     // Create columns for the standard Gaussian splat data
     const columns = [
@@ -164,13 +248,13 @@ const readSpz = async (source: ReadSource): Promise<DataTable> => {
         let rot1Norm = 0.0;
         let rot2Norm = 0.0;
         let rot3Norm = 0.0;
-        if (version === 2) {
+        if (version === MIN_SPZ_VERSION) {
             rot1Norm = (rotationsView.getUint8(splatIndex * 3 + 0) / 127.5) - 1.0;
             rot2Norm = (rotationsView.getUint8(splatIndex * 3 + 1) / 127.5) - 1.0;
             rot3Norm = (rotationsView.getUint8(splatIndex * 3 + 2) / 127.5) - 1.0;
             const dot = rot1Norm * rot1Norm + rot2Norm * rot2Norm + rot3Norm * rot3Norm;
             rot0Norm = Math.sqrt(Math.max(0.0, 1.0 - dot));
-        } else if (version === 3) {
+        } else if (version >= 3 && version <= LATEST_SPZ_VERSION) {
             // Smallest-three quaternion decode from packed uint32
             // SPZ stores as [x, y, z, w] (indices 0-3)
             tmpQuat[0] = tmpQuat[1] = tmpQuat[2] = tmpQuat[3] = 0.0;

--- a/test/formats.test.mjs
+++ b/test/formats.test.mjs
@@ -3,35 +3,33 @@
  * Tests round-trip conversions and input-only format reading.
  */
 
-import { describe, it, before } from 'node:test';
 import assert from 'node:assert';
 import { readFile as fsReadFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import { before, describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
+
 
 import {
     Column,
     DataTable,
-    Transform,
-    computeSummary,
-    getInputFormat,
-    readFile,
-    readPly,
-    readSplat,
-    readKsplat,
-    readSpz,
-    readSog,
-    writePly,
-    writeCompressedPly,
-    writeSog,
-    writeCsv,
-    MemoryReadFileSystem,
     MemoryFileSystem,
+    MemoryReadFileSystem,
+    Transform,
+    WebPCodec,
     ZipReadFileSystem,
-    WebPCodec
+    computeSummary,
+    readKsplat,
+    readPly,
+    readSog,
+    readSplat,
+    readSpz,
+    writeCompressedPly,
+    writeCsv,
+    writePly,
+    writeSog
 } from '../src/lib/index.js';
-
-import { compareSummaries, compareDataTables } from './helpers/summary-compare.mjs';
+import { compareDataTables, compareSummaries } from './helpers/summary-compare.mjs';
 import { createMinimalTestData, encodePlyBinary } from './helpers/test-utils.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -161,6 +159,112 @@ const createSpzV3Fixture = () => {
 
     view.setUint32(offset, SPZ_V3_PACKED_QUATERNIONS.identity, true);
     view.setUint32(offset + 4, SPZ_V3_PACKED_QUATERNIONS.rotate45Z, true);
+
+    return new Uint8Array(buffer);
+};
+
+// Wraps raw bytes in a minimal valid ZSTD frame using a single Raw block (block_type=0).
+// This avoids requiring a JS ZSTD encoder; fzstd's decoder accepts raw blocks per RFC 8478.
+const wrapZstdRaw = (data) => {
+    const len = data.length;
+    if (len > 0x1FFFFF) throw new Error(`Raw block too large: ${len}`);
+    const out = new Uint8Array(4 + 1 + 4 + 3 + len);
+    const view = new DataView(out.buffer);
+    view.setUint32(0, 0xFD2FB528, true);          // ZSTD magic
+    out[4] = 0xA0;                                 // FHD
+    view.setUint32(5, len, true);                  // Frame_Content_Size (4 bytes LE)
+    const blockHeader = (len << 3) | 0b001;        // Block_Size << 3 | Block_Type=0 | Last_Block=1
+    out[9]  = blockHeader & 0xFF;
+    out[10] = (blockHeader >>> 8) & 0xFF;
+    out[11] = (blockHeader >>> 16) & 0xFF;
+    out.set(data, 12);
+    return out;
+};
+
+const SPZ_V4_HARMONICS_COMPONENT_COUNT = [0, 9, 24, 45, 72];
+
+const createSpzV4Fixture = ({ shDegree = 0 } = {}) => {
+    const count = 2;
+    const HEADER_SIZE = 32;
+
+    const positions = new Uint8Array(count * 9);
+    const alphas = new Uint8Array(count);
+    const colors = new Uint8Array(count * 3);
+    const scales = new Uint8Array(count * 3);
+    const rotations = new Uint8Array(count * 4);
+
+    const positionValues = [
+        [0, 0, 0],
+        [1, 0, 0]
+    ];
+    for (let i = 0; i < count; i++) {
+        const values = positionValues[i].map(value => (Math.round(value * 256) & 0xFFFFFF) >>> 0);
+        for (let j = 0; j < 3; j++) {
+            positions[i * 9 + j * 3 + 0] = values[j] & 0xFF;
+            positions[i * 9 + j * 3 + 1] = (values[j] >> 8) & 0xFF;
+            positions[i * 9 + j * 3 + 2] = (values[j] >> 16) & 0xFF;
+        }
+    }
+
+    alphas[0] = 230;
+    alphas[1] = 230;
+
+    colors.set([180, 90, 128, 90, 180, 128]);
+
+    const encodedScale = Math.round((Math.log(0.1) + 10) * 16);
+    for (let i = 0; i < count; i++) {
+        scales[i * 3 + 0] = encodedScale;
+        scales[i * 3 + 1] = encodedScale;
+        scales[i * 3 + 2] = encodedScale;
+    }
+
+    // Reuse the v3-verified packed quaternions — v4 packing is identical per spec.
+    const rotView = new DataView(rotations.buffer);
+    rotView.setUint32(0, SPZ_V3_PACKED_QUATERNIONS.identity, true);
+    rotView.setUint32(4, SPZ_V3_PACKED_QUATERNIONS.rotate45Z, true);
+
+    const streams = [positions, alphas, colors, scales, rotations];
+    if (shDegree > 0) {
+        const sh = new Uint8Array(count * SPZ_V4_HARMONICS_COMPONENT_COUNT[shDegree]);
+        sh.fill(128);
+        streams.push(sh);
+    }
+
+    const compressed = streams.map(wrapZstdRaw);
+    const numStreams = compressed.length;
+    const tocSize = numStreams * 16;
+    const tocByteOffset = HEADER_SIZE;
+    const totalDataSize = compressed.reduce((sum, c) => sum + c.length, 0);
+    const totalSize = HEADER_SIZE + tocSize + totalDataSize;
+
+    const buffer = new ArrayBuffer(totalSize);
+    const view = new DataView(buffer);
+    const bytes = new Uint8Array(buffer);
+
+    const SPZ_VERSION = 4;
+    const FRACTIONAL_BITS = 12;
+
+    view.setUint32(0, 0x5053474E, true);  // NGSP Magic Number
+    view.setUint32(4, SPZ_VERSION, true);  // Version
+    view.setUint32(8, count, true);
+    view.setUint8(12, shDegree);
+    view.setUint8(13, FRACTIONAL_BITS);
+    view.setUint8(14, 0);
+    view.setUint8(15, numStreams);
+    view.setUint32(16, tocByteOffset, true);
+
+    let tocOffset = HEADER_SIZE;
+    for (let i = 0; i < numStreams; i++) {
+        view.setBigUint64(tocOffset, BigInt(compressed[i].length), true);
+        view.setBigUint64(tocOffset + 8, BigInt(streams[i].length), true);
+        tocOffset += 16;
+    }
+
+    let dataOffset = HEADER_SIZE + tocSize;
+    for (const c of compressed) {
+        bytes.set(c, dataOffset);
+        dataOffset += c.length;
+    }
 
     return new Uint8Array(buffer);
 };
@@ -466,6 +570,71 @@ describe('SPZ Format (Input Only)', () => {
         assert(Math.abs(rot1[1]) < 0.01);
         assert(Math.abs(rot2[1]) < 0.01);
         assert(Math.abs(rot3[1] - Math.sin(Math.PI / 4)) < 0.01);
+    });
+
+    it('should read .spz v4 file with shDegree=0 (5 streams, no SH)', async () => {
+        const spzData = createSpzV4Fixture({ shDegree: 0 });
+        const source = new BufferReadSource(spzData);
+        const dataTable = await readSpz(source);
+
+        assert.strictEqual(dataTable.numRows, 2);
+
+        const summary = computeSummary(dataTable);
+        for (const [name, stats] of Object.entries(summary.columns)) {
+            assert.strictEqual(stats.nanCount, 0, `${name} has NaN values`);
+        }
+
+        // v4 quaternion packing must match v3: same hardcoded packed values must decode identically.
+        const rot0 = dataTable.getColumnByName('rot_0').data;
+        const rot1 = dataTable.getColumnByName('rot_1').data;
+        const rot2 = dataTable.getColumnByName('rot_2').data;
+        const rot3 = dataTable.getColumnByName('rot_3').data;
+
+        assert(Math.abs(rot0[0] - 1.0) < 1e-6);
+        assert(Math.abs(rot1[0]) < 1e-6);
+        assert(Math.abs(rot2[0]) < 1e-6);
+        assert(Math.abs(rot3[0]) < 1e-6);
+
+        assert(Math.abs(rot0[1] - Math.cos(Math.PI / 4)) < 0.01);
+        assert(Math.abs(rot1[1]) < 0.01);
+        assert(Math.abs(rot2[1]) < 0.01);
+        assert(Math.abs(rot3[1] - Math.sin(Math.PI / 4)) < 0.01);
+    });
+
+    it('should read .spz v4 file with shDegree=4 (6 streams with SH)', async () => {
+        const spzData = createSpzV4Fixture({ shDegree: 4 });
+        const source = new BufferReadSource(spzData);
+        const dataTable = await readSpz(source);
+
+        assert.strictEqual(dataTable.numRows, 2);
+        // Degree 1 = 9 SH coefficients per point → f_rest_0..f_rest_8 columns
+        for (let i = 0; i < 72; i++) {
+            assert(dataTable.hasColumn(`f_rest_${i}`));
+        }
+
+        // SH bytes were all 128, which decodes to (128 - 128) / 128 = 0
+        for (let i = 0; i < 72; i++) {
+            const col = dataTable.getColumnByName(`f_rest_${i}`).data;
+            assert.strictEqual(col[0], 0);
+            assert.strictEqual(col[1], 0);
+        }
+    });
+
+    it('should reject v4 file with mismatched stream count', async () => {
+        const spzData = createSpzV4Fixture({ shDegree: 0 });
+        // Corrupt numStreams: spec says shDegree=0 must have 5 streams, claim 4.
+        spzData[15] = 4;
+        const source = new BufferReadSource(spzData);
+        await assert.rejects(readSpz(source), /stream count/i);
+    });
+
+    it('should reject v4 file with TOC past end of file', async () => {
+        const spzData = createSpzV4Fixture({ shDegree: 0 });
+        const view = new DataView(spzData.buffer);
+        // Push tocByteOffset past end of file.
+        view.setUint32(16, spzData.length + 100, true);
+        const source = new BufferReadSource(spzData);
+        await assert.rejects(readSpz(source), /TOC/i);
     });
 });
 


### PR DESCRIPTION
Fixes #

- [ ] I confirm I have read the [contributing guidelines](https://github.com/splat-transform/splat-transform/blob/main/.github/CONTRIBUTING.md)
  - ^ This doesn't seem to exist in the current main

This PR introduces [SPZ V4](https://www.nianticspatial.com/blog/spz4) to splat-transform and subsequently the super splat renderer.
- Major introductions to SPZ v4 include zstd compression and a plaintext header which are both handled in this PR
- Extensions were also introduced with SPZ v4, but are not handled in this PR. Extension data will be ignored during spz parsing.

Implementation:
- Referenced release 3.0.0 in https://github.com/nianticlabs/spz. At the moment, the "spec" is in the code, so rules of the spz file format need to be interpreted from the reference library.
  - The code changes include a split branch for v2/v3 doing gzip uncompress, and v4 to handle the multiple zstd streams for each splat attribute.
- Introduced [fzstd](https://github.com/101arrowz/fzstd) to package.json. It's not quite well maintained, but is a lightweight source for decompressing zstd data. (Happy to consider [zstd-wasm](https://github.com/bokuweb/zstd-wasm) if there's a preference).

Let me know if there's anything else to consider. Thanks!

# Tests

## Unit Tests

Added some basic unit tests to cover a couple edge cases that come from the zstd decompression approach of SPZ v4

`npm test`

```
...
▶ writeOctreeFiles
  ✔ writes metadata and little-endian nodes followed by leafData (1.348292ms)
✔ writeOctreeFiles (1.853875ms)
ℹ tests 473
ℹ suites 131
ℹ pass 473
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 4796.251083
```

## Testing in Super Splat

In local splat-transform clone:
`npm run build && npm link`

In local supersplat clone:
`npm link @playcanvas/splat-transform`

|SPZ v4 Before|SPZ v4 After|
|-|-|
|<img width="2562" height="1316" alt="Screenshot 2026-04-22 at 3 28 57 PM" src="https://github.com/user-attachments/assets/b4ce1939-6b0b-4401-97bb-64132ba4172c" />|<img width="1728" height="963" alt="image" src="https://github.com/user-attachments/assets/63654a55-9834-4801-85d5-3c3724b9b806" />|
- Also checked SPZ v2 and v3

Sanity Check SPZ headers: https://nianticlabs.github.io/spz/