### PR TITLE
Reorganize CLI help and README options by usage scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ splat-transform [GLOBAL] input [ACTIONS]  ...  output [ACTIONS]
 
 ## Actions
 
-Actions are applied per-file in the order they appear. They can be repeated and used in any order:
+Actions execute in the order specified and can be repeated. Any action may appear after any input or output file:
 
 ```none
 -t, --translate        <x,y,z>          Translate Gaussians by (x, y, z)
@@ -156,7 +156,12 @@ Apply when writing `.voxel.json` (sparse voxel octree for collision detection). 
 
 ```none
     --voxel-params     [size,opacity]   Voxel size and opacity threshold. Default: 0.05,0.1
-    --voxel-external-fill [size]        Fill exterior voxels by dilation from seed (interior scenes).
+    --voxel-external-fill [size]        Seal exterior voxels via boundary flood fill (interior scenes).
+                                          [size] (world units) is the dilation distance applied
+                                          before the flood fill to bridge small wall gaps.
+                                          --seed-pos is used to verify the volume is enclosed at
+                                          the seed; the fill is skipped if the seed is reachable
+                                          from outside.
                                           Default size: 1.6
     --voxel-floor-fill [radius]         Fill each column upward from bottom until hitting solid (exterior scenes).
                                           Optional radius (world units): only patch XZ areas surrounded by floor

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ splat-transform [GLOBAL] input [ACTIONS]  ...  output [ACTIONS]
 
 ## Actions
 
-Actions can be repeated and applied in any order:
+Actions are applied per-file in the order they appear. They can be repeated and used in any order:
 
 ```none
 -t, --translate        <x,y,z>          Translate Gaussians by (x, y, z)
@@ -99,7 +99,7 @@ Actions can be repeated and applied in any order:
 -M, --morton-order                      Reorder Gaussians by Morton code (Z-order curve)
 ```
 
