### PR TITLE
Add SOG v1 (legacy) read support

### DIFF
--- a/src/lib/readers/read-sog-v1.ts
+++ b/src/lib/readers/read-sog-v1.ts
@@ -1,19 +1,34 @@
 import { Column, DataTable } from '../data-table';
-import { basename, dirname, join, type ReadFileSystem, readFile } from '../io/read';
+import { join, type ReadFileSystem } from '../io/read';
 import { logger, Transform, WebPCodec } from '../utils';
-import { readSogV1, type MetaV1 } from './read-sog-v1';
 
-// V2 (current) SOG meta layout - codebook-based quantization for scales /
-// sh0 / shN. Legacy V1 uses a different per-channel mins/maxs scheme and is
-// handled separately in read-sog-v1.ts.
-type MetaV2 = {
-    version: 2;
-    count: number;
-    means: { mins: number[]; maxs: number[]; files: string[] };
-    scales: { codebook: number[]; files: string[] };
+// V1 (legacy) SOG meta layout. Quantization is a per-channel linear lerp
+// between mins/maxs, with no codebook. The engine's SOG parser still loads
+// these (with a deprecation warning), so we mirror its decoding so older
+// published assets keep working through splat-transform.
+//
+// The current (V2) format is handled in read-sog.ts; the public readSog
+// dispatcher there falls back to readSogV1 when it sees a meta without
+// `version: 2`. Keeping V1 isolated here lets both code paths stay free of
+// version branching, and makes deleting V1 support trivial when the legacy
+// data is no longer in circulation.
+type MetaV1 = {
+    means: {
+        shape: [number, number];
+        mins: number[];
+        maxs: number[];
+        files: string[];
+    };
+    scales: { mins: number[]; maxs: number[]; files: string[] };
     quats: { files: string[] };
-    sh0: { codebook: number[]; files: string[] };
-    shN?: { count: number; bands: number; codebook: number[]; files: string[] };
+    sh0: { mins: number[]; maxs: number[]; files: string[] };
+    shN?: {
+        shape?: [number, number];
+        mins: number;
+        maxs: number;
+        quantization?: number;
+        files: string[];
+    };
 };
 
 const decodeMeans = (lo: Uint8Array, hi: Uint8Array, count: number) => {
@@ -58,46 +73,34 @@ const unpackQuat = (px: number, py: number, pz: number, tag: number): [number, n
     return comps as [number, number, number, number];
 };
 
-const sigmoidInv = (y: number) => {
-    const e = Math.min(1 - 1e-6, Math.max(1e-6, y));
-    return Math.log(e / (1 - e));
-};
+// Centroids texture width -> SH band count. The palette packs 64 entries per
+// row, each `shCoeffs` pixels wide, so width = 64 * shCoeffs. V1 has no
+// `bands` field in meta, so we infer from the texture geometry. Mapping
+// mirrors the engine's GSplatSogData.calcBands.
+const v1ShBandsWidths: Record<number, number> = { 192: 1, 512: 2, 960: 3 };
 
 /**
- * Read a SOG file from a ReadFileSystem.
+ * Read a legacy V1 SOG file from a ReadFileSystem.
  *
- * The current (V2) format is decoded inline. Legacy V1 files (no `version`
- * field, per-channel mins/maxs instead of codebooks) are detected here and
- * forwarded to {@link readSogV1} in read-sog-v1.ts.
+ * Called by readSog (in read-sog.ts) after it detects a V1 meta payload.
+ * Receives the already-parsed meta and the directory it was loaded from so
+ * we don't re-fetch the JSON.
  *
- * @param fileSystem - The file system to read from
- * @param filename - Path to meta.json (relative paths resolved from its directory).
- * The basename is used verbatim for the initial meta fetch so
- * any URL querystring/fragment (e.g. presigned `?token=...`)
- * is preserved.
+ * @param fileSystem - The file system to read texture files from
+ * @param baseDir - Directory containing the SOG textures (relative paths in
+ * meta are resolved from here)
+ * @param meta - The parsed V1 meta.json payload
  * @returns DataTable with Gaussian splat data
  * @ignore
  */
-const readSog = async (fileSystem: ReadFileSystem, filename: string): Promise<DataTable> => {
-    const baseDir = dirname(filename);
-    const metaName = basename(filename);
-    const resolve = (name: string) => (baseDir ? join(baseDir, name) : name);
-
-    const metaBytes = await readFile(fileSystem, resolve(metaName));
-    const rawMeta = JSON.parse(new TextDecoder().decode(metaBytes)) as MetaV2 | MetaV1;
-
-    // Dispatch to the legacy reader for any meta without `version: 2`.
-    const isV2 = (m: MetaV2 | MetaV1): m is MetaV2 => (m as MetaV2).version === 2;
-    if (!isV2(rawMeta)) {
-        return readSogV1(fileSystem, baseDir, rawMeta);
-    }
-    const meta = rawMeta;
+const readSogV1 = async (fileSystem: ReadFileSystem, baseDir: string, meta: MetaV1): Promise<DataTable> => {
+    logger.warn('Reading SOG v1 (legacy) data. Please re-export with the latest tools to update to v2.');
 
     const decoder = await WebPCodec.create();
-    const count = meta.count;
+    const count = meta.means.shape[0];
 
     const load = async (name: string): Promise<Uint8Array> => {
-        const src = await fileSystem.createSource(resolve(name));
+        const src = await fileSystem.createSource(baseDir ? join(baseDir, name) : name);
         try {
             return await src.read().readAll();
         } finally {
@@ -122,9 +125,6 @@ const readSog = async (fileSystem: ReadFileSystem, filename: string): Promise<Da
         new Column('rot_3', new Float32Array(count))
     ];
 
-    // One bar across all per-gaussian decode passes. Total = passes * count
-    // (means, quats, scales, sh0, plus an optional shN pass). Each pass ticks
-    // with `count` once it has finished writing into the output columns.
     const numPasses = 4 + (meta.shN ? 1 : 0);
     const bar = logger.bar('decoding', numPasses * count);
     let passesDone = 0;
@@ -156,7 +156,7 @@ const readSog = async (fileSystem: ReadFileSystem, filename: string): Promise<Da
 
     // quats: 4 bytes per splat, last byte is the "largest component" tag
     // (252-255 -> w/x/y/z is largest); other 3 encode the smaller components
-    // scaled by sqrt(2).
+    // scaled by sqrt(2). Identical to V2.
     const quatsWebp = await load(meta.quats.files[0]);
     const { rgba: qr, width: qw, height: qh } = decoder.decodeRGBA(quatsWebp);
     if (qw * qh < count) throw new Error('SOG quats texture too small for count');
@@ -176,52 +176,63 @@ const readSog = async (fileSystem: ReadFileSystem, filename: string): Promise<Da
     }
     tickPass();
 
-    // scales: each byte indexes the shared 256-entry codebook.
+    // scales: per-axis 8-bit linear lerp between mins/maxs (log-space).
     const scalesWebp = await load(meta.scales.files[0]);
     const { rgba: sl, width: sw, height: sh } = decoder.decodeRGBA(scalesWebp);
     if (sw * sh < count) throw new Error('SOG scales texture too small for count');
-    const sCode = new Float32Array(meta.scales.codebook);
+    const sMins = meta.scales.mins;
+    const sMaxs = meta.scales.maxs;
     const s0 = columns[3].data as Float32Array;
     const s1 = columns[4].data as Float32Array;
     const s2 = columns[5].data as Float32Array;
     for (let i = 0; i < count; i++) {
         const o = i * 4;
-        s0[i] = sCode[sl[o]];
-        s1[i] = sCode[sl[o + 1]];
-        s2[i] = sCode[sl[o + 2]];
+        s0[i] = sMins[0] + (sMaxs[0] - sMins[0]) * (sl[o + 0] / 255);
+        s1[i] = sMins[1] + (sMaxs[1] - sMins[1]) * (sl[o + 1] / 255);
+        s2[i] = sMins[2] + (sMaxs[2] - sMins[2]) * (sl[o + 2] / 255);
     }
     tickPass();
 
-    // sh0: 3 color bytes index the shared codebook; opacity byte is a sigmoid
-    // value, decoded back to a logit via sigmoidInv.
+    // sh0: 3 color channels lerped between mins[0..2]/maxs[0..2]; opacity is
+    // a *pre-sigmoid logit* lerped between mins[3]/maxs[3] and written
+    // straight into the opacity column (no sigmoid round-trip needed).
     const sh0Webp = await load(meta.sh0.files[0]);
     const { rgba: c0, width: cw, height: ch } = decoder.decodeRGBA(sh0Webp);
     if (cw * ch < count) throw new Error('SOG sh0 texture too small for count');
-    const cCode = new Float32Array(meta.sh0.codebook);
+    const cMins = meta.sh0.mins;
+    const cMaxs = meta.sh0.maxs;
     const dc0 = columns[6].data as Float32Array;
     const dc1 = columns[7].data as Float32Array;
     const dc2 = columns[8].data as Float32Array;
     const opCol = columns[9].data as Float32Array;
     for (let i = 0; i < count; i++) {
         const o = i * 4;
-        dc0[i] = cCode[c0[o + 0]];
-        dc1[i] = cCode[c0[o + 1]];
-        dc2[i] = cCode[c0[o + 2]];
-        opCol[i] = sigmoidInv(c0[o + 3] / 255);
+        dc0[i] = cMins[0] + (cMaxs[0] - cMins[0]) * (c0[o + 0] / 255);
+        dc1[i] = cMins[1] + (cMaxs[1] - cMins[1]) * (c0[o + 1] / 255);
+        dc2[i] = cMins[2] + (cMaxs[2] - cMins[2]) * (c0[o + 2] / 255);
+        opCol[i] = cMins[3] + (cMaxs[3] - cMins[3]) * (c0[o + 3] / 255);
     }
     tickPass();
 
-    // shN (optional): indirect lookup via labels -> centroids palette, with
-    // each centroid pixel byte indexing the shared codebook.
+    // shN: indirect lookup via labels -> centroids palette, with each centroid
+    // pixel byte lerped between scalar mins/maxs that span all SH coeffs.
     if (meta.shN) {
-        const { bands, count: paletteCount } = meta.shN;
+        const centroidsWebp = await load(meta.shN.files[0]);
+        const labelsWebp = await load(meta.shN.files[1]);
+        const { rgba: centroidsRGBA, width: cW, height: cH } = decoder.decodeRGBA(centroidsWebp);
+        const { rgba: labelsRGBA } = decoder.decodeRGBA(labelsWebp);
+
+        const bands = v1ShBandsWidths[cW] ?? 0;
         const shCoeffs = [0, 3, 8, 15][bands];
+
         if (shCoeffs > 0) {
-            const codebook = new Float32Array(meta.shN.codebook);
-            const centroidsWebp = await load(meta.shN.files[0]);
-            const labelsWebp = await load(meta.shN.files[1]);
-            const { rgba: centroidsRGBA, width: cW, height: cH } = decoder.decodeRGBA(centroidsWebp);
-            const { rgba: labelsRGBA } = decoder.decodeRGBA(labelsWebp);
+            const shMin = meta.shN.mins;
+            const shSpan = meta.shN.maxs - meta.shN.mins;
+            const dequant = (b: number) => shMin + shSpan * (b / 255);
+
+            // Upper-bound palette guard: V1 has no explicit count, so use the
+            // texture geometry (`floor(cW / shCoeffs) * cH` palette slots).
+            const paletteCount = Math.floor(cW / shCoeffs) * cH;
 
             const baseIdx = columns.length;
             for (let i = 0; i < shCoeffs * 3; i++) {
@@ -243,9 +254,9 @@ const readSog = async (fileSystem: ReadFileSystem, filename: string): Promise<Da
                 if (label >= paletteCount) continue; // safety
                 for (let j = 0; j < shCoeffs; j++) {
                     const [lr, lg, lb] = getCentroidPixel(label, j);
-                    (columns[baseIdx + j + shCoeffs * 0].data as Float32Array)[i] = codebook[lr] ?? 0;
-                    (columns[baseIdx + j + shCoeffs * 1].data as Float32Array)[i] = codebook[lg] ?? 0;
-                    (columns[baseIdx + j + shCoeffs * 2].data as Float32Array)[i] = codebook[lb] ?? 0;
+                    (columns[baseIdx + j + shCoeffs * 0].data as Float32Array)[i] = dequant(lr);
+                    (columns[baseIdx + j + shCoeffs * 1].data as Float32Array)[i] = dequant(lg);
+                    (columns[baseIdx + j + shCoeffs * 2].data as Float32Array)[i] = dequant(lb);
                 }
             }
         }
@@ -260,4 +271,4 @@ const readSog = async (fileSystem: ReadFileSystem, filename: string): Promise<Da
     return new DataTable(columns, Transform.PLY);
 };
 
-export { readSog };
+export { readSogV1, type MetaV1 };

--- a/src/lib/readers/read-sog-v1.ts
+++ b/src/lib/readers/read-sog-v1.ts
@@ -94,8 +94,6 @@ const v1ShBandsWidths: Record<number, number> = { 192: 1, 512: 2, 960: 3 };
  * @ignore
  */
 const readSogV1 = async (fileSystem: ReadFileSystem, baseDir: string, meta: MetaV1): Promise<DataTable> => {
-    logger.warn('Reading SOG v1 (legacy) data. Please re-export with the latest tools to update to v2.');
-
     const decoder = await WebPCodec.create();
     const count = meta.means.shape[0];
 
@@ -167,12 +165,13 @@ const readSogV1 = async (fileSystem: ReadFileSystem, baseDir: string, meta: Meta
     for (let i = 0; i < count; i++) {
         const o = i * 4;
         const tag = qr[o + 3];
-        if (tag < 252 || tag > 255) {
-            r0[i] = 0; r1[i] = 0; r2[i] = 0; r3[i] = 1;
+        if (tag < 252 || tag > 255) { // invalid tag, default to identity (rot_0 = w)
+            r0[i] = 1; r1[i] = 0; r2[i] = 0; r3[i] = 0;
             continue;
         }
-        const [x, y, z, wq] = unpackQuat(qr[o], qr[o + 1], qr[o + 2], tag);
-        r0[i] = x; r1[i] = y; r2[i] = z; r3[i] = wq;
+        // unpackQuat returns components in (w, x, y, z) order; rot_0..rot_3 map to (w, x, y, z).
+        const [w, x, y, z] = unpackQuat(qr[o], qr[o + 1], qr[o + 2], tag);
+        r0[i] = w; r1[i] = x; r2[i] = y; r3[i] = z;
     }
     tickPass();
 

--- a/src/lib/readers/read-sog-v1.ts
+++ b/src/lib/readers/read-sog-v1.ts
@@ -219,10 +219,19 @@ const readSogV1 = async (fileSystem: ReadFileSystem, baseDir: string, meta: Meta
         const centroidsWebp = await load(meta.shN.files[0]);
         const labelsWebp = await load(meta.shN.files[1]);
         const { rgba: centroidsRGBA, width: cW, height: cH } = decoder.decodeRGBA(centroidsWebp);
-        const { rgba: labelsRGBA } = decoder.decodeRGBA(labelsWebp);
+        const { rgba: labelsRGBA, width: lW, height: lH } = decoder.decodeRGBA(labelsWebp);
 
+        // Validate label texture size up-front: out-of-bounds typed-array reads
+        // coerce to 0 via the bitwise ops below, which would silently map many
+        // splats to centroid 0 instead of failing.
+        if (lW * lH < count) throw new Error('SOG shN labels texture too small for count');
+
+        // Centroids width determines the band count (palette packs 64 entries
+        // per row, each shCoeffs pixels wide). An unrecognized width means the
+        // shN payload is malformed; throw rather than silently skipping.
         const bands = v1ShBandsWidths[cW] ?? 0;
         const shCoeffs = [0, 3, 8, 15][bands];
+        if (bands === 0) throw new Error(`SOG shN centroids texture has unrecognized width ${cW}, expected one of 192 / 512 / 960`);
 
         if (shCoeffs > 0) {
             const shMin = meta.shN.mins;

--- a/src/lib/readers/read-sog.ts
+++ b/src/lib/readers/read-sog.ts
@@ -167,12 +167,13 @@ const readSog = async (fileSystem: ReadFileSystem, filename: string): Promise<Da
     for (let i = 0; i < count; i++) {
         const o = i * 4;
         const tag = qr[o + 3];
-        if (tag < 252 || tag > 255) {
-            r0[i] = 0; r1[i] = 0; r2[i] = 0; r3[i] = 1;
+        if (tag < 252 || tag > 255) { // invalid tag, default to identity (rot_0 = w)
+            r0[i] = 1; r1[i] = 0; r2[i] = 0; r3[i] = 0;
             continue;
         }
-        const [x, y, z, wq] = unpackQuat(qr[o], qr[o + 1], qr[o + 2], tag);
-        r0[i] = x; r1[i] = y; r2[i] = z; r3[i] = wq;
+        // unpackQuat returns components in (w, x, y, z) order; rot_0..rot_3 map to (w, x, y, z).
+        const [w, x, y, z] = unpackQuat(qr[o], qr[o + 1], qr[o + 2], tag);
+        r0[i] = w; r1[i] = x; r2[i] = y; r3[i] = z;
     }
     tickPass();
 

--- a/src/lib/readers/read-sog.ts
+++ b/src/lib/readers/read-sog.ts
@@ -84,14 +84,22 @@ const readSog = async (fileSystem: ReadFileSystem, filename: string): Promise<Da
     const resolve = (name: string) => (baseDir ? join(baseDir, name) : name);
 
     const metaBytes = await readFile(fileSystem, resolve(metaName));
-    const rawMeta = JSON.parse(new TextDecoder().decode(metaBytes)) as MetaV2 | MetaV1;
+    const rawMeta = JSON.parse(new TextDecoder().decode(metaBytes)) as MetaV2 | (MetaV1 & { version?: number });
 
-    // Dispatch to the legacy reader for any meta without `version: 2`.
-    const isV2 = (m: MetaV2 | MetaV1): m is MetaV2 => (m as MetaV2).version === 2;
-    if (!isV2(rawMeta)) {
-        return readSogV1(fileSystem, baseDir, rawMeta);
+    // Dispatch:
+    //   - V1 (legacy) has no `version` field        -> readSogV1
+    //   - V2 (current) has `version: 2`             -> handled inline below
+    //   - any other (future/unknown) version        -> hard error rather than
+    //     silently mis-routing to V1, which would surface as confusing
+    //     downstream failures (missing `means.shape`, etc.).
+    const version = rawMeta.version;
+    if (version === undefined) {
+        return readSogV1(fileSystem, baseDir, rawMeta as MetaV1);
     }
-    const meta = rawMeta;
+    if (version !== 2) {
+        throw new Error(`Unsupported SOG meta version: ${version}`);
+    }
+    const meta = rawMeta as MetaV2;
 
     const decoder = await WebPCodec.create();
     const count = meta.count;
@@ -222,7 +230,14 @@ const readSog = async (fileSystem: ReadFileSystem, filename: string): Promise<Da
             const centroidsWebp = await load(meta.shN.files[0]);
             const labelsWebp = await load(meta.shN.files[1]);
             const { rgba: centroidsRGBA, width: cW, height: cH } = decoder.decodeRGBA(centroidsWebp);
-            const { rgba: labelsRGBA } = decoder.decodeRGBA(labelsWebp);
+            const { rgba: labelsRGBA, width: lW, height: lH } = decoder.decodeRGBA(labelsWebp);
+
+            // Validate texture geometry up-front: missing guards would let
+            // truncated textures silently produce zeros (out-of-bounds typed-
+            // array reads coerce to 0 via the bitwise ops below) instead of
+            // failing like the means/quats/scales/sh0 passes do.
+            if (lW * lH < count) throw new Error('SOG shN labels texture too small for count');
+            if (cW !== 64 * shCoeffs) throw new Error(`SOG shN centroids texture width ${cW} does not match expected ${64 * shCoeffs} for ${bands}-band palette`);
 
             const baseIdx = columns.length;
             for (let i = 0; i < shCoeffs * 3; i++) {

--- a/test/formats.test.mjs
+++ b/test/formats.test.mjs
@@ -351,7 +351,7 @@ describe('SOG Format (V1 Legacy)', () => {
 
         // Identity quaternion (w largest, mode 0): a=b=c=0 -> bytes 127 with
         // tag 252 (= mode 0). The decoder's unpackQuat call then produces
-        // (0,0,0, ~1).
+        // a quat with w ~= 1 and x/y/z ~= 0 (column convention: rot_0 = w).
         const quatBytes = new Uint8Array(2 * 4);
         for (let i = 0; i < count; i++) {
             quatBytes[i * 4 + 0] = 127;

--- a/test/formats.test.mjs
+++ b/test/formats.test.mjs
@@ -324,6 +324,188 @@ describe('SOG Format (Unbundled)', () => {
     });
 });
 
+describe('SOG Format (V1 Legacy)', () => {
+    // Build a tiny synthetic V1 SOG fixture (2 splats, no SH) by encoding the
+    // textures with the V1 quantization scheme: linear lerp between per-axis
+    // mins/maxs. This mirrors the layout published by older PlayCanvas tools
+    // (e.g. https://d8dooaaq2ugo3.cloudfront.net/4e05290d/v1/meta.json) and
+    // verifies that readSog still decodes it correctly.
+    const buildV1Fixture = async () => {
+        const codec = await WebPCodec.create();
+        const count = 2;
+
+        // Pick simple ground-truth values that survive quantization.
+        const positions = [
+            [0.5, -0.25, 1.0],
+            [-0.5, 0.25, -1.0]
+        ];
+        const scales = [
+            [Math.log(0.1), Math.log(0.2), Math.log(0.05)],
+            [Math.log(0.05), Math.log(0.1), Math.log(0.2)]
+        ];
+        const colors = [
+            [0.2, 0.4, 0.6],
+            [-0.2, -0.4, -0.6]
+        ];
+        const opacities = [1.0, -1.5]; // logit values stored directly in V1
+
+        // Identity quaternion (w largest, mode 0): a=b=c=0 -> bytes 127 with
+        // tag 252 (= mode 0). The decoder's unpackQuat call then produces
+        // (0,0,0, ~1).
+        const quatBytes = new Uint8Array(2 * 4);
+        for (let i = 0; i < count; i++) {
+            quatBytes[i * 4 + 0] = 127;
+            quatBytes[i * 4 + 1] = 127;
+            quatBytes[i * 4 + 2] = 127;
+            quatBytes[i * 4 + 3] = 252;
+        }
+
+        // Means: per-axis mins/maxs span the actual value range; bytes encode
+        // a logTransform'd position (sign(x) * ln(|x|+1)) packed into 16 bits
+        // across two textures.
+        const logT = v => Math.sign(v) * Math.log(Math.abs(v) + 1);
+        const means = {
+            mins: [0, 0, 0].map((_, k) => Math.min(logT(positions[0][k]), logT(positions[1][k]))),
+            maxs: [0, 0, 0].map((_, k) => Math.max(logT(positions[0][k]), logT(positions[1][k])))
+        };
+        const meansLo = new Uint8Array(count * 4);
+        const meansHi = new Uint8Array(count * 4);
+        for (let i = 0; i < count; i++) {
+            for (let k = 0; k < 3; k++) {
+                const lv = logT(positions[i][k]);
+                const span = means.maxs[k] - means.mins[k] || 1;
+                const u16 = Math.round(((lv - means.mins[k]) / span) * 65535);
+                meansLo[i * 4 + k] = u16 & 0xff;
+                meansHi[i * 4 + k] = (u16 >> 8) & 0xff;
+            }
+            meansLo[i * 4 + 3] = 255;
+            meansHi[i * 4 + 3] = 255;
+        }
+
+        // Scales: per-axis mins/maxs, single 8-bit lerp.
+        const scaleMeta = {
+            mins: [0, 0, 0].map((_, k) => Math.min(scales[0][k], scales[1][k])),
+            maxs: [0, 0, 0].map((_, k) => Math.max(scales[0][k], scales[1][k]))
+        };
+        const scaleBytes = new Uint8Array(count * 4);
+        for (let i = 0; i < count; i++) {
+            for (let k = 0; k < 3; k++) {
+                const span = scaleMeta.maxs[k] - scaleMeta.mins[k] || 1;
+                scaleBytes[i * 4 + k] = Math.round(((scales[i][k] - scaleMeta.mins[k]) / span) * 255);
+            }
+            scaleBytes[i * 4 + 3] = 255;
+        }
+
+        // sh0: 4-element mins/maxs (rgb + opacity logit), 8-bit lerp per channel.
+        const sh0Meta = {
+            mins: [
+                Math.min(colors[0][0], colors[1][0]),
+                Math.min(colors[0][1], colors[1][1]),
+                Math.min(colors[0][2], colors[1][2]),
+                Math.min(opacities[0], opacities[1])
+            ],
+            maxs: [
+                Math.max(colors[0][0], colors[1][0]),
+                Math.max(colors[0][1], colors[1][1]),
+                Math.max(colors[0][2], colors[1][2]),
+                Math.max(opacities[0], opacities[1])
+            ]
+        };
+        const sh0Bytes = new Uint8Array(count * 4);
+        for (let i = 0; i < count; i++) {
+            for (let k = 0; k < 3; k++) {
+                const span = sh0Meta.maxs[k] - sh0Meta.mins[k] || 1;
+                sh0Bytes[i * 4 + k] = Math.round(((colors[i][k] - sh0Meta.mins[k]) / span) * 255);
+            }
+            const opSpan = sh0Meta.maxs[3] - sh0Meta.mins[3] || 1;
+            sh0Bytes[i * 4 + 3] = Math.round(((opacities[i] - sh0Meta.mins[3]) / opSpan) * 255);
+        }
+
+        // Encode each texture as a 1-row WebP. Encoder requires a non-zero
+        // height; using width=count, height=1 packs all entries on one row.
+        const meansLoWebp = codec.encodeLosslessRGBA(meansLo, count, 1);
+        const meansHiWebp = codec.encodeLosslessRGBA(meansHi, count, 1);
+        const quatsWebp = codec.encodeLosslessRGBA(quatBytes, count, 1);
+        const scalesWebp = codec.encodeLosslessRGBA(scaleBytes, count, 1);
+        const sh0Webp = codec.encodeLosslessRGBA(sh0Bytes, count, 1);
+
+        const meta = {
+            // No `version` field => V1
+            means: {
+                shape: [count, 3],
+                mins: means.mins,
+                maxs: means.maxs,
+                files: ['means_l.webp', 'means_u.webp']
+            },
+            scales: {
+                shape: [count, 3],
+                mins: scaleMeta.mins,
+                maxs: scaleMeta.maxs,
+                files: ['scales.webp']
+            },
+            quats: {
+                shape: [count, 4],
+                files: ['quats.webp']
+            },
+            sh0: {
+                shape: [count, 1, 4],
+                mins: sh0Meta.mins,
+                maxs: sh0Meta.maxs,
+                files: ['sh0.webp']
+            }
+        };
+
+        const fs = new MemoryReadFileSystem();
+        fs.set('meta.json', new TextEncoder().encode(JSON.stringify(meta)));
+        fs.set('means_l.webp', meansLoWebp);
+        fs.set('means_u.webp', meansHiWebp);
+        fs.set('quats.webp', quatsWebp);
+        fs.set('scales.webp', scalesWebp);
+        fs.set('sh0.webp', sh0Webp);
+
+        return { fs, count, positions, scales, colors, opacities };
+    };
+
+    it('should decode V1 meta.json (no version field, mins/maxs lerp)', async () => {
+        const { fs, count, positions, scales, colors, opacities } = await buildV1Fixture();
+
+        const dataTable = await readSog(fs, 'meta.json');
+
+        assert.strictEqual(dataTable.numRows, count);
+        assert(dataTable.hasColumn('x'));
+        assert(dataTable.hasColumn('opacity'));
+
+        const get = name => dataTable.getColumnByName(name).data;
+        for (let i = 0; i < count; i++) {
+            // Position uses a 16-bit lerp + invLogTransform; tolerance accounts
+            // for that quantization round-trip.
+            assert(Math.abs(get('x')[i] - positions[i][0]) < 1e-3, `x[${i}]`);
+            assert(Math.abs(get('y')[i] - positions[i][1]) < 1e-3, `y[${i}]`);
+            assert(Math.abs(get('z')[i] - positions[i][2]) < 1e-3, `z[${i}]`);
+
+            // Scales / colors / opacity use 8-bit lerp; ~1/255 of the span.
+            for (let k = 0; k < 3; k++) {
+                const sSpan = Math.abs(scales[0][k] - scales[1][k]) + 1e-6;
+                assert(Math.abs(get(`scale_${k}`)[i] - scales[i][k]) < sSpan / 200, `scale_${k}[${i}]`);
+
+                const cSpan = Math.abs(colors[0][k] - colors[1][k]) + 1e-6;
+                assert(Math.abs(get(`f_dc_${k}`)[i] - colors[i][k]) < cSpan / 200, `f_dc_${k}[${i}]`);
+            }
+            const oSpan = Math.abs(opacities[0] - opacities[1]) + 1e-6;
+            assert(Math.abs(get('opacity')[i] - opacities[i]) < oSpan / 200, `opacity[${i}]`);
+
+            // Quat encoded with mode 0 (w is the max component) and byte 127
+            // for x/y/z; byte 127 maps to ~-0.0039 not exactly 0, so the
+            // reconstructed w is ~1 and the smallest components are ~-0.003.
+            // Engine convention: rot_0 = w, rot_1..3 = x,y,z.
+            assert(Math.abs(get('rot_0')[i] - 1) < 5e-3, `rot_0[${i}] = ${get('rot_0')[i]}`);
+            assert(Math.abs(get('rot_1')[i]) < 5e-3, `rot_1[${i}]`);
+            assert(Math.abs(get('rot_2')[i]) < 5e-3, `rot_2[${i}]`);
+            assert(Math.abs(get('rot_3')[i]) < 5e-3, `rot_3[${i}]`);
+        }
+    });
+});
+
 describe('SPLAT Format (Input Only)', () => {
     it('should read .splat file', async () => {
         const splatData = await fsReadFile(join(fixturesDir, 'minimal.splat'));


### PR DESCRIPTION
splat-transform's SOG reader only handled the current v2 format (codebook-based quantization). v1 SOG files - still produced by older PlayCanvas tools and still loaded by the engine - parsed as zero-row tables and failed with `Unsupported data in file`.

For example, `splat-transform https://d8dooaaq2ugo3.cloudfront.net/4e05290d/v1/meta.json out.ply` previously errored after the WebP decode pass; it now decodes cleanly into a 60.5K-gaussian PLY (3 SH bands).

### Why a literal "rewrite v1 meta as v2" approach doesn't work

The two formats interpret texture bytes differently. v2's `byte → float` mapping is a single shared 256-entry codebook lookup (one codebook per category, used for all axes/channels). v1's mapping is a per-axis linear lerp between `mins[k]` and `maxs[k]`. Pretending a v1 file is v2 would require re-quantizing the WebP textures themselves (decode v1 → recover floats → re-cluster against a synthesized codebook → re-encode WebP), which is both lossy and far more work than a direct v1 decode.

### Implementation

- `src/lib/readers/read-sog.ts` (existing): pure v2 decoder. The dispatcher at the top routes `meta.version === 2` to inline v2 decode, no `version` field to the legacy reader, and any other value to a hard `Unsupported SOG meta version` error so future formats can't silently mis-route.
- `src/lib/readers/read-sog-v1.ts` (new): self-contained v1 decoder. Direct `min + (max - min) * (byte / 255)` lerp inline - no version branching, no codebook abstraction, no LUT layer. Mirrors the engine's `GSplatSogData` v1 decode logic, including:
  - count from `meta.means.shape[0]` (no top-level `count`)
  - per-axis lerp for scales and sh0 colors
  - opacity stored as a pre-sigmoid logit lerped between `sh0.mins[3]`/`maxs[3]`, written directly to the opacity column
  - shN band count inferred from the centroids texture width (192/512/960 → 1/2/3 bands), since v1 lacks an explicit `bands` field
  - shN palette upper bound derived from texture geometry, since v1 lacks a `count` field

This mirrors the existing pattern of `decompress-ply.ts` as a sibling helper to `read-ply.ts` for variant decode paths. ~100 lines of small pure helpers (`decodeMeans`, `unpackQuat`, `invLogTransform`, the file `load` helper, column setup, means/quats decode loops) are duplicated across the two files. The trade is intentional: each file reads top-to-bottom with no version awareness, and v1 can be deleted in one operation when the legacy data is gone (delete the file + the dispatch branch + one import).

### Tests

Added `SOG Format (V1 Legacy)` test that builds a synthetic 2-splat v1 fixture from scratch using `WebPCodec.encodeLosslessRGBA` and verifies positions, scales, colors, opacity, and rotations decode within tight tolerance. All 480 existing tests continue to pass.