### PR TITLE
docs: Add Docker backend guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ For library usage, install as a dependency:
 npm install @playcanvas/splat-transform
 ```
 
+For running on a backend with Docker (including GPU/Vulkan setup), see the [Docker Backend Guide](guides/DOCKER.md).
+
 ## CLI Usage
 
 ```bash

--- a/guides/DOCKER.md
+++ b/guides/DOCKER.md
@@ -95,6 +95,15 @@ docker run --rm --gpus all -v "$PWD":/work splat-transform \
     input.ply output.sog
 ```
 
+The image runs as a non-root user (UID 2000), so any files written into a host-mounted directory will be owned by UID 2000 rather than your host user, and the container will fail to write at all if the host directory isn't writable by UID 2000. The portable fix is to pass `--user "$(id -u):$(id -g)"`:
+
+```bash
+docker run --rm --gpus all --user "$(id -u):$(id -g)" \
+    -v "$PWD":/work splat-transform input.ply output.sog
+```
+
+The remaining examples omit `--user` for brevity — add it to any invocation that mounts a host directory.
+
 Any normal `splat-transform` invocation works — see the [README](../README.md) for the full CLI surface. For example:
 
 ```bash
@@ -146,6 +155,8 @@ Run it without `--gpus`:
 docker run --rm -v "$PWD":/work splat-transform input.ply output.ply
 ```
 
+Unlike the GPU image, `node:22-slim` runs as root by default, so without `--user` the files written into a bind-mounted host directory will be owned by root on the host. Pass `--user "$(id -u):$(id -g)"` (as described in [Build and run](#build-and-run)), or add a non-root `USER` line to the Dockerfile if this image is for shared use.
+
 If you keep the GPU image but want to force CPU mode for a single run, pass `-g cpu`:
 
 ```bash
