### PR TITLE
Add a guide for generating streamed SOG data

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ npm install @playcanvas/splat-transform
 
 For running on a backend with Docker (including GPU/Vulkan setup), see the [Docker Backend Guide](guides/DOCKER.md).
 
+## Guides
+
+- [Streamed SOG Guide](guides/STREAMED_SOG.md) — build a multi-LOD streamed SOG from a single PLY.
+- [Collision Mesh Guide](guides/COLLISION.md) — generate voxel/collision data from a splat scene.
+- [Docker Backend Guide](guides/DOCKER.md) — run splat-transform on a backend (incl. GPU/Vulkan setup).
+
 ## CLI Usage
 
 ```bash
@@ -66,7 +72,7 @@ splat-transform [GLOBAL] input [ACTIONS]  ...  output [ACTIONS]
 | `.csv` | ❌ | ✅ | Comma-separated values spreadsheet |
 | `.html` | ❌ | ✅ | HTML viewer app (single-page or unbundled) based on SOG |
 | `.voxel.json` | ❌ | ✅ | Sparse voxel octree for collision detection |
-| `lod-meta.json` | ❌ | ✅ | Multi-level-of-detail SOG bundle (accompanied by per-LOD `.sog` chunks) |
+| `lod-meta.json` | ❌ | ✅ | Streamed LOD data stored in SOG chunks |
 | `.webp` | ❌ | ✅ | Lossless WebP image rendered from a camera view via GPU rasterizer |
 | `null` | ❌ | ✅ | Discard output (useful with `--summary` for analysis-only runs) |
 
@@ -171,6 +177,8 @@ Apply when writing `lod-meta.json` (multi-LOD streaming SOG bundle).
 -C, --lod-chunk-count  <n>              Approximate number of Gaussians per LOD chunk in K. Default: 512
 -X, --lod-chunk-extent <n>              Approximate size of an LOD chunk in world units (m). Default: 16
 ```
+
+See the [Generating Streamed SOG Data](guides/STREAMED_SOG.md) guide for an end-to-end walkthrough.
 
 ## Voxel Output Options
 

--- a/guides/COLLISION.md
+++ b/guides/COLLISION.md
@@ -1,4 +1,4 @@
-# Gaussian Splatting Collision Generation Guide
+# Generating Collision Data from Gaussian Splats
 
 This guide explains how to generate collision data from a Gaussian splat scene using `splat-transform`. It covers both **voxel generation** (a sparse voxel octree, `.voxel.json` + `.voxel.bin`) and **mesh generation** (`.collision.glb`) suitable for runtime collision detection.
 

--- a/guides/STREAMED_SOG.md
+++ b/guides/STREAMED_SOG.md
@@ -1,0 +1,65 @@
+# Generating Streamed SOG Format
+
+This guide explains how to turn a single PLY scene into the PlayCanvas **streamed SOG** format.
+
+Streamed SOG splits the scene into SOG chunks at several levels of detail. The viewer can then stream in only the chunks and detail levels it needs for the current camera. This lets large scenes (tens of millions of Gaussians) load progressively and stay interactive.
+
+## Overview
+
+The pipeline has two stages:
+1. Generate multiple versions of the scene at increasingly lower LOD
+2. Combine the files into streamed SOG format
+
+## Prerequisites
+
+- `splat-transform` installed — see [Installation](../README.md#installation).
+- A single full-resolution `.ply` scene.
+
+## Step 1: Generate the LOD chain
+
+Treat your full-resolution scene as **LOD 0**. Each subsequent level is produced by decimating the previous one to 50% — `--decimate 50%` keeps half the Gaussians:
+
+```bash
+splat-transform lod0.ply --decimate 50% lod1.ply
+splat-transform lod1.ply --decimate 50% lod2.ply
+splat-transform lod2.ply --decimate 50% lod3.ply
+# …repeat for as many levels as you need
+```
+Keep halving until the coarsest level has around 1M Gaussians, which represents the lowest renderable LOD.
+
+## Step 2: Combine into streamed SOG
+
+Pass every level as an input, tagging each with `--lod <n>`, and write to a path ending in `lod-meta.json`. The `--lod` option applies to the **preceding** input file:
+
+```bash
+splat-transform \
+    lod0.ply --lod 0 \
+    lod1.ply --lod 1 \
+    lod2.ply --lod 2 \
+    lod3.ply --lod 3 \
+    ./scene/lod-meta.json
+```
+
+This generates the `./scene/` folder of streamed SOG:
+
+```
+scene/
+├── lod-meta.json        # spatial tree + per-chunk LOD index
+├── 0_0/                 # LOD 0, chunk 0 — unbundled SOG (meta.json + .webp textures)
+│   ├── meta.json
+│   └── *.webp
+├── 0_1/                 # LOD 0, chunk 1
+├── 1_0/                 # LOD 1, chunk 0
+└── …                    # one folder per {lod}_{chunk}
+```
+
+### Tuning the chunking
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `-C, --lod-chunk-count <n>` | `512` | Approximate Gaussians per chunk, in thousands (K). |
+| `-X, --lod-chunk-extent <n>` | `16` | Approximate chunk size in world units (m). |
+
+Smaller chunks mean finer-grained streaming (more, smaller files); larger chunks mean fewer requests but coarser granularity.
+
+The `scene/` folder is now ready to serve to a viewer that supports streamed SOG format.


### PR DESCRIPTION
Adds a walkthrough for producing streamed SOG (multi-LOD, spatially chunked) from a single PLY, and surfaces it from the README.
- New `guides/STREAMED_SOG.md`: generate an LOD chain by repeatedly decimating with `--decimate 50%`, then combine the levels into streamed SOG with `--lod`, writing `lod-meta.json` plus per-chunk SOG folders. Covers chunk tuning (`-C`/`-X`) and troubleshooting.
- README: add a `## Guides` index listing all three guides (Streamed SOG, Collision, Docker), link the new guide from the LOD Output Options section, and reword the `lod-meta.json` formats-table row to "Streamed LOD data stored in SOG chunks".
- Docs only, no code changes. Commands verified end-to-end on a generated test scene.