-## Global Options
+## General Options
 
 ```none
 -h, --help                              Show this help and exit
@@ -109,28 +109,65 @@ Actions can be repeated and applied in any order:
     --mem                               Show memory usage in progress output
     --tty                               Interactive bar rendering (default on a TTY; --no-tty to disable)
 -w, --overwrite                         Overwrite output file if it exists
--i, --iterations       <n>              Iterations for SOG SH compression (more=better). Default: 10
+```
+
+## SOG Compression Options
+
+Apply when writing `.sog`, `meta.json`, `lod-meta.json`, or `.html` outputs.
+
+```none
+-i, --iterations       <n>              Iterations for SH compression (more=better). Default: 10
 -L, --list-gpus                         List available GPU adapters and exit
--g, --gpu              <n|cpu>          Select device for SOG compression: GPU adapter index | 'cpu'
+-g, --gpu              <n|cpu>          Compression device: GPU adapter index | 'cpu'
+```
+
+## HTML Viewer Output Options
+
+Apply when writing `.html` outputs.
+
+```none
 -E, --viewer-settings  <settings.json>  HTML viewer settings JSON file
 -U, --unbundled                         Generate unbundled HTML viewer with separate files
--O, --lod-select       <n,n,...>        Comma-separated LOD levels to read from LCC input
--C, --lod-chunk-count  <n>              Approximate number of Gaussians per LOD chunk in K. Default: 512
--X, --lod-chunk-extent <n>              Approximate size of an LOD chunk in world units (m). Default: 16
-    --voxel-params     [size,opacity]   Voxel size and opacity threshold for .voxel.json. Default: 0.05,0.1
-    --voxel-external-fill [size]        Fill exterior voxels by dilation from seed. Default size: 1.6
-    --voxel-floor-fill [radius]         Fill each column upward from bottom until hitting solid (runs before carve).
-                                          Optional radius (world units): only patch XZ areas surrounded by floor
-                                          within 2*radius; large empty exterior areas are left alone.
-                                          Default radius: 1.6
-    --voxel-carve [h,r]                 Carve navigable space using capsule flood fill from seed.
-                                          Default: height=1.6, radius=0.2
-    --seed-pos         <x,y,z>          Seed position for voxel processing and --filter-cluster. Default: 0,0,0
--K, --collision-mesh [smooth|faces]     Generate collision mesh (.collision.glb). Default shape: smooth.
 ```
 
 > [!NOTE]
 > See the [SuperSplat Viewer Settings Schema](https://github.com/playcanvas/supersplat-viewer?tab=readme-ov-file#settings-schema) for details on how to pass data to the `-E` option.
+
+## LCC Input Options
+
+Apply when reading `.lcc` files.
+
+```none
+-O, --lod-select       <n,n,...>        Comma-separated LOD levels to read from LCC input
+```
+
+## LOD Output Options
+
+Apply when writing `lod-meta.json` (multi-LOD streaming SOG bundle).
+
+```none
+-C, --lod-chunk-count  <n>              Approximate number of Gaussians per LOD chunk in K. Default: 512
+-X, --lod-chunk-extent <n>              Approximate size of an LOD chunk in world units (m). Default: 16
+```
+
+## Voxel Output Options
+
+Apply when writing `.voxel.json` (sparse voxel octree for collision detection). See the [Collision Mesh Guide](guides/COLLISION.md) for a deep dive on each step and tuning.
+
+```none
+    --voxel-params     [size,opacity]   Voxel size and opacity threshold. Default: 0.05,0.1
+    --voxel-external-fill [size]        Fill exterior voxels by dilation from seed (interior scenes).
+                                          Default size: 1.6
+    --voxel-floor-fill [radius]         Fill each column upward from bottom until hitting solid (exterior scenes).
+                                          Optional radius (world units): only patch XZ areas surrounded by floor
+                                          within 2*radius; large empty exterior areas are left alone.
+                                          Default radius: 1.6
+    --voxel-carve      [h,r]            Carve navigable space using capsule flood fill from seed.
+                                          Default: height=1.6, radius=0.2
+    --seed-pos         <x,y,z>          Seed position for voxel fill/carve and --filter-cluster.
+                                          Default: 0,0,0
+-K, --collision-mesh   [smooth|faces]   Generate collision mesh (.collision.glb). Default: smooth
+```
 
 ## Examples
 
@@ -244,22 +281,54 @@ splat-transform gen-grid.mjs -p width=10,height=10,scale=10,color=0.1 scenes/gri
 
 ### Voxel Format
 
-The voxel format stores sparse voxel octree data for collision detection. It consists of two files: `.voxel.json` (metadata) and `.voxel.bin` (binary octree data).
+The voxel format stores sparse voxel octree data for collision detection. It consists of two files: `.voxel.json` (metadata) and `.voxel.bin` (binary octree data). Pass `-K` to also emit a `.collision.glb` mesh derived from the voxel grid.
+
+For a step-by-step walkthrough of each option (with illustrations), see the [Collision Mesh Guide](guides/COLLISION.md).
+
+#### Recommended pipeline
 
 ```bash
-# Generate voxel collision data from a splat file
-splat-transform input.ply output.voxel.json
+splat-transform input.ply \
+    --filter-cluster --seed-pos x,y,z \
+    [--voxel-external-fill | --voxel-floor-fill] [--voxel-carve] \
+    [-K [smooth|faces]] \
+    output.voxel.json
+```
 
-# Generate voxel data with custom resolution and opacity threshold
+`--filter-cluster` isolates the central scene and discards stray floaters before voxelization. `--seed-pos` is shared by `--filter-cluster` and the voxel fill/carve passes — set it once to a known-walkable point inside the scene.
+
+#### Interior scenes (rooms, indoor scans)
+
+Use `--voxel-external-fill` to seal the void around the room interior, then `--voxel-carve` to hollow out the navigable space:
+
+```bash
+splat-transform room.ply \
+    --filter-cluster --seed-pos 0,1,0 \
+    --voxel-external-fill --voxel-carve \
+    -K room.voxel.json
+```
+
+#### Exterior scenes (outdoor objects, terrain)
+
+Use `--voxel-floor-fill` to fill the ground beneath surfaces, optionally followed by `--voxel-carve`:
+
+```bash
+splat-transform terrain.ply \
+    --filter-cluster --seed-pos 0,0,0 \
+    --voxel-floor-fill \
+    -K terrain.voxel.json
+```
+
+#### Other examples
+
+```bash
+# Voxelize with custom resolution and opacity threshold
 splat-transform --voxel-params 0.1,0.3 input.ply output.voxel.json
 
-# Generate voxel data with exterior fill and carve
-splat-transform --voxel-external-fill --voxel-carve input.ply output.voxel.json
-
-# Generate voxel data with custom seed position and carve parameters
+# Custom carve capsule (height, radius)
 splat-transform --seed-pos 1,0,0 --voxel-carve 2.0,0.3 input.ply output.voxel.json
 
-# Generate voxel data with a watertight voxel-face collision mesh
+# Watertight voxel-face collision mesh
 splat-transform -K faces input.ply output.voxel.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -89,10 +89,12 @@ Actions execute in the order specified and can be repeated. Any action may appea
                                           Use n% to keep a percentage of Gaussians
 -G, --filter-floaters  [size,op,min]    Remove Gaussians not contributing to any solid voxel.
                                           Evaluates each Gaussian at occupied voxel centers.
-                                          Default: size=0.05, opacity=0.1, min=0.004 (1/255)
+                                          Default: size=0.05, opacity=0.1, min=0.004 (1/255).
+                                          Bare flag (no value) uses all defaults.
 -D, --filter-cluster   [res,op,min]     Keep only the connected cluster at --seed-pos.
                                           GPU-voxelizes at coarse resolution (res world units/voxel).
-                                          Default: res=1.0, opacity=0.999, min=0.1
+                                          Default: res=1.0, opacity=0.999, min=0.1.
+                                          Bare flag (no value) uses all defaults.
 -p, --params           <key=val,...>    Pass parameters to .mjs generator script
 -l, --lod              <n>              Tag the Gaussians with LOD level n (n >= 0)
 -m, --summary                           Print per-column statistics to stdout
@@ -111,14 +113,23 @@ Actions execute in the order specified and can be repeated. Any action may appea
 -w, --overwrite                         Overwrite output file if it exists
 ```
 
+## GPU Options
+
+Used by SOG compression and GPU voxelization (`--filter-cluster`, `--filter-floaters`, `.voxel.json` output).
+
+```none
+-L, --list-gpus                         List available GPU adapters and exit
+-g, --gpu              <n|cpu>          Device for GPU operations: GPU adapter index | 'cpu'
+                                          ('cpu' disables GPU and is incompatible with
+                                          GPU-only features like --filter-cluster)
+```
+
 ## SOG Compression Options
 
 Apply when writing `.sog`, `meta.json`, `lod-meta.json`, or `.html` outputs.
 
 ```none
 -i, --iterations       <n>              Iterations for SH compression (more=better). Default: 10
--L, --list-gpus                         List available GPU adapters and exit
--g, --gpu              <n|cpu>          Compression device: GPU adapter index | 'cpu'
 ```
 
 ## HTML Viewer Output Options

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Actions are applied per-file in the order they appear. They can be repeated and 
                                           GPU-voxelizes at coarse resolution (res world units/voxel).
                                           Default: res=1.0, opacity=0.999, min=0.1
 -p, --params           <key=val,...>    Pass parameters to .mjs generator script
--l, --lod              <n>              Specify the level of detail, n >= 0
+-l, --lod              <n>              Tag the Gaussians with LOD level n (n >= 0)
 -m, --summary                           Print per-column statistics to stdout
 -M, --morton-order                      Reorder Gaussians by Morton code (Z-order curve)
 ```

--- a/guides/COLLISION.md
+++ b/guides/COLLISION.md
@@ -59,7 +59,7 @@ After voxelization, the surface is typically a thin shell with holes. Filling cl
 
 For room scans, where you want a closed interior volume that carve can flood. The pass:
 
-1. Dilates the solid grid by `[size]` voxels to bridge small holes in the walls.
+1. Dilates the solid grid by `[size]` world units (converted internally to a voxel half-extent) to bridge small holes in the walls.
 2. Flood-fills empty space inward from the bounding-box boundary — every voxel reachable from outside is marked as exterior.
 3. Marks the exterior region as solid in the output, leaving only the enclosed interior as empty space for carve.
 
@@ -69,7 +69,7 @@ For room scans, where you want a closed interior volume that carve can flood. Th
 --voxel-external-fill [size]    Default size: 1.6
 ```
 
-The optional `size` controls the dilation distance used to seal small wall gaps — increase if walls have noisy holes the fill leaks through.
+The optional `size` (world units) controls the dilation distance used to seal small wall gaps — increase if walls have noisy holes the fill leaks through.
 
 ![external-fill: cross-section of a room before/after, showing void around the room marked solid](images/external-fill.png)
 <!-- TODO: illustration -->

--- a/guides/COLLISION.md
+++ b/guides/COLLISION.md
@@ -1,0 +1,164 @@
+# Collision Mesh Guide
+
+This guide explains how to generate collision data from a Gaussian splat scene using `splat-transform`. The output is a sparse voxel octree (`.voxel.json` + `.voxel.bin`) and an optional mesh (`.collision.glb`) suitable for runtime collision detection.
+
+## Overview
+
+Two outputs are produced from the same voxelization pass:
+
+- **`.voxel.json` / `.voxel.bin`** — sparse voxel octree for raycasts and broad-phase collision queries.
+- **`.collision.glb`** — triangulated mesh built from the voxel grid (only when `-K` / `--collision-mesh` is passed).
+
+A typical pipeline runs four stages, with the latter two being optional depending on the scene type:
+
+```
+input splat ──► filter-cluster ──► voxelize ──► fill ──► carve ──► [collision mesh]
+```
+
+<!-- TODO: pipeline diagram -->
+
+## Step 1: Isolating the scene with `--filter-cluster`
+
+Splats often contain stray floaters and disconnected geometry far from the scene of interest. `--filter-cluster` GPU-voxelizes the input at a coarse resolution and keeps only the connected component containing `--seed-pos`.
+
+```bash
+splat-transform input.ply --filter-cluster --seed-pos 0,1,0 output.voxel.json
+```
+
+Run this *before* fine-grained voxelization. Without it, fill and carve passes can leak through gaps or seed the wrong cluster.
+
+![filter-cluster: before/after showing the central cluster selected](images/filter-cluster.png)
+<!-- TODO: illustration -->
+
+### Tuning
+
+```none
+-D, --filter-cluster [res,op,min]
+```
+
+- `res` — voxel size in world units used for clustering (default `1.0`). Coarser = faster, more permissive about gaps.
+- `op` — opacity threshold (default `0.999`).
+- `min` — minimum contribution per voxel (default `0.1`).
+
+## Step 2: Voxelization (`--voxel-params`)
+
+Controls the grid that all subsequent passes operate on.
+
+```none
+--voxel-params [size,opacity]   Default: 0.05,0.1
+```
+
+- `size` — voxel edge length in world units. Smaller = higher fidelity, larger files, slower fills.
+- `opacity` — minimum splat opacity required to mark a voxel solid.
+
+## Step 3: Sealing the shell
+
+After voxelization, the surface is typically a thin shell with holes. Filling closes those holes so carve has a watertight volume to flood. Choose the fill that matches your scene type — they are not normally combined.
+
+### Interior scenes — `--voxel-external-fill`
+
+For room scans, where the camera was *inside* the volume you want to navigate. The pass dilates outward from `--seed-pos` (which must be inside the room) until it meets the wall surface, then marks everything *outside* the room as solid. The unmarked interior becomes the carve target.
+
+```none
+--voxel-external-fill [size]    Default size: 1.6
+```
+
+The optional `size` controls the dilation distance used to seal small wall gaps — increase if walls have noisy holes the fill leaks through.
+
+![external-fill: cross-section of a room before/after, showing void around the room marked solid](images/external-fill.png)
+<!-- TODO: illustration -->
+
+### Exterior scenes — `--voxel-floor-fill`
+
+For outdoor scans, terrain, or objects on a ground plane. The pass walks each XZ column upward from the bottom of the bounding box until it hits a solid voxel, marking everything below as solid. This produces a ground volume even when the scan only captured the surface.
+
+```none
+--voxel-floor-fill [radius]     Default radius: 1.6
+```
+
+The optional `radius` (world units) restricts patching to XZ areas surrounded by floor within `2*radius` — large empty exterior areas are left alone, so this won't accidentally fill the sky.
+
+![floor-fill: cross-section of a terrain before/after, showing solid mass below the surface](images/floor-fill.png)
+<!-- TODO: illustration -->
+
+### Choosing
+
+| Scene type             | Fill                     |
+| ---------------------- | ------------------------ |
+| Indoor room scan       | `--voxel-external-fill`  |
+| Outdoor terrain/object | `--voxel-floor-fill`     |
+| Single object in space | (skip both)              |
+
+## Step 4: Carving navigable space (`--voxel-carve`)
+
+Flood-fills a capsule volume from `--seed-pos`, marking voxels the capsule can reach as *navigable*. This produces the actual walkable region used at runtime.
+
+```none
+--voxel-carve [h,r]             Default: height=1.6, radius=0.2
+```
+
+- `h` — capsule height (world units), roughly the agent height.
+- `r` — capsule radius, roughly the agent radius.
+
+The capsule must fit at the seed position. If carve produces no output, the seed is likely inside solid geometry or the capsule is too large to fit.
+
+![carve: room before/after the capsule flood](images/carve.png)
+<!-- TODO: illustration -->
+
+## Step 5: Generating the collision mesh (`-K` / `--collision-mesh`)
+
+```none
+-K, --collision-mesh [smooth|faces]   Default: smooth
+```
+
+Two output shapes:
+
+### `smooth` (default)
+
+A smoothed mesh fitted to the voxel surface. Lower triangle count, more natural contours, suitable for character collision.
+
+![smooth collision mesh output](images/mesh-smooth.png)
+<!-- TODO: illustration -->
+
+### `faces`
+
+A watertight mesh built from the exposed voxel faces — every face is axis-aligned to the voxel grid. Higher triangle count but exactly matches the voxel volume; useful when collision must agree with raycasts against the voxel data.
+
+![voxel-face collision mesh output](images/mesh-faces.png)
+<!-- TODO: illustration -->
+
+## Full examples
+
+### Interior room scan
+
+```bash
+splat-transform room.ply \
+    --filter-cluster --seed-pos 0,1,0 \
+    --voxel-external-fill --voxel-carve \
+    -K room.voxel.json
+```
+
+### Exterior terrain
+
+```bash
+splat-transform terrain.ply \
+    --filter-cluster --seed-pos 0,0,0 \
+    --voxel-floor-fill \
+    -K terrain.voxel.json
+```
+
+### High-fidelity voxel-face mesh
+
+```bash
+splat-transform input.ply \
+    --voxel-params 0.025,0.1 \
+    -K faces output.voxel.json
+```
+
+## Troubleshooting
+
+- **Carve produces nothing.** `--seed-pos` is inside solid geometry, or the capsule (`h,r`) doesn't fit at the seed. Move the seed or shrink the capsule.
+- **Fill leaks through walls.** Increase `--voxel-external-fill` size, or lower the voxel `opacity` so thin walls are marked solid.
+- **Carve leaks into adjacent rooms.** Walls are too thin or have gaps. Lower voxel `size` for higher resolution, or increase fill size.
+- **Collision mesh is too dense.** Use `-K smooth` (default), or coarsen `--voxel-params` size.
+- **`--filter-cluster` selects the wrong cluster.** Move `--seed-pos` into the cluster you want, or increase its `res` to bridge intentional gaps.

--- a/guides/COLLISION.md
+++ b/guides/COLLISION.md
@@ -57,7 +57,13 @@ After voxelization, the surface is typically a thin shell with holes. Filling cl
 
 ### Interior scenes — `--voxel-external-fill`
 
-For room scans, where the camera was *inside* the volume you want to navigate. The pass dilates outward from `--seed-pos` (which must be inside the room) until it meets the wall surface, then marks everything *outside* the room as solid. The unmarked interior becomes the carve target.
+For room scans, where you want a closed interior volume that carve can flood. The pass:
+
+1. Dilates the solid grid by `[size]` voxels to bridge small holes in the walls.
+2. Flood-fills empty space inward from the bounding-box boundary — every voxel reachable from outside is marked as exterior.
+3. Marks the exterior region as solid in the output, leaving only the enclosed interior as empty space for carve.
+
+`--seed-pos` is used as a sanity check: if the seed ends up reachable from outside (i.e. the volume isn't actually enclosed at the seed), the fill is skipped and the original grid is returned.
 
 ```none
 --voxel-external-fill [size]    Default size: 1.6

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -607,96 +607,66 @@ SUPPORTED OUTPUTS
 
 ACTIONS (can be repeated, in any order)
     -t, --translate        <x,y,z>          Translate Gaussians by (x, y, z)
-    -r, --rotate           <x,y,z>          Rotate Gaussians by Euler angles (x, y, z), in degrees
+    -r, --rotate           <x,y,z>          Rotate Gaussians by Euler angles, in degrees
     -s, --scale            <factor>         Uniformly scale Gaussians by factor
     -H, --filter-harmonics <0|1|2|3>        Remove spherical harmonic bands > n
-    -N, --filter-nan                        Remove Gaussians with NaN values and most Inf values;
-                                              retains +Infinity in opacity and -Infinity in scale_*
+    -N, --filter-nan                        Remove Gaussians with NaN/Inf values
     -B, --filter-box       <x,y,z,X,Y,Z>    Remove Gaussians outside box (min, max corners)
-    -S, --filter-sphere    <x,y,z,radius>   Remove Gaussians outside sphere (center, radius)
-    -V, --filter-value     <name,cmp,value> Keep Gaussians where <name> <cmp> <value>
+    -S, --filter-sphere    <x,y,z,radius>   Remove Gaussians outside sphere
+    -V, --filter-value     <name,cmp,value> Keep Gaussians where <name> <cmp> <value>;
                                               cmp ∈ {lt,lte,gt,gte,eq,neq}
-                                              opacity, scale_*, f_dc_* use transformed values
-                                              (linear opacity 0-1, linear scale, linear color 0-1).
-                                              Append _raw for raw PLY values (e.g. opacity_raw).
-    -F, --decimate         <n|n%>           Simplify to n Gaussians via progressive pairwise merging
-                                              Use n% to keep a percentage of Gaussians
-    -G, --filter-floaters  [size,op,min]    Remove Gaussians not contributing to any solid voxel.
-                                              Evaluates each Gaussian at occupied voxel centers.
-                                              Default: size=0.05, opacity=0.1, min=0.004 (1/255)
-    -D, --filter-cluster   [res,op,min]     Keep only the connected cluster at --seed-pos.
-                                              GPU-voxelizes at coarse resolution (res world units/voxel).
-                                              Default: res=1.0, opacity=0.999, min=0.1
+    -F, --decimate         <n|n%>           Simplify to n (or n%) Gaussians via pairwise merging
+    -G, --filter-floaters  [size,op,min]    Remove Gaussians not contributing to any solid voxel
+    -D, --filter-cluster   [res,op,min]     Keep only the connected cluster at --seed-pos
     -p, --params           <key=val,...>    Pass parameters to .mjs generator script
     -l, --lod              <n>              Specify the level of detail, n >= 0
     -m, --summary                           Print per-column statistics to stdout
     -M, --morton-order                      Reorder Gaussians by Morton code (Z-order curve)
 
-GLOBAL OPTIONS
+GENERAL
     -h, --help                              Show this help and exit
     -v, --version                           Show version and exit
     -q, --quiet                             Suppress non-error output
         --verbose                           Show debug-level diagnostics
         --mem                               Show peak memory in progress output
-        --tty                               Interactive bar rendering (default on a TTY; --no-tty to disable)
+        --tty                               Interactive bar rendering (--no-tty to disable)
     -w, --overwrite                         Overwrite output file if it exists
-    -i, --iterations       <n>              Iterations for SOG SH compression (more=better). Default: 10
+
+SOG COMPRESSION (.sog, meta.json, lod-meta.json, .html outputs)
+    -i, --iterations       <n>              SH compression iterations (more=better). Default: 10
     -L, --list-gpus                         List available GPU adapters and exit
-    -g, --gpu              <n|cpu>          Select device for SOG compression: GPU adapter index | 'cpu'
+    -g, --gpu              <n|cpu>          Compression device: GPU adapter index | 'cpu'
+
+HTML VIEWER OUTPUT (.html)
     -E, --viewer-settings  <settings.json>  HTML viewer settings JSON file
     -U, --unbundled                         Generate unbundled HTML viewer with separate files
-    -O, --lod-select       <n,n,...>        Comma-separated LOD levels to read from LCC input
-    -C, --lod-chunk-count  <n>              Approximate number of Gaussians per LOD chunk in K. Default: 512
-    -X, --lod-chunk-extent <n>              Approximate size of an LOD chunk in world units (m). Default: 16
-        --voxel-params     [size,opacity]   Voxel size and opacity threshold for .voxel.json. Default: 0.05,0.1
-        --voxel-external-fill [size]        Fill exterior voxels by dilation from seed. Default size: 1.6
-        --voxel-floor-fill [size]           Fill below-floor voxels by upward column walk from bottom. Default size: 1.6
-        --voxel-carve [h,r]                 Carve navigable space using capsule flood fill from seed. Default: 1.6,0.2
-        --seed-pos         <x,y,z>          Seed position for voxel processing and --filter-cluster. Default: 0,0,0
-    -K, --collision-mesh   [smooth|faces]   Generate collision mesh (.collision.glb). Default shape: smooth
+
+LCC INPUT (.lcc)
+    -O, --lod-select       <n,n,...>        Comma-separated LOD levels to read
+
+LOD OUTPUT (lod-meta.json)
+    -C, --lod-chunk-count  <n>              Approximate Gaussians per LOD chunk in K. Default: 512
+    -X, --lod-chunk-extent <n>              Approximate LOD chunk size in world units. Default: 16
+
+VOXEL OUTPUT (.voxel.json)
+        --voxel-params     [size,opacity]   Voxel size + opacity threshold. Default: 0.05,0.1
+        --voxel-external-fill [size]        Fill exterior voxels by dilation from seed (interior scenes). Default: 1.6
+        --voxel-floor-fill [radius]         Fill columns upward from bottom (exterior scenes). Default: 1.6
+        --voxel-carve      [h,r]            Carve navigable space via capsule flood fill from seed. Default: 1.6,0.2
+        --seed-pos         <x,y,z>          Seed position for voxel fill/carve and --filter-cluster. Default: 0,0,0
+    -K, --collision-mesh   [smooth|faces]   Generate collision mesh (.collision.glb). Default: smooth
 
 EXAMPLES
-    # Scale then translate
-    splat-transform bunny.ply -s 0.5 -t 0,0,10 bunny-scaled.ply
+    # Convert formats
+    splat-transform input.ply output.sog
 
-    # Merge two files with transforms and compress to SOG format
-    splat-transform -w cloudA.ply -r 0,90,0 cloudB.ply -s 2 merged.sog
+    # Merge files with transforms
+    splat-transform -w a.ply -r 0,90,0 b.ply -s 2 merged.sog
 
-    # Generate unbundled HTML viewer with separate CSS, JS and SOG files
-    splat-transform -U bunny.ply bunny-viewer.html
+    # Generate voxel collision data
+    splat-transform input.ply --filter-cluster output.voxel.json
 
-    # Generate synthetic splats using a generator script
-    splat-transform gen-grid.mjs -p width=500,height=500,scale=0.1 grid.ply
-
-    # Generate LOD with custom chunk size and node split size
-    splat-transform -O 0,1,2 -C 1024 -X 32 input.lcc output/lod-meta.json
-
-    # Generate voxel data
-    splat-transform input.ply output.voxel.json
-
-    # Generate voxel data with collision mesh
-    splat-transform -K input.ply output.voxel.json
-
-    # Generate voxel data with voxel-face collision mesh
-    splat-transform -K faces input.ply output.voxel.json
-
-    # Generate voxel data with custom resolution and opacity threshold
-    splat-transform --voxel-params 0.1,0.3 input.ply output.voxel.json
-
-    # Generate voxel data with exterior fill and carve
-    splat-transform --voxel-external-fill --voxel-carve input.ply output.voxel.json
-
-    # Generate voxel data with custom seed position and carve parameters
-    splat-transform --seed-pos 1,0,0 --voxel-carve 2.0,0.3 input.ply output.voxel.json
-
-    # Print statistical summary, then write output
-    splat-transform bunny.ply --summary output.ply
-
-    # Print summary without writing a file (discard output)
-    splat-transform bunny.ply -m null
-
-    # Read input from a URL and write to a local file
-    splat-transform https://example.com/scene.ply scene.sog
+    More examples: https://github.com/playcanvas/splat-transform#examples
 `;
 
 const main = async () => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -605,7 +605,7 @@ SUPPORTED INPUTS
 SUPPORTED OUTPUTS
     .ply   .compressed.ply   .sog   meta.json   lod-meta.json   .glb   .csv   .html   .voxel.json   null
 
-ACTIONS (can be repeated, in any order)
+ACTIONS (executed in order; can be repeated)
     -t, --translate        <x,y,z>          Translate Gaussians by (x, y, z)
     -r, --rotate           <x,y,z>          Rotate Gaussians by Euler angles, in degrees
     -s, --scale            <factor>         Uniformly scale Gaussians by factor
@@ -616,8 +616,8 @@ ACTIONS (can be repeated, in any order)
     -V, --filter-value     <name,cmp,value> Keep Gaussians where <name> <cmp> <value>;
                                               cmp ∈ {lt,lte,gt,gte,eq,neq}
     -F, --decimate         <n|n%>           Simplify to n (or n%) Gaussians via pairwise merging
-    -G, --filter-floaters  [size,op,min]    Remove Gaussians not contributing to any solid voxel
-    -D, --filter-cluster   [res,op,min]     Keep only the connected cluster at --seed-pos
+    -G, --filter-floaters  [size,op,min]    Remove Gaussians not contributing to any solid voxel. Default: 0.05,0.1,0.004
+    -D, --filter-cluster   [res,op,min]     Keep only the connected cluster at --seed-pos. Default: 1.0,0.999,0.1
     -p, --params           <key=val,...>    Pass parameters to .mjs generator script
     -l, --lod              <n>              Tag the Gaussians with LOD level n (n >= 0)
     -m, --summary                           Print per-column statistics to stdout
@@ -632,10 +632,13 @@ GENERAL
         --tty                               Interactive bar rendering (--no-tty to disable)
     -w, --overwrite                         Overwrite output file if it exists
 
+GPU (used by SOG compression and GPU voxelization: --filter-cluster, --filter-floaters, .voxel.json output)
+    -L, --list-gpus                         List available GPU adapters and exit
+    -g, --gpu              <n|cpu>          Device for GPU operations: GPU adapter index | 'cpu'
+                                              ('cpu' disables GPU and is incompatible with GPU-only features)
+
 SOG COMPRESSION (.sog, meta.json, lod-meta.json, .html outputs)
     -i, --iterations       <n>              SH compression iterations (more=better). Default: 10
-    -L, --list-gpus                         List available GPU adapters and exit
-    -g, --gpu              <n|cpu>          Compression device: GPU adapter index | 'cpu'
 
 HTML VIEWER OUTPUT (.html)
     -E, --viewer-settings  <settings.json>  HTML viewer settings JSON file

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -610,7 +610,7 @@ ACTIONS (can be repeated, in any order)
     -r, --rotate           <x,y,z>          Rotate Gaussians by Euler angles, in degrees
     -s, --scale            <factor>         Uniformly scale Gaussians by factor
     -H, --filter-harmonics <0|1|2|3>        Remove spherical harmonic bands > n
-    -N, --filter-nan                        Remove Gaussians with NaN/Inf values
+    -N, --filter-nan                        Remove Gaussians with NaN values and most Inf values
     -B, --filter-box       <x,y,z,X,Y,Z>    Remove Gaussians outside box (min, max corners)
     -S, --filter-sphere    <x,y,z,radius>   Remove Gaussians outside sphere
     -V, --filter-value     <name,cmp,value> Keep Gaussians where <name> <cmp> <value>;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -650,7 +650,7 @@ LOD OUTPUT (lod-meta.json)
 
 VOXEL OUTPUT (.voxel.json)
         --voxel-params     [size,opacity]   Voxel size + opacity threshold. Default: 0.05,0.1
-        --voxel-external-fill [size]        Fill exterior voxels by dilation from seed (interior scenes). Default: 1.6
+        --voxel-external-fill [size]        Seal exterior voxels via boundary flood fill (interior scenes). Default: 1.6
         --voxel-floor-fill [radius]         Fill columns upward from bottom (exterior scenes). Default: 1.6
         --voxel-carve      [h,r]            Carve navigable space via capsule flood fill from seed. Default: 1.6,0.2
         --seed-pos         <x,y,z>          Seed position for voxel fill/carve and --filter-cluster. Default: 0,0,0

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -619,7 +619,7 @@ ACTIONS (can be repeated, in any order)
     -G, --filter-floaters  [size,op,min]    Remove Gaussians not contributing to any solid voxel
     -D, --filter-cluster   [res,op,min]     Keep only the connected cluster at --seed-pos
     -p, --params           <key=val,...>    Pass parameters to .mjs generator script
-    -l, --lod              <n>              Specify the level of detail, n >= 0
+    -l, --lod              <n>              Tag the Gaussians with LOD level n (n >= 0)
     -m, --summary                           Print per-column statistics to stdout
     -M, --morton-order                      Reorder Gaussians by Morton code (Z-order curve)
 


### PR DESCRIPTION
## Summary

- Group CLI/README options by what they actually apply to (general, SOG compression, HTML viewer, LCC input, LOD output, voxel output) instead of one flat list.
- Trim the CLI `EXAMPLES` block to three core recipes plus a link to the README — the long list was clutter at the terminal.
- Rewrite the README voxel section around the recommended pipeline (`--filter-cluster` → fill → carve → mesh) with separate interior (`--voxel-external-fill`) and exterior (`--voxel-floor-fill`) recipes.
- Add `guides/COLLISION.md` as a deeper reference with image placeholders for the filter/fill/carve/mesh stages.
- Minor: clarify `--lod` action description ("tag the Gaussians with LOD level n").

## Why

Previously every flag was listed in one block, even though many only apply to specific input/output formats (e.g. `--lod-select` is LCC-only, `--lod-chunk-*` only matter for `lod-meta.json` output, voxel/collision flags only apply to `.voxel.json` output). Scoping the help text makes it easier to find relevant flags and clarifies which combinations make sense.

## Notes for reviewer

- No code changes — docs and help-string only.
- `guides/COLLISION.md` references `images/*.png` that don't exist yet; placeholders to be filled in later.
- New doc lives at `guides/` because `docs/` is the typedoc output directory (gitignored, published to api.playcanvas.com).
- Build and lint pass.