@@ -160,5 +171,6 @@ Note that `-g cpu` is incompatible with the GPU-only features (`--filter-cluster
 - **`vulkaninfo` reports `Could not find a Vulkan ICD`.** The host NVIDIA driver does not expose Vulkan. On AWS, switch from the Tesla driver to the GRID driver (v19.2+) and reinstall, then install `vulkan vulkan-tools libXext` on the host.
 - **`vulkaninfo` segfaults or fails to load `libXext.so.6`.** `libxext6` is missing from the image — make sure the `apt-get install` line in the Dockerfile includes it (and on AWS, that `libXext` is also installed on the host).
 - **`docker: Error response from daemon: could not select device driver "" with capabilities: [[gpu]]`.** The NVIDIA Container Toolkit is not installed or the Docker daemon has not picked up its config. Reinstall the toolkit and restart Docker.
-- **Output files are written as root and cannot be deleted from the host.** The image runs as UID 2000. Either `chown` the output directory to UID 2000 before mounting, or pass `--user "$(id -u):$(id -g)"` to `docker run`.
+- **Outputs in the bind-mounted directory aren't owned by my host user.** The container's default user (UID 2000 in the GPU image, root in the slim image) doesn't match your host UID. Pass `--user "$(id -u):$(id -g)"` to `docker run` to align them, or `chown` the output directory to the container UID before mounting.
+- **`Permission denied` writing to the bind-mounted directory.** The container's default user has no write access to the host directory. Use `--user "$(id -u):$(id -g)"`, or `chown` the host directory so the container user can write.
 - **`splat-transform: command not found` inside the container.** Make sure `npm install -g @playcanvas/splat-transform` ran successfully during the build. The default entrypoint already invokes the binary, so `docker run <image> --help` should work without specifying `splat-transform`.

--- a/guides/DOCKER.md
+++ b/guides/DOCKER.md
@@ -1,0 +1,164 @@
+# Docker Backend Guide
+
+This guide explains how to run `splat-transform` as a containerised backend service on a Linux host with an NVIDIA GPU.
+
+## When you need this
+
+`splat-transform` is a Node.js CLI and the published npm package runs anywhere Node 18+ runs — Docker is not strictly required.
+
+A few features are **GPU-only** and will not run without WebGPU:
+
+- `--filter-cluster` and `--filter-floaters`.
+- `.voxel.json` output and `-K` / `--collision-mesh` (see the [Collision Mesh Guide](COLLISION.md)).
+
+A few are **GPU-accelerated but optional**:
+
+- SOG / `meta.json` / `lod-meta.json` / `.html` viewer output (see [SOG Compression Options](../README.md#sog-compression-options) in the README). The only step inside this writer that uses the GPU is k-means clustering of spherical-harmonic coefficients, so:
+  - Inputs **without** SH bands (e.g. `.splat`, SH-stripped PLYs, or anything piped through `-H 0` / `--filter-harmonics 0`) write SOG fully on the CPU.
+  - Inputs **with** SH bands work on the CPU too via `-g cpu`, but SH clustering is roughly 5-10x slower without a GPU.
+
+All GPU paths go through WebGPU, which on Linux is implemented over Vulkan. That sets the host and container requirements below.
+
+If you don't need the GPU-only features and you're happy paying the CPU cost for SH compression (or your inputs have no SH), skip to the [CPU-only variant](#cpu-only-variant).
+
+## Host prerequisites (outside Docker)
+
+These must be configured on the host machine — they cannot be installed from inside a container, because the container reuses the host's NVIDIA driver and Vulkan ICD.
+
+1. **NVIDIA GPU** with a driver that exposes a Vulkan ICD (most consumer drivers do; some headless cloud drivers do not by default).
+2. **Docker Engine** with the **[NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)** installed and configured. This is what makes `--gpus all` work and what mounts the host's NVIDIA Vulkan loader into the container.
+3. **Vulkan loader and tools on the host** (used by the toolkit when projecting Vulkan into the container).
+
+### AWS GPU instances
+
+On AWS GPU instances (`g4dn`, `g5`, `g6`, etc.) running Amazon Linux 2023, the default driver is the *compute-only* Tesla driver and does not include Vulkan. To use any of the WebGPU paths you need:
+
+- **NVIDIA GRID Driver v19.2 or newer** (this is the variant that ships the Vulkan ICD). Install it on the host following AWS's [NVIDIA driver installation instructions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/install-nvidia-driver.html) and pick the *GRID* driver, not the *Tesla* one.
+- **Vulkan packages on the host OS**:
+
+  ```bash
+  sudo dnf install vulkan vulkan-tools libXext
+  ```
+
+This step is *below* Docker — it lives on the EC2 instance itself. The container in the next section assumes both have already been done.
+
+## Minimal Dockerfile
+
+A minimal single-stage Dockerfile that installs the published CLI on top of an NVIDIA CUDA + Vulkan base image:
+
+```dockerfile
+# syntax=docker/dockerfile:1.4
+FROM nvidia/cuda:12.8.1-devel-ubuntu22.04
+
+# Expose compute + graphics + utility caps so the NVIDIA Container Toolkit
+# mounts the host's Vulkan ICD into the container at runtime.
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,graphics,utility
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl gnupg \
+        vulkan-tools \
+        libgl1 libglvnd0 libglx0 libegl1 libxext6 \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g @playcanvas/splat-transform \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --uid 2000 splat
+USER splat
+WORKDIR /work
+
+ENTRYPOINT ["splat-transform"]
+```
+
+A few notes on what each part is doing:
+
+- `nvidia/cuda:...-devel-ubuntu22.04` — gives you a CUDA-aware base image that the NVIDIA Container Toolkit recognises. The CUDA toolkit itself is not used by `splat-transform`; we just need a base where `--gpus all` projects the host driver and Vulkan loader correctly.
+- `NVIDIA_DRIVER_CAPABILITIES=compute,graphics,utility` — `graphics` is the important one; without it the toolkit will not mount the Vulkan ICD.
+- `vulkan-tools` — provides `vulkaninfo`, useful for debugging.
+- `libgl1`, `libglvnd0`, `libglx0`, `libegl1`, `libxext6` — runtime libraries Vulkan/EGL drivers depend on.
+- `npm install -g @playcanvas/splat-transform` — installs the published CLI on the `PATH`.
+- The non-root `splat` user is a good default for batch workers and means files written into a host-mounted directory aren't owned by root.
+
+## Build and run
+
+Build the image:
+
+```bash
+docker build -t splat-transform .
+```
+
+Run a conversion, mounting the current directory as `/work`:
+
+```bash
+docker run --rm --gpus all -v "$PWD":/work splat-transform \
+    input.ply output.sog
+```
+
+Any normal `splat-transform` invocation works — see the [README](../README.md) for the full CLI surface. For example:
+
+```bash
+# GPU SOG compression
+docker run --rm --gpus all -v "$PWD":/work splat-transform \
+    -i 20 input.ply output.sog
+
+# Voxel + collision mesh
+docker run --rm --gpus all -v "$PWD":/work splat-transform \
+    room.ply --filter-cluster --seed-pos 0,1,0 \
+    --voxel-external-fill --voxel-carve \
+    -K room.voxel.json
+```
+
+## Verifying GPU access
+
+Two quick checks confirm the GPU is visible.
+
+List GPU adapters via the CLI:
+
+```bash
+docker run --rm --gpus all splat-transform --list-gpus
+```
+
+You should see at least one Vulkan adapter named after your GPU (e.g. `NVIDIA L4`, `Tesla T4`).
+
+Sanity-check Vulkan directly:
+
+```bash
+docker run --rm --gpus all --entrypoint vulkaninfo splat-transform --summary
+```
+
+`vulkaninfo` should print a `GPU0` section with an NVIDIA `driverID`. If this fails, the host setup (driver / NVIDIA Container Toolkit / Vulkan ICD) is the problem, not the image.
+
+## CPU-only variant
+
+If you don't need the GPU-only features (`--filter-cluster`, `--filter-floaters`, `.voxel.json`, `-K`) you can skip the GPU setup entirely and use a much smaller base image. SOG / `meta.json` / `lod-meta.json` / `.html` outputs still work in this image — the SH compression step falls back to CPU:
+
+```dockerfile
+FROM node:22-slim
+RUN npm install -g @playcanvas/splat-transform
+WORKDIR /work
+ENTRYPOINT ["splat-transform"]
+```
+
+Run it without `--gpus`:
+
+```bash
+docker run --rm -v "$PWD":/work splat-transform input.ply output.ply
+```
+
+If you keep the GPU image but want to force CPU mode for a single run, pass `-g cpu`:
+
+```bash
+docker run --rm -v "$PWD":/work splat-transform -g cpu input.ply output.sog
+```
+
+Note that `-g cpu` is incompatible with the GPU-only features (`--filter-cluster`, `--filter-floaters`, `.voxel.json`, `-K`). CPU-side SH compression also runs roughly 5-10x slower than GPU.
+
+## Troubleshooting
+
+- **`--list-gpus` reports no adapters.** The Vulkan ICD is not reaching the container. Check that you ran with `--gpus all`, that `NVIDIA_DRIVER_CAPABILITIES` includes `graphics`, and that the NVIDIA Container Toolkit is installed and configured on the host.
+- **`vulkaninfo` reports `Could not find a Vulkan ICD`.** The host NVIDIA driver does not expose Vulkan. On AWS, switch from the Tesla driver to the GRID driver (v19.2+) and reinstall, then install `vulkan vulkan-tools libXext` on the host.
+- **`vulkaninfo` segfaults or fails to load `libXext.so.6`.** `libxext6` is missing from the image — make sure the `apt-get install` line in the Dockerfile includes it (and on AWS, that `libXext` is also installed on the host).
+- **`docker: Error response from daemon: could not select device driver "" with capabilities: [[gpu]]`.** The NVIDIA Container Toolkit is not installed or the Docker daemon has not picked up its config. Reinstall the toolkit and restart Docker.
+- **Output files are written as root and cannot be deleted from the host.** The image runs as UID 2000. Either `chown` the output directory to UID 2000 before mounting, or pass `--user "$(id -u):$(id -g)"` to `docker run`.
+- **`splat-transform: command not found` inside the container.** Make sure `npm install -g @playcanvas/splat-transform` ran successfully during the build. The default entrypoint already invokes the binary, so `docker run <image> --help` should work without specifying `splat-transform`.

--- a/guides/DOCKER.md
+++ b/guides/DOCKER.md
@@ -4,7 +4,7 @@ This guide explains how to run `splat-transform` as a containerised backend serv
 
 ## When you need this
 
-`splat-transform` is a Node.js CLI and the published npm package runs anywhere Node 18+ runs — Docker is not strictly required.
+`splat-transform` is a Node.js CLI and the published npm package runs anywhere Node 22+ runs — Docker is not strictly required.
 
 A few features are **GPU-only** and will not run without WebGPU:
 
@@ -26,43 +26,76 @@ If you don't need the GPU-only features and you're happy paying the CPU cost for
 These must be configured on the host machine — they cannot be installed from inside a container, because the container reuses the host's NVIDIA driver and Vulkan ICD.
 
 1. **NVIDIA GPU** with a driver that exposes a Vulkan ICD (most consumer drivers do; some headless cloud drivers do not by default).
-2. **Docker Engine** with the **[NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)** installed and configured. This is what makes `--gpus all` work and what mounts the host's NVIDIA Vulkan loader into the container.
-3. **Vulkan loader and tools on the host** (used by the toolkit when projecting Vulkan into the container).
+2. **Docker Engine** with the **[NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)** installed and configured. This is what makes `--gpus all` work and what projects the host's NVIDIA driver libraries (including the Vulkan ICD JSON) into the container at runtime.
+3. **(Optional) `vulkan-tools` on the host** — useful for sanity-checking the driver from outside Docker (e.g. `vulkaninfo --summary` on the host before launching containers). The container brings its own Vulkan loader via the `vulkan-tools` apt package installed in the Dockerfile below.
 
 ### AWS GPU instances
 
-On AWS GPU instances (`g4dn`, `g5`, `g6`, etc.) running Amazon Linux 2023, the default driver is the *compute-only* Tesla driver and does not include Vulkan. To use any of the WebGPU paths you need:
+On AWS GPU instances (`g4dn`, `g5`, `g6`, etc.) running Amazon Linux 2023 the default driver is the *compute-only* Tesla driver and does not include Vulkan. To use any of the WebGPU paths you need to install the **NVIDIA GRID Driver v19.2 or newer** on the host — the GRID driver ships the Vulkan ICD that the Tesla driver lacks.
 
-- **NVIDIA GRID Driver v19.2 or newer** (this is the variant that ships the Vulkan ICD). Install it on the host following AWS's [NVIDIA driver installation instructions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/install-nvidia-driver.html) and pick the *GRID* driver, not the *Tesla* one.
-- **Vulkan packages on the host OS**:
+NVIDIA hosts the GRID installer in an S3 bucket, so the EC2 instance role must have the `AmazonS3ReadOnlyAccess` policy attached.
 
-  ```bash
-  sudo dnf install vulkan vulkan-tools libXext
-  ```
+Update and reboot first:
 
-This step is *below* Docker — it lives on the EC2 instance itself. The container in the next section assumes both have already been done.
+```bash
+sudo dnf update -y
+sudo reboot
+```
+
+After the reboot, install the driver and reboot again:
+
+```bash
+sudo aws s3 cp --recursive s3://ec2-linux-nvidia-drivers/grid-19.2/ .   # installs v580.x.x
+sudo chmod +x NVIDIA-Linux-x86_64*.run
+sudo ./NVIDIA-Linux-x86_64*.run
+sudo reboot
+```
+
+Install the Vulkan loader, tools, and `libXext` (which `vulkaninfo` links against):
+
+```bash
+sudo dnf install vulkan vulkan-tools libXext
+```
+
+Verify the driver and Vulkan ICD from the host:
+
+```bash
+nvidia-smi             # driver version, GPU model
+vulkaninfo --summary   # NVIDIA Vulkan ICD with a physical device
+```
+
+This is host/OS level — it cannot be done from inside the container. The Dockerfile in the next section assumes the driver and Vulkan packages are already installed on the host.
 
 ## Minimal Dockerfile
 
-A minimal single-stage Dockerfile that installs the published CLI on top of an NVIDIA CUDA + Vulkan base image:
+A minimal multi-stage Dockerfile that installs the published CLI on top of an NVIDIA CUDA + Vulkan base image:
 
 ```dockerfile
 # syntax=docker/dockerfile:1.4
+
+# Pull Node.js from the official image rather than piping a remote
+# install script to bash.
+FROM node:22-slim AS node
+
 FROM nvidia/cuda:12.8.1-devel-ubuntu22.04
 
 # Expose compute + graphics + utility caps so the NVIDIA Container Toolkit
-# mounts the host's Vulkan ICD into the container at runtime.
+# projects the host's NVIDIA driver libraries and Vulkan ICD into the
+# container at runtime.
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,graphics,utility
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        ca-certificates curl gnupg \
+        ca-certificates \
         vulkan-tools \
         libgl1 libglvnd0 libglx0 libegl1 libxext6 \
-    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
-    && npm install -g @playcanvas/splat-transform \
     && rm -rf /var/lib/apt/lists/*
+
+# Bring in Node.js and npm from the official image.
+COPY --from=node /usr/local/bin/ /usr/local/bin/
+COPY --from=node /usr/local/lib/node_modules/ /usr/local/lib/node_modules/
+
+RUN npm install -g @playcanvas/splat-transform
 
 RUN useradd --create-home --uid 2000 splat
 USER splat
@@ -73,10 +106,11 @@ ENTRYPOINT ["splat-transform"]
 
 A few notes on what each part is doing:
 
-- `nvidia/cuda:...-devel-ubuntu22.04` — gives you a CUDA-aware base image that the NVIDIA Container Toolkit recognises. The CUDA toolkit itself is not used by `splat-transform`; we just need a base where `--gpus all` projects the host driver and Vulkan loader correctly.
+- `nvidia/cuda:...-devel-ubuntu22.04` — gives you a CUDA-aware base image that the NVIDIA Container Toolkit recognises. The CUDA toolkit itself is not used by `splat-transform`; we just need a base where `--gpus all` projects the host's NVIDIA driver and Vulkan ICD correctly.
 - `NVIDIA_DRIVER_CAPABILITIES=compute,graphics,utility` — `graphics` is the important one; without it the toolkit will not mount the Vulkan ICD.
-- `vulkan-tools` — provides `vulkaninfo`, useful for debugging.
+- `vulkan-tools` — provides `vulkaninfo` (useful for debugging) and pulls in the Vulkan loader the container needs.
 - `libgl1`, `libglvnd0`, `libglx0`, `libegl1`, `libxext6` — runtime libraries Vulkan/EGL drivers depend on.
+- `node:22-slim` stage + `COPY --from=node` — provides Node.js and npm without piping a third-party install script to `bash`.
 - `npm install -g @playcanvas/splat-transform` — installs the published CLI on the `PATH`.
 - The non-root `splat` user is a good default for batch workers and means files written into a host-mounted directory aren't owned by root.
 


### PR DESCRIPTION
## Summary

- Adds `guides/DOCKER.md`, a generic guide for running `splat-transform` in a Docker container on a Linux host with an NVIDIA GPU.
- Adds a one-line cross-link from the README `Installation` section so the guide is discoverable.

## What's in the guide

- **When you need this** — splits features into:
  - **GPU-only**: `--filter-cluster`, `--filter-floaters`, `.voxel.json` output, `-K` / `--collision-mesh`.
  - **GPU-accelerated but optional**: SOG / `meta.json` / `lod-meta.json` / `.html` outputs. Only the SH k-means clustering step uses the GPU, so SH-less inputs (or `-H 0` / `--filter-harmonics 0`) write SOG fully on CPU, and SH-bearing inputs still work via `-g cpu` (~5-10x slower).
- **Host prerequisites** — NVIDIA driver with Vulkan ICD, NVIDIA Container Toolkit, plus an AWS-specific note (NVIDIA GRID Driver v19.2+ instead of the Tesla driver, `sudo dnf install vulkan vulkan-tools libXext` on Amazon Linux). Explicitly notes these must be done on the host because the container reuses the host's Vulkan loader.
- **Minimal Dockerfile** — single-stage, ~20 lines, `FROM nvidia/cuda:12.8.1-devel-ubuntu22.04`, sets `NVIDIA_DRIVER_CAPABILITIES=compute,graphics,utility`, installs `vulkan-tools`, the `libgl*`/`libglx*`/`libegl1`/`libxext6` runtime libs, Node 22 from NodeSource, and `npm install -g @playcanvas/splat-transform`. Runs as a non-root user with `ENTRYPOINT ["splat-transform"]`.
- **Build & run** — `docker build`, `docker run --rm --gpus all -v "$PWD":/work splat-transform ...`, plus a voxel + collision-mesh example.
- **Verifying GPU access** — `--list-gpus` from the CLI and `vulkaninfo --summary` via `--entrypoint`.
- **CPU-only variant** — slim `node:22-slim` image. Notes that SOG/`meta.json`/`lod-meta.json`/`.html` still work with the CPU SH fallback; only the four GPU-only features are off-limits. Also documents `-g cpu` for forcing CPU mode in the GPU image.
- **Troubleshooting** — common failure modes: no adapters listed, missing Vulkan ICD, `libXext` segfaults, missing NVIDIA Container Toolkit, root-owned mounted output, and missing entrypoint.

No code changes; documentation only.

## Test plan

- [x] Render `guides/DOCKER.md` on GitHub and confirm formatting / cross-links resolve.
- [x] Confirm the `Installation` link in `README.md` resolves to `guides/DOCKER.md`.
- [x] (Optional) Build the suggested Dockerfile on a GPU host and run `splat-transform --list-gpus` to verify the recipe works end-to-end.
