### PR TITLE
Fix filter-sphere CLI number parsing

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -480,7 +480,7 @@ const parseArguments = async () => {
                     if (parts.length !== 4) {
                         throw new Error(`Invalid filter-sphere value: ${t.value}`);
                     }
-                    const values = parts.map(parseNumber);
+                    const values = parts.map((p: string) => parseNumber(p));
                     current.processActions.push({
                         kind: 'filterSphere',
                         center: new Vec3(values[0], values[1], values[2]),

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -10,9 +10,11 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = dirname(__dirname);
+const cliArgsEnvName = 'SPLAT_TRANSFORM_CLI_TEST_ARGS';
 
 const cliBootstrap = `
-process.argv = ['node', 'src/cli/index.ts', ...process.argv.slice(1)];
+const cliArgs = JSON.parse(process.env.${cliArgsEnvName});
+process.argv = ['node', 'src/cli/index.ts', ...cliArgs];
 const { main } = await import('./src/cli/index.ts');
 await main();
 `;
@@ -20,17 +22,17 @@ await main();
 const runCli = (args) => {
     return new Promise((resolve, reject) => {
         const child = spawn(process.execPath, [
+            '--input-type=module',
             '--import',
             'tsx',
             '-e',
-            cliBootstrap,
-            '--',
-            ...args
+            cliBootstrap
         ], {
             cwd: rootDir,
             env: {
                 ...process.env,
-                NO_COLOR: '1'
+                NO_COLOR: '1',
+                [cliArgsEnvName]: JSON.stringify(args)
             },
             stdio: ['ignore', 'pipe', 'pipe']
         });

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -1,0 +1,81 @@
+/**
+ * CLI parsing regression tests.
+ */
+
+import { spawn } from 'node:child_process';
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = dirname(__dirname);
+
+const cliBootstrap = `
+process.argv = ['node', 'src/cli/index.ts', ...process.argv.slice(1)];
+const { main } = await import('./src/cli/index.ts');
+await main();
+`;
+
+const runCli = (args) => {
+    return new Promise((resolve, reject) => {
+        const child = spawn(process.execPath, [
+            '--import',
+            'tsx',
+            '-e',
+            cliBootstrap,
+            '--',
+            ...args
+        ], {
+            cwd: rootDir,
+            env: {
+                ...process.env,
+                NO_COLOR: '1'
+            },
+            stdio: ['ignore', 'pipe', 'pipe']
+        });
+
+        let stdout = '';
+        let stderr = '';
+        child.stdout.setEncoding('utf8');
+        child.stderr.setEncoding('utf8');
+        child.stdout.on('data', chunk => {
+            stdout += chunk;
+        });
+        child.stderr.on('data', chunk => {
+            stderr += chunk;
+        });
+        child.on('error', reject);
+        child.on('close', code => {
+            resolve({ code, stdout, stderr });
+        });
+    });
+};
+
+describe('CLI parsing', () => {
+    it('allows filter-sphere coordinates below their array indexes', async () => {
+        const result = await runCli([
+            '--gpu',
+            'cpu',
+            'test/fixtures/splat/minimal.splat',
+            '--filter-sphere',
+            '0,1.6,0,15',
+            'null'
+        ]);
+
+        assert.strictEqual(result.code, 0, `CLI failed:\n${result.stderr}\n${result.stdout}`);
+    });
+
+    it('allows negative filter-sphere center coordinates', async () => {
+        const result = await runCli([
+            '--gpu',
+            'cpu',
+            'test/fixtures/splat/minimal.splat',
+            '--filter-sphere',
+            '-1,0,-2,10',
+            'null'
+        ]);
+
+        assert.strictEqual(result.code, 0, `CLI failed:\n${result.stderr}\n${result.stdout}`);
+    });
+});


### PR DESCRIPTION
Fixes #236.

## Summary
- Fix `--filter-sphere` CLI parsing so `Array.map` does not pass the element index as `parseNumber`'s optional minimum.
- Add CLI regression tests for coordinates below their array indexes and negative sphere centers.

## Testing
- `node --import tsx --test test\cli.test.mjs`
- `npm.cmd run lint`
- `npm.cmd test`
