### PR TITLE
Fix Windows D3D12 stability and voxel/LOD output correctness

### DIFF
--- a/src/cli/node-device.ts
+++ b/src/cli/node-device.ts
@@ -118,6 +118,15 @@ const createDevice = async (adapterName?: string): Promise<GraphicsDevice> => {
 
     await graphicsDevice.createDevice();
 
+    // Surface Dawn's device-lost reason directly. PlayCanvas logs this only via
+    // Debug.warn (debug builds) and then attempts to recreate the device, which
+    // can fail noisily (e.g. DXGI_ERROR_DEVICE_REMOVED on D3D12 TDR) and bury
+    // the original cause.
+    // @ts-ignore - wgpu is private on WebgpuGraphicsDevice but exposed in practice
+    (graphicsDevice.wgpu as any)?.lost?.then((info: any) => {
+        logger.error(`WebGPU device was lost: reason=${info.reason || 'unknown'}, message=${info.message || '(none)'}`);
+    });
+
     return graphicsDevice;
 };
 

--- a/src/cli/node-device.ts
+++ b/src/cli/node-device.ts
@@ -121,9 +121,11 @@ const createDevice = async (adapterName?: string): Promise<GraphicsDevice> => {
     // Surface Dawn's device-lost reason directly. PlayCanvas logs this only via
     // Debug.warn (debug builds) and then attempts to recreate the device, which
     // can fail noisily (e.g. DXGI_ERROR_DEVICE_REMOVED on D3D12 TDR) and bury
-    // the original cause.
+    // the original cause. Skip the `destroyed` reason — that fires on intentional
+    // device.destroy() during normal shutdown.
     // @ts-ignore - wgpu is private on WebgpuGraphicsDevice but exposed in practice
     (graphicsDevice.wgpu as any)?.lost?.then((info: any) => {
+        if (info?.reason === 'destroyed') return;
         logger.error(`WebGPU device was lost: reason=${info.reason || 'unknown'}, message=${info.message || '(none)'}`);
     });
 

--- a/src/lib/gpu/gpu-dilation.ts
+++ b/src/lib/gpu/gpu-dilation.ts
@@ -756,13 +756,18 @@ class GpuDilation {
         this.dispatchClear(slot, slot.bufferA, numWords);
         this.dispatchExtract(slot, minBx, minBy, minBz, outerBx, outerBy, outerBz, numXWords);
 
-        // Tiny throwaway readback forces a queue submit between extract
-        // and dilate. WITHOUT this, atomicOr writes from the extract pass
-        // aren't reliably visible to the next dilate pass (apparent
-        // missing memory barrier in PlayCanvas/Dawn for cross-pass atomic
-        // writes). Promise is intentionally not awaited — only the
-        // implicit submit+barrier matters. 16 bytes ≈ negligible PCIe.
-        slot.bufferA.read(0, 16, null, true).catch(() => { /* ignore */ });
+        // Force a queue submission boundary between the extract pass (which
+        // writes bufferA via atomicOr — bound as `storage, read_write` with
+        // `array<atomic<u32>>`) and the dilate-X pass (which reads bufferA
+        // bound as `storage, read` with `array<u32>`). Without this, the
+        // atomic writes are not reliably visible to the next pass — dilation
+        // produces empty output. Other inter-pass transitions in this
+        // pipeline (clear→extract, dilateX→Z→Y, Y→compact) rely on automatic
+        // intra-encoder synchronization without issue. Verified raw Dawn
+        // synchronizes this case correctly, so the bug is somewhere in
+        // PlayCanvas's compute dispatch / bind-group path.
+        // TODO(#issue): file upstream and remove once fixed.
+        (this.device as unknown as { submit: () => void }).submit();
 
         // X-pass: A → B
         this.dispatchX(slot, slot.bufferA, slot.bufferB, numXWords, outerNy, outerNz, halfExtentXZ);

--- a/src/lib/gpu/gpu-dilation.ts
+++ b/src/lib/gpu/gpu-dilation.ts
@@ -766,7 +766,6 @@ class GpuDilation {
         // intra-encoder synchronization without issue. Verified raw Dawn
         // synchronizes this case correctly, so the bug is somewhere in
         // PlayCanvas's compute dispatch / bind-group path.
-        // TODO(#issue): file upstream and remove once fixed.
         (this.device as unknown as { submit: () => void }).submit();
 
         // X-pass: A → B

--- a/src/lib/voxel/voxelize.ts
+++ b/src/lib/voxel/voxelize.ts
@@ -48,8 +48,14 @@ const voxelizeToBuffer = async (
     const bStride = numBlocksX * numBlocksY;
     const batchSize = 16;
 
-    const MEGA_MAX_BATCHES = 512;
-    const MEGA_MAX_INDICES = 4 * 1024 * 1024;
+    // Caps for one mega-flush. Sized to keep a single compute dispatch's
+    // wall-clock comfortably under Windows D3D12 TDR (~2s watchdog) on slower
+    // GPUs without materially affecting throughput on fast GPUs (the
+    // double-buffered slots keep the GPU fed across the extra flushes).
+    // Output is bit-identical regardless: each batch's full Gaussian list rides
+    // with it, and slot buffers grow on demand to accommodate any oversize batch.
+    const MEGA_MAX_BATCHES = 256;
+    const MEGA_MAX_INDICES = 2 * 1024 * 1024;
 
     const maxBlocks = GpuVoxelization.MAX_BLOCKS_PER_BATCH;
     const numSlots = GpuVoxelization.NUM_SLOTS;

--- a/src/lib/writers/write-lod.ts
+++ b/src/lib/writers/write-lod.ts
@@ -163,6 +163,9 @@ const writeLod = async (options: WriteLodOptions, fs: FileSystem) => {
     // converts to Transform.PLY). Without this, view-dependent streaming
     // built on tree.bound picks the wrong chunks because the bounds are
     // 180°-Z-rotated relative to the splat positions inside them.
+    // This intentionally mutates the input tables to avoid doubling peak
+    // memory during LOD export. Callers should treat writeLod as consuming its
+    // DataTable inputs.
     const dataTable = convertToSpace(options.dataTable, Transform.PLY, true);
     const envDataTable = options.envDataTable ? convertToSpace(options.envDataTable, Transform.PLY, true) : null;
 

--- a/src/lib/writers/write-lod.ts
+++ b/src/lib/writers/write-lod.ts
@@ -158,8 +158,13 @@ type WriteLodOptions = {
 const writeLod = async (options: WriteLodOptions, fs: FileSystem) => {
     const { filename, iterations, createDevice, chunkCount, chunkExtent } = options;
 
-    const dataTable = convertToSpace(options.dataTable, Transform.IDENTITY, true);
-    const envDataTable = options.envDataTable ? convertToSpace(options.envDataTable, Transform.IDENTITY, true) : null;
+    // Operate in PLY space so per-leaf bounds in tree.bound are in the same
+    // coordinate frame as the SOG chunk data emitted by writeSog (which also
+    // converts to Transform.PLY). Without this, view-dependent streaming
+    // built on tree.bound picks the wrong chunks because the bounds are
+    // 180°-Z-rotated relative to the splat positions inside them.
+    const dataTable = convertToSpace(options.dataTable, Transform.PLY, true);
+    const envDataTable = options.envDataTable ? convertToSpace(options.envDataTable, Transform.PLY, true) : null;
 
     const outputDir = dirname(filename);
 

--- a/src/lib/writers/write-voxel.ts
+++ b/src/lib/writers/write-voxel.ts
@@ -377,15 +377,29 @@ const writeVoxel = async (options: WriteVoxelOptions, fs: FileSystem): Promise<v
         gpuVoxelization.uploadAllGaussians(pcDataTable, extentsResult.extents);
 
         // Align grid bounds to block boundaries BEFORE voxelization so the
-        // block coordinates used during voxelization match what the reader expects.
-        // When fillExterior runs, pad by halfExtent + 1 voxels per side so the
-        // boundary-face flood seeds survive the dilation (notably below the floor).
+        // block coordinates used during voxelization match what the reader
+        // expects. fillExterior and fillFloor both need a margin of empty
+        // voxels outside the splat's tight 3-sigma extents to do their job:
+        // fillExterior so the boundary-face flood seeds survive its dilation
+        // (notably below the floor), fillFloor so its column walk has empty
+        // XZ columns to convert into wall pillars and the dilation halo to
+        // extend the floor footprint outward.
+        //
+        // Lateral pad combines both as `dilation_radius + 1` voxels per side.
+        // Vertical pad is only contributed by exteriorPad — fillFloor's
+        // dilation is XZ-only, and Y padding would extend the wall pillars
+        // above the splat's natural ceiling and below its floor.
         const exteriorPad = hasFillExterior ?
             (Math.ceil(navExteriorRadius! / voxelResolution) + 1) * voxelResolution :
             0;
+        const floorPad = hasFloorFill ?
+            (Math.ceil(floorFillDilation / voxelResolution) + 1) * voxelResolution :
+            0;
+        const padXZ = Math.max(exteriorPad, floorPad);
+        const padY = exteriorPad;
         let gridBounds = alignGridBounds(
-            bounds.min.x - exteriorPad, bounds.min.y - exteriorPad, bounds.min.z - exteriorPad,
-            bounds.max.x + exteriorPad, bounds.max.y + exteriorPad, bounds.max.z + exteriorPad,
+            bounds.min.x - padXZ, bounds.min.y - padY, bounds.min.z - padXZ,
+            bounds.max.x + padXZ, bounds.max.y + padY, bounds.max.z + padXZ,
             voxelResolution
         );
 

--- a/src/lib/writers/write-voxel.ts
+++ b/src/lib/writers/write-voxel.ts
@@ -180,34 +180,46 @@ const cropToNavigable = (
     }
 
     const { minBx, minBy, minBz, maxBx, maxBy, maxBz } = navBounds;
-    const cropMaxBx = maxBx + 1;
-    const cropMaxBy = maxBy + 1;
-    const cropMaxBz = maxBz + 1;
 
-    if (minBx === 0 && minBy === 0 && minBz === 0 &&
+    // Pad by 1 block on each side so the cropped grid retains the solid wall
+    // blocks immediately surrounding the navigable cavity. Matches the
+    // MARGIN = 1 pattern used by carve() before this re-crop strips it. The
+    // collision-mesh extractors treat out-of-grid as empty, so without this
+    // padding the mesh has holes wherever the cavity reaches the cropped
+    // boundary; with it, the mesh extractor sees a real SOLID→EMPTY
+    // transition at the cavity edge and emits a sealed wall there.
+    const MARGIN = 1;
+    const cropMinBx = Math.max(0, minBx - MARGIN);
+    const cropMinBy = Math.max(0, minBy - MARGIN);
+    const cropMinBz = Math.max(0, minBz - MARGIN);
+    const cropMaxBx = Math.min(nbx, maxBx + 1 + MARGIN);
+    const cropMaxBy = Math.min(nby, maxBy + 1 + MARGIN);
+    const cropMaxBz = Math.min(nbz, maxBz + 1 + MARGIN);
+
+    if (cropMinBx === 0 && cropMinBy === 0 && cropMinBz === 0 &&
         cropMaxBx === nbx && cropMaxBy === nby && cropMaxBz === nbz) {
         return { grid, gridBounds };
     }
 
     const cropBar = logger.bar('Cropping grid', grid.types.length);
     const croppedGrid = grid.cropTo(
-        minBx, minBy, minBz, cropMaxBx, cropMaxBy, cropMaxBz,
+        cropMinBx, cropMinBy, cropMinBz, cropMaxBx, cropMaxBy, cropMaxBz,
         done => cropBar.update(done)
     );
     cropBar.end();
 
     const blockSize = 4 * voxelResolution;
     const croppedMin = new Vec3(
-        gridBounds.min.x + minBx * blockSize,
-        gridBounds.min.y + minBy * blockSize,
-        gridBounds.min.z + minBz * blockSize
+        gridBounds.min.x + cropMinBx * blockSize,
+        gridBounds.min.y + cropMinBy * blockSize,
+        gridBounds.min.z + cropMinBz * blockSize
     );
     const croppedBounds: Bounds = {
         min: croppedMin,
         max: new Vec3(
-            croppedMin.x + (cropMaxBx - minBx) * blockSize,
-            croppedMin.y + (cropMaxBy - minBy) * blockSize,
-            croppedMin.z + (cropMaxBz - minBz) * blockSize
+            croppedMin.x + (cropMaxBx - cropMinBx) * blockSize,
+            croppedMin.y + (cropMaxBy - cropMinBy) * blockSize,
+            croppedMin.z + (cropMaxBz - cropMinBz) * blockSize
         )
     };
 


### PR DESCRIPTION
## Summary

Bundles five mostly-independent fixes for Windows D3D12 stability, an inter-pass synchronization bug, a coordinate-frame mismatch in LOD output, and padding correctness around voxel cropping/grid alignment.

### Windows D3D12 stability

- **`voxelize.ts`** — Halve `MEGA_MAX_BATCHES` (512→256) and `MEGA_MAX_INDICES` (4M→2M) so a single compute dispatch's wall-clock stays comfortably under Windows D3D12's ~2s TDR watchdog on slower GPUs. Output is bit-identical; double-buffered slots keep fast GPUs fed across the extra flushes.
- **`gpu-dilation.ts`** — Replace the 16-byte throwaway readback with an explicit `device.submit()` between the extract pass (writes `bufferA` via `atomicOr`, bound `read_write` as `array<atomic<u32>>`) and the dilate-X pass (reads `bufferA` as `array<u32>`). Without the queue boundary the atomic writes are not reliably visible to the next pass and dilation produces empty output. Verified raw Dawn synchronizes this case correctly, so the bug lives in PlayCanvas's compute dispatch / bind-group path. All other inter-pass transitions in this pipeline rely on intra-encoder synchronization without issue.
- **`node-device.ts`** — Surface Dawn's device-lost reason directly. PlayCanvas only `Debug.warn`s this in debug builds and then attempts to recreate the device, which on D3D12 TDR fails noisily and buries the original cause. Filters out `reason === 'destroyed'` to match PlayCanvas's own handler and avoid a misleading message during normal shutdown.

### Output correctness

- **`write-lod.ts`** — **Output-format change.** Convert the working data table to `Transform.PLY` (was `Transform.IDENTITY`) so per-leaf bounds in `tree.bound` end up in the same coordinate frame as the SOG chunk data emitted by `writeSog` (which also converts to PLY). Without this, view-dependent streaming built on `tree.bound` picks the wrong chunks because the bounds are 180°-Z-rotated relative to the splat positions inside them. **Consumers caching previous `lod-meta.json` output will need to rebuild** — XZ extents are now flipped (180° around Z).
- **`write-voxel.ts` — `cropToNavigable`** — Pad the cropped grid by 1 block on each side so it retains the solid wall blocks immediately surrounding the navigable cavity. Matches the `MARGIN = 1` pattern that `carve()` applies before this re-crop strips it. The collision-mesh extractor treats out-of-grid as empty, so without this padding the mesh has holes wherever the cavity reaches the cropped boundary; with it, the extractor sees a real SOLID→EMPTY transition and emits a sealed wall.
- **`write-voxel.ts` — pre-voxelization grid alignment** — Pad the grid for both `fillExterior` and `fillFloor`, not just `fillExterior`. `fillFloor` needs empty XZ columns outside the splat's tight 3-sigma extents to convert into wall pillars, plus dilation halo room to extend the floor footprint. Lateral pad becomes `max(exteriorPad, floorPad)`; vertical pad stays tied to `exteriorPad` only, since `fillFloor`'s dilation is XZ-only and Y padding would extend wall pillars above/below the splat's natural extent.

## Test plan

- [ ] Type-check passes (`npx tsc --noEmit`).
- [ ] Voxelize+collision on a scene that previously had open walls at the cavity edge — confirm GLB is now sealed.
- [ ] LOD write on a known scene — dump first leaf's `tree.bound` and a sample of its splat positions; both should sit in PLY space.
- [ ] Windows TDR repro scene runs end-to-end without device loss; if a drop does occur, confirm the reason is logged at `error` level.
- [ ] macOS/Linux: time a large voxelize before/after to confirm no regression from the halved mega-flush caps.