### PR TITLE
Fix GPU decimation on large scenes and stop swallowing GPU failures

### DIFF
--- a/src/cli/node-device.ts
+++ b/src/cli/node-device.ts
@@ -118,15 +118,41 @@ const createDevice = async (adapterName?: string): Promise<GraphicsDevice> => {
 
     await graphicsDevice.createDevice();
 
-    // Surface Dawn's device-lost reason directly. PlayCanvas logs this only via
-    // Debug.warn (debug builds) and then attempts to recreate the device, which
-    // can fail noisily (e.g. DXGI_ERROR_DEVICE_REMOVED on D3D12 TDR) and bury
-    // the original cause. Skip the `destroyed` reason — that fires on intentional
-    // device.destroy() during normal shutdown.
+    // Centralized GPU error handling. WebGPU never throws OOM/validation errors
+    // into JS — they arrive asynchronously via `uncapturederror` (when no error
+    // scope is active) or as device-lost, and PlayCanvas only Debug.warns then
+    // tries to recreate the device, burying the cause. Left unsurfaced, an OOM
+    // (e.g. a large scene on a smaller GPU) leaves buffers invalid/zeroed and
+    // consumers silently produce degenerate output — which is how a streamed-SOG
+    // LOD chain ended up with several identical full-resolution levels. Handling
+    // it here once means every GPU consumer (decimate, filters, voxelization, …)
+    // fails loudly without wrapping each call site in its own error scope.
     // @ts-ignore - wgpu is private on WebgpuGraphicsDevice but exposed in practice
-    (graphicsDevice.wgpu as any)?.lost?.then((info: any) => {
+    const wgpu = (graphicsDevice as any).wgpu;
+
+    // A corrupted GPU result must never be written out, so we escalate to a hard
+    // failure: re-raise on the next tick so main()'s uncaughtException handler
+    // turns it into a non-zero exit. logger.error first so the precise cause is
+    // recorded even if the rethrow races process teardown.
+    const escalateGpuError = (summary: string) => {
+        logger.error(`WebGPU ${summary} — aborting (a corrupted GPU result must not be written)`);
+        const err = new Error(`WebGPU ${summary}`);
+        setImmediate(() => {
+            throw err;
+        });
+    };
+
+    wgpu?.addEventListener?.('uncapturederror', (ev: any) => {
+        const e = ev?.error;
+        const kind = e?.constructor?.name === 'GPUOutOfMemoryError' ? 'out-of-memory' : 'error';
+        escalateGpuError(`${kind}: ${e?.message || '(no message)'}`);
+    });
+
+    // Skip the `destroyed` reason — that fires on intentional device.destroy()
+    // during normal shutdown.
+    wgpu?.lost?.then((info: any) => {
         if (info?.reason === 'destroyed') return;
-        logger.error(`WebGPU device was lost: reason=${info.reason || 'unknown'}, message=${info.message || '(none)'}`);
+        escalateGpuError(`device lost: reason=${info?.reason || 'unknown'}, message=${info?.message || '(none)'}`);
     });
 
     return graphicsDevice;

--- a/src/lib/data-table/decimate.ts
+++ b/src/lib/data-table/decimate.ts
@@ -1,5 +1,5 @@
 import { Column, DataTable } from './data-table';
-import { type EdgeCostCache, GpuEdgeCost } from '../gpu/gpu-edge-cost';
+import { APP_CHUNK, type EdgeCostCache, GpuEdgeCost } from '../gpu/gpu-edge-cost';
 import { GpuKnn } from '../gpu/gpu-knn';
 import { KdTree } from '../spatial/kd-tree';
 import {
@@ -881,7 +881,6 @@ const simplifyGaussians = async (
                 const costSub = logger.group('Computing edge costs (GPU)');
 
                 const C = appData.length;
-                const APP_CHUNK = 16;
                 const numChunks = Math.ceil(C / APP_CHUNK);
 
                 const posScalars = new Float32Array(n * 8);
@@ -897,10 +896,11 @@ const simplifyGaussians = async (
                     posScalars[o + 7] = cache.v[s * 3 + 2];
                 }
 
-                // Pack appearance into chunks of ≤16 columns. Each chunk's
-                // stride is its live width (only the final chunk may be < 16),
-                // so no padding is stored or uploaded. The width formula must
-                // match the strides baked into the kernel in GpuEdgeCost.
+                // Pack appearance into chunks of ≤APP_CHUNK columns. Each
+                // chunk's stride is its live width (only the final chunk may be
+                // partial), so no padding is stored or uploaded. APP_CHUNK is
+                // the same constant the kernel bakes its strides from, so the
+                // host packing and the kernel layout stay in lockstep.
                 const appChunks: Float32Array[] = [];
                 for (let ch = 0; ch < numChunks; ch++) {
                     const kStart = ch * APP_CHUNK;

--- a/src/lib/data-table/decimate.ts
+++ b/src/lib/data-table/decimate.ts
@@ -861,39 +861,52 @@ const simplifyGaussians = async (
             let costs = new Float32Array(edgeCount);
 
             if (device) {
-            // GPU path: pack per-splat cache into the layout the kernel
-            // expects (interleaved positions, interleaved scalars). The
-            // cache is already Float32, so `R` passes through directly.
+            // GPU path: pack the per-splat cache into the layout the kernel
+            // expects — position + scalars interleaved 8-wide in one buffer,
+            // appearance split into 16-column chunks (each chunk stays under
+            // the ~2 GB per-binding limit). `R` is already Float32, so the
+            // rotation passes through directly.
                 const costSub = logger.group('Computing edge costs (GPU)');
 
                 const C = appData.length;
-                const positionsPacked = new Float32Array(n * 3);
-                const splatScalars = new Float32Array(n * 5);
-                const appearance = new Float32Array(n * C);
+                const APP_CHUNK = 16;
+                const numChunks = Math.ceil(C / APP_CHUNK);
 
+                const posScalars = new Float32Array(n * 8);
                 for (let s = 0; s < n; s++) {
-                    positionsPacked[s * 3 + 0] = cx[s] as number;
-                    positionsPacked[s * 3 + 1] = cy[s] as number;
-                    positionsPacked[s * 3 + 2] = cz[s] as number;
-
-                    splatScalars[s * 5 + 0] = cache.mass[s];
-                    splatScalars[s * 5 + 1] = cache.logdet[s];
-                    splatScalars[s * 5 + 2] = cache.v[s * 3 + 0];
-                    splatScalars[s * 5 + 3] = cache.v[s * 3 + 1];
-                    splatScalars[s * 5 + 4] = cache.v[s * 3 + 2];
+                    const o = s * 8;
+                    posScalars[o + 0] = cx[s] as number;
+                    posScalars[o + 1] = cy[s] as number;
+                    posScalars[o + 2] = cz[s] as number;
+                    posScalars[o + 3] = cache.mass[s];
+                    posScalars[o + 4] = cache.logdet[s];
+                    posScalars[o + 5] = cache.v[s * 3 + 0];
+                    posScalars[o + 6] = cache.v[s * 3 + 1];
+                    posScalars[o + 7] = cache.v[s * 3 + 2];
                 }
-                // Pack appearance row-major.
-                for (let s = 0; s < n; s++) {
-                    const base = s * C;
-                    for (let k = 0; k < C; k++) {
-                        appearance[base + k] = appData[k][s] as number;
+
+                // Pack appearance into chunks of ≤16 columns. Each chunk's
+                // stride is its live width (only the final chunk may be < 16),
+                // so no padding is stored or uploaded. The width formula must
+                // match the strides baked into the kernel in GpuEdgeCost.
+                const appChunks: Float32Array[] = [];
+                for (let ch = 0; ch < numChunks; ch++) {
+                    const kStart = ch * APP_CHUNK;
+                    const width = Math.min(APP_CHUNK, C - kStart);
+                    const chunk = new Float32Array(n * width);
+                    for (let s = 0; s < n; s++) {
+                        const dst = s * width;
+                        for (let kk = 0; kk < width; kk++) {
+                            chunk[dst + kk] = appData[kStart + kk][s] as number;
+                        }
                     }
+                    appChunks.push(chunk);
                 }
+
                 const cacheGpu: EdgeCostCache = {
-                    positions: positionsPacked,
+                    posScalars,
                     rotR: cache.R,
-                    splatScalars,
-                    appearance,
+                    appChunks,
                     numAppCols: C,
                     numSplats: n
                 };

--- a/src/lib/data-table/decimate.ts
+++ b/src/lib/data-table/decimate.ts
@@ -847,9 +847,20 @@ const simplifyGaussians = async (
             // the comment at the declaration.
             allKnn = new Uint32Array(0);
 
+            // The loop only runs while n > targetCount, and a non-degenerate
+            // k-NN graph over n >= 2 splats always yields edges (splat 0's
+            // neighbours have higher indices). Zero edges here therefore means
+            // the GPU step failed (e.g. a swallowed out-of-memory left the k-NN
+            // buffer zeroed) — never a legitimate "can't decimate further". Fail
+            // rather than return an incompletely-decimated scene, regardless of
+            // how many earlier iterations succeeded.
             if (edgeCount === 0) {
                 g.end();
-                break;
+                throw new Error(
+                    `decimation produced no edges from the k-NN graph at ${n} splats (target ${targetCount}) — ` +
+                    'the GPU step likely failed (e.g. out-of-memory). ' +
+                    'Refusing to return an incompletely-decimated scene.'
+                );
             }
 
             const appData: any[] = [];
@@ -982,9 +993,18 @@ const simplifyGaussians = async (
             costs = new Float32Array(0);
             sorted = new Uint32Array(0);
 
+            // pairs.length === 0 only happens when every edge cost is non-finite
+            // (any finite cost yields at least one pair), i.e. a total
+            // cost-computation failure — GPU corruption / NaN. As above, the loop
+            // guarantees n > targetCount, so this is always a failure to reach
+            // the target, not a legitimate stop. Fatal regardless of prior progress.
             if (pairs.length === 0) {
                 g.end();
-                break;
+                throw new Error(
+                    `decimation found no valid merge pairs among ${edgeCount} edges at ${n} splats (target ${targetCount}) — ` +
+                    'the GPU step likely failed (e.g. out-of-memory) or produced non-finite costs. ' +
+                    'Refusing to return an incompletely-decimated scene.'
+                );
             }
 
             // Allocate output table

--- a/src/lib/data-table/decimate.ts
+++ b/src/lib/data-table/decimate.ts
@@ -873,11 +873,11 @@ const simplifyGaussians = async (
             let costs = new Float32Array(edgeCount);
 
             if (device) {
-            // GPU path: pack the per-splat cache into the layout the kernel
-            // expects — position + scalars interleaved 8-wide in one buffer,
-            // appearance split into 16-column chunks (each chunk stays under
-            // the ~2 GB per-binding limit). `R` is already Float32, so the
-            // rotation passes through directly.
+                // GPU path: pack the per-splat cache into the layout the kernel
+                // expects — position + scalars interleaved 8-wide in one buffer,
+                // appearance split into 16-column chunks (each chunk stays under
+                // the ~2 GB per-binding limit). `R` is already Float32, so the
+                // rotation passes through directly.
                 const costSub = logger.group('Computing edge costs (GPU)');
 
                 const C = appData.length;

--- a/src/lib/data-table/decimate.ts
+++ b/src/lib/data-table/decimate.ts
@@ -696,10 +696,11 @@ const simplifyGaussians = async (
     // the per-iteration version has a transient destroy/create overlap where
     // GpuKnn buffers haven't been reclaimed by the WebGPU backend before
     // GpuEdgeCost allocates fresh ones. Hoisting reuses the same backing
-    // storage across iterations. Edge buffer is sized to the true upper
-    // bound n·k (not n·k/2 — that's only the expected count; per-iteration
-    // variance lets the actual edgeCount exceed n·k/2 by a few percent, and
-    // GPU buffers are fixed-size so we'd OOM mid-decimate if we under-size).
+    // storage across iterations. `initialMaxE` is the true upper bound on edge
+    // count, n·k (not n·k/2 — that's only the expected count; per-iteration
+    // variance lets the actual edgeCount exceed n·k/2 by a few percent). It's a
+    // validation bound, not a buffer size: GpuEdgeCost uploads edges per
+    // dispatch batch, so its edge buffers are batch-sized regardless.
     const initialN = current.numRows;
     const kEffMax = Math.min(Math.max(1, KNN_K), Math.max(1, initialN - 1));
     const initialMaxE = initialN * kEffMax;

--- a/src/lib/data-table/decimate.ts
+++ b/src/lib/data-table/decimate.ts
@@ -850,16 +850,19 @@ const simplifyGaussians = async (
             // The loop only runs while n > targetCount, and a non-degenerate
             // k-NN graph over n >= 2 splats always yields edges (splat 0's
             // neighbours have higher indices). Zero edges here therefore means
-            // the GPU step failed (e.g. a swallowed out-of-memory left the k-NN
-            // buffer zeroed) — never a legitimate "can't decimate further". Fail
-            // rather than return an incompletely-decimated scene, regardless of
-            // how many earlier iterations succeeded.
+            // the neighbour step produced nothing usable — on the GPU path a
+            // swallowed out-of-memory leaving the k-NN buffer zeroed, on the CPU
+            // path a degenerate input — never a legitimate "can't decimate
+            // further". Fail rather than return an incompletely-decimated scene,
+            // regardless of how many earlier iterations succeeded.
             if (edgeCount === 0) {
                 g.end();
+                const cause = device ?
+                    'the GPU step likely failed (e.g. out-of-memory)' :
+                    'the input is likely degenerate (e.g. non-finite positions)';
                 throw new Error(
                     `decimation produced no edges from the k-NN graph at ${n} splats (target ${targetCount}) — ` +
-                    'the GPU step likely failed (e.g. out-of-memory). ' +
-                    'Refusing to return an incompletely-decimated scene.'
+                    `${cause}. Refusing to return an incompletely-decimated scene.`
                 );
             }
 
@@ -995,15 +998,18 @@ const simplifyGaussians = async (
 
             // pairs.length === 0 only happens when every edge cost is non-finite
             // (any finite cost yields at least one pair), i.e. a total
-            // cost-computation failure — GPU corruption / NaN. As above, the loop
-            // guarantees n > targetCount, so this is always a failure to reach
-            // the target, not a legitimate stop. Fatal regardless of prior progress.
+            // cost-computation failure — GPU corruption on the GPU path, or
+            // non-finite inputs on either path. As above, the loop guarantees
+            // n > targetCount, so this is always a failure to reach the target,
+            // not a legitimate stop. Fatal regardless of prior progress.
             if (pairs.length === 0) {
                 g.end();
+                const cause = device ?
+                    'the GPU step likely failed (e.g. out-of-memory) or produced non-finite costs' :
+                    'cost computation produced only non-finite values (e.g. non-finite inputs)';
                 throw new Error(
                     `decimation found no valid merge pairs among ${edgeCount} edges at ${n} splats (target ${targetCount}) — ` +
-                    'the GPU step likely failed (e.g. out-of-memory) or produced non-finite costs. ' +
-                    'Refusing to return an incompletely-decimated scene.'
+                    `${cause}. Refusing to return an incompletely-decimated scene.`
                 );
             }
 

--- a/src/lib/gpu/gpu-edge-cost.ts
+++ b/src/lib/gpu/gpu-edge-cost.ts
@@ -320,6 +320,11 @@ class GpuEdgeCost {
         const appStrides = [0, 1, 2].map((ch) => {
             return Math.min(APP_CHUNK, Math.max(0, maxAppCols - ch * APP_CHUNK));
         });
+        // Non-empty chunk count the kernel reads. execute() validates the cache
+        // supplies exactly this many: a short count would leave a hoisted (reused
+        // across iterations) appearance buffer holding the previous iteration's
+        // data, which the kernel would then read as this iteration's appearance.
+        const numAppChunks = appStrides.filter(stride => stride > 0).length;
 
         const bindGroupFormat = new BindGroupFormat(device, [
             new BindUniformBufferFormat('uniforms', SHADERSTAGE_COMPUTE),
@@ -422,6 +427,9 @@ class GpuEdgeCost {
             if (e > maxE) throw new Error(`GpuEdgeCost: E=${e} exceeds maxE=${maxE}`);
             if (cache.numAppCols !== maxAppCols) {
                 throw new Error(`GpuEdgeCost: numAppCols=${cache.numAppCols} must equal maxAppCols=${maxAppCols} (baked into the kernel)`);
+            }
+            if (cache.appChunks.length !== numAppChunks) {
+                throw new Error(`GpuEdgeCost: cache supplies ${cache.appChunks.length} appearance chunks but the kernel layout expects ${numAppChunks}`);
             }
             if (edgeJ.length !== e || outCosts.length !== e) {
                 throw new Error('GpuEdgeCost: edgeI / edgeJ / outCosts must have same length');

--- a/src/lib/gpu/gpu-edge-cost.ts
+++ b/src/lib/gpu/gpu-edge-cost.ts
@@ -17,6 +17,15 @@ import {
 } from 'playcanvas';
 
 /**
+ * Appearance columns per storage chunk. The kernel exposes three appearance
+ * bindings (appA/appB/appC), so the layout holds up to 3·APP_CHUNK columns; at
+ * 16 the widest chunk reaches the ~2 GB per-binding limit around ~33.5M splats.
+ * The CPU-side packing in `data-table/decimate.ts` imports this same constant,
+ * so the kernel strides and the host packing can't drift.
+ */
+export const APP_CHUNK = 16;
+
+/**
  * WGSL kernel: per-edge KL-style cost (matches `computeEdgeCost` in
  * `data-table/decimate.ts`).
  *
@@ -301,13 +310,12 @@ class GpuEdgeCost {
     constructor(device: GraphicsDevice, maxN: number, maxE: number, maxAppCols: number) {
         const workgroupSize = 64;
         const edgesPerBatch = 1024 * workgroupSize;  // 65,536
-        // Appearance is split at fixed 16-column boundaries (the chunk *count*),
-        // but each chunk's *stride* is its live column count — only the last
-        // non-empty chunk is ever partial, so partial chunks neither allocate
-        // nor upload padding. The widest possible chunk (16 cols) reaches the
-        // ~2 GB limit at ~33.5M splats, past the ~11.2M wall the single 48-col
-        // buffer hit. These strides must match the packing in decimate.ts.
-        const APP_CHUNK = 16;
+        // Appearance is split at fixed APP_CHUNK-column boundaries, but each
+        // chunk's *stride* is its live column count — only the last non-empty
+        // chunk is ever partial, so partial chunks neither allocate nor upload
+        // padding. The widest possible chunk reaches the ~2 GB limit at ~33.5M
+        // splats, past the ~11.2M wall the single 48-col buffer hit. The three
+        // kernel bindings (appA/appB/appC) cap the layout at three chunks.
         // e.g. [16, 11, 0] for 27 cols, [3, 0, 0] for DC-only.
         const appStrides = [0, 1, 2].map((ch) => {
             return Math.min(APP_CHUNK, Math.max(0, maxAppCols - ch * APP_CHUNK));

--- a/src/lib/gpu/gpu-edge-cost.ts
+++ b/src/lib/gpu/gpu-edge-cost.ts
@@ -86,7 +86,7 @@ const STRIDE_C: u32 = ${strideC}u;
 // Symmetric 3x3 covariance helpers — we pass them around as 6 f32 (xx, xy, xz, yy, yz, zz).
 
 // Σ = R · diag(v) · R^T for row-major R (a 9-float array starting at offset r9).
-// Variances v come from splatScalars[s5 + 2..4]. Result is 6 floats:
+// Variances v come from posScalars[s8 + 5..7]. Result is 6 floats:
 // (xx, xy, xz, yy, yz, zz).
 fn sigmaFromRotVar(r9: u32, s8: u32) -> array<f32, 6> {
     let r00 = rotR[r9 + 0u]; let r01 = rotR[r9 + 1u]; let r02 = rotR[r9 + 2u];
@@ -180,7 +180,7 @@ fn main(@builtin(global_invocation_id) gid: vec3u) {
     // Entropy of the merged Gaussian: H = 0.5 (k log(2π) + log|Σ_m| + k), k=3.
     let EpNegLogQ = 0.5 * (3.0 * LOG2PI + logdet_m + 3.0);
 
-    // Read per-axis std for each input (variances live at splatScalars[s5+2..4]).
+    // Read per-axis std for each input (variances live at posScalars[s8+5..7]).
     let vix = posScalars[i8 + 5u]; let viy = posScalars[i8 + 6u]; let viz = posScalars[i8 + 7u];
     let vjx = posScalars[j8 + 5u]; let vjy = posScalars[j8 + 6u]; let vjz = posScalars[j8 + 7u];
     let stdix = sqrt(max(vix, 0.0));
@@ -359,6 +359,8 @@ class GpuEdgeCost {
         // limit so we fail with a clear message instead of a driver-side error.
         // Edges are uploaded per batch (batch-sized buffers), so they can't hit
         // the limit; the widest appearance chunk and rotR are the candidates.
+        // posScalars (8 floats/splat) is strictly smaller than rotR (9), so the
+        // rotR check already bounds it — no separate check needed.
         const maxStorage = (device as any).limits?.maxStorageBufferBindingSize;
         if (typeof maxStorage === 'number') {
             const checkLimit = (label: string, bytes: number) => {

--- a/src/lib/gpu/gpu-edge-cost.ts
+++ b/src/lib/gpu/gpu-edge-cost.ts
@@ -26,13 +26,15 @@ import {
  * (the same `z` for both components, matching the CPU implementation),
  * and adds an L2 distance over the appearance (SH) coefficients.
  *
+ * @param strideA - Live column count of appearance chunk A (0 if unused).
+ * @param strideB - Live column count of appearance chunk B (0 if unused).
+ * @param strideC - Live column count of appearance chunk C (0 if unused).
  * @returns WGSL source.
  */
-const edgeCostWgsl = () => /* wgsl */`
+const edgeCostWgsl = (strideA: number, strideB: number, strideC: number) => /* wgsl */`
 struct Uniforms {
     edgeOffset: u32,
     edgeCount: u32,
-    numAppCols: u32,
     z0: f32,
     z1: f32,
     z2: f32,
@@ -43,34 +45,46 @@ struct Uniforms {
 // allocate an edgeCount*2 Uint32 scratch to interleave (i, j) on every call.
 @group(0) @binding(1) var<storage, read> edgesI: array<u32>;
 @group(0) @binding(2) var<storage, read> edgesJ: array<u32>;
-// Positions, interleaved xyz: positions[3s + 0/1/2].
-@group(0) @binding(3) var<storage, read> positions: array<f32>;
+// Per-splat geometry, interleaved 8-wide:
+//   posScalars[8s + 0..2] = position xyz
+//   posScalars[8s + 3]    = mass
+//   posScalars[8s + 4]    = logdet
+//   posScalars[8s + 5..7] = variances (vx, vy, vz)
+@group(0) @binding(3) var<storage, read> posScalars: array<f32>;
 // Row-major 3x3 rotation matrix per splat (9 floats per splat).
 @group(0) @binding(4) var<storage, read> rotR: array<f32>;
-// Per-splat scalars packed: splatScalars[5s + 0] = mass,
-//                          splatScalars[5s + 1] = logdet,
-//                          splatScalars[5s + 2..4] = variances (vx, vy, vz).
-@group(0) @binding(5) var<storage, read> splatScalars: array<f32>;
-// Appearance: row-major, app[s * C + k] = ch k of splat s.
-@group(0) @binding(6) var<storage, read> appearance: array<f32>;
+// Appearance, split into up to three chunks (≤16 columns each) so no single
+// binding exceeds maxStorageBufferBindingSize (~2 GB). Each chunk's stride is
+// its live column count (STRIDE_A/B/C below); appA holds columns 0.., appB the
+// next span, appC the next. Unused chunks have stride 0, are bound to a dummy
+// buffer, and are never read.
+@group(0) @binding(5) var<storage, read> appA: array<f32>;
+@group(0) @binding(6) var<storage, read> appB: array<f32>;
+@group(0) @binding(7) var<storage, read> appC: array<f32>;
 // Output: cost per edge.
-@group(0) @binding(7) var<storage, read_write> costs: array<f32>;
+@group(0) @binding(8) var<storage, read_write> costs: array<f32>;
 
 const EPS_COV: f32 = 1e-8;
 const LOG2PI: f32 = 1.8378770664093453;
+// Per-chunk appearance strides = live column count in each chunk (0 = unused,
+// dummy-bound). Baked here because the column count is fixed for the lifetime
+// of the kernel, so loop bounds and indexing resolve statically.
+const STRIDE_A: u32 = ${strideA}u;
+const STRIDE_B: u32 = ${strideB}u;
+const STRIDE_C: u32 = ${strideC}u;
 
 // Symmetric 3x3 covariance helpers — we pass them around as 6 f32 (xx, xy, xz, yy, yz, zz).
 
 // Σ = R · diag(v) · R^T for row-major R (a 9-float array starting at offset r9).
 // Variances v come from splatScalars[s5 + 2..4]. Result is 6 floats:
 // (xx, xy, xz, yy, yz, zz).
-fn sigmaFromRotVar(r9: u32, s5: u32) -> array<f32, 6> {
+fn sigmaFromRotVar(r9: u32, s8: u32) -> array<f32, 6> {
     let r00 = rotR[r9 + 0u]; let r01 = rotR[r9 + 1u]; let r02 = rotR[r9 + 2u];
     let r10 = rotR[r9 + 3u]; let r11 = rotR[r9 + 4u]; let r12 = rotR[r9 + 5u];
     let r20 = rotR[r9 + 6u]; let r21 = rotR[r9 + 7u]; let r22 = rotR[r9 + 8u];
-    let vx = splatScalars[s5 + 2u];
-    let vy = splatScalars[s5 + 3u];
-    let vz = splatScalars[s5 + 4u];
+    let vx = posScalars[s8 + 5u];
+    let vy = posScalars[s8 + 6u];
+    let vz = posScalars[s8 + 7u];
     return array<f32, 6>(
         r00*r00*vx + r01*r01*vy + r02*r02*vz,   // xx
         r00*r10*vx + r01*r11*vy + r02*r12*vz,   // xy
@@ -113,18 +127,16 @@ fn main(@builtin(global_invocation_id) gid: vec3u) {
     let i = edgesI[eIdx];
     let j = edgesJ[eIdx];
 
-    let i3 = i * 3u;
-    let j3 = j * 3u;
+    let i8 = i * 8u;
+    let j8 = j * 8u;
     let i9 = i * 9u;
     let j9 = j * 9u;
-    let i5 = i * 5u;
-    let j5 = j * 5u;
 
-    let mu_i = vec3f(positions[i3 + 0u], positions[i3 + 1u], positions[i3 + 2u]);
-    let mu_j = vec3f(positions[j3 + 0u], positions[j3 + 1u], positions[j3 + 2u]);
+    let mu_i = vec3f(posScalars[i8 + 0u], posScalars[i8 + 1u], posScalars[i8 + 2u]);
+    let mu_j = vec3f(posScalars[j8 + 0u], posScalars[j8 + 1u], posScalars[j8 + 2u]);
 
-    let wi = splatScalars[i5 + 0u];
-    let wj = splatScalars[j5 + 0u];
+    let wi = posScalars[i8 + 3u];
+    let wj = posScalars[j8 + 3u];
     let W = wi + wj;
     let Wsafe = select(1.0, W, W > 0.0);
     let pi_w_raw = wi / Wsafe;
@@ -139,8 +151,8 @@ fn main(@builtin(global_invocation_id) gid: vec3u) {
     let dj = mu_j - mm;
 
     // Σ_i and Σ_j from rotation + variances.
-    let sig_i = sigmaFromRotVar(i9, i5);
-    let sig_j = sigmaFromRotVar(j9, j5);
+    let sig_i = sigmaFromRotVar(i9, i8);
+    let sig_j = sigmaFromRotVar(j9, j8);
 
     // Merged covariance: pi*(Σ_i + δi·δiᵀ) + pj*(Σ_j + δj·δjᵀ), + EPS on diag.
     let s_xx = pi_w * (sig_i[0] + di.x*di.x) + pj_w * (sig_j[0] + dj.x*dj.x) + EPS_COV;
@@ -160,8 +172,8 @@ fn main(@builtin(global_invocation_id) gid: vec3u) {
     let EpNegLogQ = 0.5 * (3.0 * LOG2PI + logdet_m + 3.0);
 
     // Read per-axis std for each input (variances live at splatScalars[s5+2..4]).
-    let vix = splatScalars[i5 + 2u]; let viy = splatScalars[i5 + 3u]; let viz = splatScalars[i5 + 4u];
-    let vjx = splatScalars[j5 + 2u]; let vjy = splatScalars[j5 + 3u]; let vjz = splatScalars[j5 + 4u];
+    let vix = posScalars[i8 + 5u]; let viy = posScalars[i8 + 6u]; let viz = posScalars[i8 + 7u];
+    let vjx = posScalars[j8 + 5u]; let vjy = posScalars[j8 + 6u]; let vjz = posScalars[j8 + 7u];
     let stdix = sqrt(max(vix, 0.0));
     let stdiy = sqrt(max(viy, 0.0));
     let stdiz = sqrt(max(viz, 0.0));
@@ -172,8 +184,8 @@ fn main(@builtin(global_invocation_id) gid: vec3u) {
     // Inverse diagonals (1 / variance) for the log-pdf quadratic term.
     let invDi = vec3f(1.0 / max(vix, 1e-30), 1.0 / max(viy, 1e-30), 1.0 / max(viz, 1e-30));
     let invDj = vec3f(1.0 / max(vjx, 1e-30), 1.0 / max(vjy, 1e-30), 1.0 / max(vjz, 1e-30));
-    let ldi = splatScalars[i5 + 1u];
-    let ldj = splatScalars[j5 + 1u];
+    let ldi = posScalars[i8 + 4u];
+    let ldj = posScalars[j8 + 4u];
 
     let z0 = uniforms.z0;
     let z1 = uniforms.z1;
@@ -206,13 +218,24 @@ fn main(@builtin(global_invocation_id) gid: vec3u) {
     let EpLogp = pi_w * Ei + pj_w * Ej;
     let geo = EpLogp + EpNegLogQ;
 
-    // Appearance L2 cost.
+    // Appearance L2 cost, summed across the (up to three) chunks. Each chunk's
+    // stride is its live column count, so partial chunks store/read no padding.
+    // A 0 stride yields 0 iterations, so the dummy-bound appB / appC are never
+    // touched on inputs with fewer SH bands.
     var cSh: f32 = 0.0;
-    let C = uniforms.numAppCols;
-    let baseI = i * C;
-    let baseJ = j * C;
-    for (var k: u32 = 0u; k < C; k = k + 1u) {
-        let d = appearance[baseI + k] - appearance[baseJ + k];
+    let iA = i * STRIDE_A; let jA = j * STRIDE_A;
+    for (var k: u32 = 0u; k < STRIDE_A; k = k + 1u) {
+        let d = appA[iA + k] - appA[jA + k];
+        cSh = cSh + d * d;
+    }
+    let iB = i * STRIDE_B; let jB = j * STRIDE_B;
+    for (var k: u32 = 0u; k < STRIDE_B; k = k + 1u) {
+        let d = appB[iB + k] - appB[jB + k];
+        cSh = cSh + d * d;
+    }
+    let iC = i * STRIDE_C; let jC = j * STRIDE_C;
+    for (var k: u32 = 0u; k < STRIDE_C; k = k + 1u) {
+        let d = appC[iC + k] - appC[jC + k];
         cSh = cSh + d * d;
     }
 
@@ -221,18 +244,20 @@ fn main(@builtin(global_invocation_id) gid: vec3u) {
 `;
 
 /**
- * Per-splat cache for the edge cost kernel. Packed layouts to stay within
- * the WebGPU per-stage storage-buffer limit (max 10).
+ * Per-splat cache for the edge cost kernel. Packed layouts to stay within the
+ * WebGPU per-stage storage-buffer count limit (8) and the per-binding size
+ * limit (~2 GB) — appearance is split into 16-column chunks for the latter.
  */
 interface EdgeCostCache {
-    /** N positions interleaved xyz (length 3N). */
-    positions: Float32Array;
+    /** Per-splat geometry interleaved 8-wide: (x, y, z, mass, logdet, vx, vy, vz). */
+    posScalars: Float32Array;
     /** Row-major 3×3 rotation per splat (length 9N). */
     rotR: Float32Array;
-    /** Per-splat scalars interleaved 5-wide: (mass, logdet, vx, vy, vz). */
-    splatScalars: Float32Array;
-    /** Appearance coefficients, row-major: appearance[s * C + k]. */
-    appearance: Float32Array;
+    /**
+     * Appearance in up to three chunks of ≤16 columns. Chunk c has stride
+     * width_c (= its live column count): appChunks[c][s * width_c + k].
+     */
+    appChunks: Float32Array[];
     /** Number of appearance columns C. */
     numAppCols: number;
     /** Number of splats. */
@@ -276,28 +301,39 @@ class GpuEdgeCost {
     constructor(device: GraphicsDevice, maxN: number, maxE: number, maxAppCols: number) {
         const workgroupSize = 64;
         const edgesPerBatch = 1024 * workgroupSize;  // 65,536
+        // Appearance is split at fixed 16-column boundaries (the chunk *count*),
+        // but each chunk's *stride* is its live column count — only the last
+        // non-empty chunk is ever partial, so partial chunks neither allocate
+        // nor upload padding. The widest possible chunk (16 cols) reaches the
+        // ~2 GB limit at ~33.5M splats, past the ~11.2M wall the single 48-col
+        // buffer hit. These strides must match the packing in decimate.ts.
+        const APP_CHUNK = 16;
+        // e.g. [16, 11, 0] for 27 cols, [3, 0, 0] for DC-only.
+        const appStrides = [0, 1, 2].map((ch) => {
+            return Math.min(APP_CHUNK, Math.max(0, maxAppCols - ch * APP_CHUNK));
+        });
 
         const bindGroupFormat = new BindGroupFormat(device, [
             new BindUniformBufferFormat('uniforms', SHADERSTAGE_COMPUTE),
             new BindStorageBufferFormat('edgesI', SHADERSTAGE_COMPUTE, true),
             new BindStorageBufferFormat('edgesJ', SHADERSTAGE_COMPUTE, true),
-            new BindStorageBufferFormat('positions', SHADERSTAGE_COMPUTE, true),
+            new BindStorageBufferFormat('posScalars', SHADERSTAGE_COMPUTE, true),
             new BindStorageBufferFormat('rotR', SHADERSTAGE_COMPUTE, true),
-            new BindStorageBufferFormat('splatScalars', SHADERSTAGE_COMPUTE, true),
-            new BindStorageBufferFormat('appearance', SHADERSTAGE_COMPUTE, true),
+            new BindStorageBufferFormat('appA', SHADERSTAGE_COMPUTE, true),
+            new BindStorageBufferFormat('appB', SHADERSTAGE_COMPUTE, true),
+            new BindStorageBufferFormat('appC', SHADERSTAGE_COMPUTE, true),
             new BindStorageBufferFormat('costs', SHADERSTAGE_COMPUTE)
         ]);
 
         const shader = new Shader(device, {
             name: 'compute-edge-cost',
             shaderLanguage: SHADERLANGUAGE_WGSL,
-            cshader: edgeCostWgsl(),
+            cshader: edgeCostWgsl(appStrides[0], appStrides[1], appStrides[2]),
             // @ts-ignore
             computeUniformBufferFormats: {
                 uniforms: new UniformBufferFormat(device, [
                     new UniformFormat('edgeOffset', UNIFORMTYPE_UINT),
                     new UniformFormat('edgeCount', UNIFORMTYPE_UINT),
-                    new UniformFormat('numAppCols', UNIFORMTYPE_UINT),
                     new UniformFormat('z0', UNIFORMTYPE_FLOAT),
                     new UniformFormat('z1', UNIFORMTYPE_FLOAT),
                     new UniformFormat('z2', UNIFORMTYPE_FLOAT)
@@ -307,21 +343,38 @@ class GpuEdgeCost {
             computeBindGroupFormat: bindGroupFormat
         });
 
-        // Pre-flight the appearance buffer against the device's storage limit
-        // so we fail with a clear message instead of a driver-side error.
-        const appBytes = maxN * maxAppCols * 4;
+        // Pre-flight the largest bindings against the device's storage limit so
+        // we fail with a clear message instead of a driver-side error. After the
+        // split, the widest appearance chunk and the edge buffers are the two
+        // that can still reach the limit (maxN*width*4 and maxE*4 bytes).
         const maxStorage = (device as any).limits?.maxStorageBufferBindingSize;
-        if (typeof maxStorage === 'number' && appBytes > maxStorage) {
-            throw new Error(
-                `GpuEdgeCost: appearance buffer (${appBytes} bytes for ${maxN} splats × ${maxAppCols} cols) ` +
-                `exceeds device maxStorageBufferBindingSize (${maxStorage})`
-            );
+        if (typeof maxStorage === 'number') {
+            const checkLimit = (label: string, bytes: number) => {
+                if (bytes > maxStorage) {
+                    throw new Error(
+                        `GpuEdgeCost: ${label} buffer (${bytes} bytes) exceeds device ` +
+                        `maxStorageBufferBindingSize (${maxStorage})`
+                    );
+                }
+            };
+            const maxChunkCols = Math.max(...appStrides);
+            checkLimit(`appearance chunk (${maxN} splats × ${maxChunkCols} cols)`, maxN * maxChunkCols * 4);
+            checkLimit(`edge (${maxE} edges)`, maxE * 4);
         }
 
-        const positionsBuf = new StorageBuffer(device, maxN * 3 * 4, BUFFERUSAGE_COPY_DST);
+        const posScalarsBuf = new StorageBuffer(device, maxN * 8 * 4, BUFFERUSAGE_COPY_DST);
         const rotRBuf = new StorageBuffer(device, maxN * 9 * 4, BUFFERUSAGE_COPY_DST);
-        const splatScalarsBuf = new StorageBuffer(device, maxN * 5 * 4, BUFFERUSAGE_COPY_DST);
-        const appearanceBuf = new StorageBuffer(device, appBytes, BUFFERUSAGE_COPY_DST);
+
+        // One buffer per non-empty appearance chunk, sized to that chunk's live
+        // column count; empty slots (inputs with fewer SH bands) share a small
+        // dummy since WebGPU forbids a zero-size binding. The 3-binding layout
+        // stays fixed regardless of band count.
+        const appDummy = new StorageBuffer(device, 16, BUFFERUSAGE_COPY_DST);
+        const appBufs: StorageBuffer[] = appStrides.map((width) => {
+            return width > 0 ?
+                new StorageBuffer(device, maxN * width * 4, BUFFERUSAGE_COPY_DST) :
+                appDummy;
+        });
 
         // Two parallel u32 buffers — uploading `edgeI` / `edgeJ` directly is
         // ~1 GB cheaper than packing into a single interleaved scratch on a
@@ -339,10 +392,11 @@ class GpuEdgeCost {
         const compute = new Compute(device, shader, 'compute-edge-cost');
         compute.setParameter('edgesI', edgesIBuf);
         compute.setParameter('edgesJ', edgesJBuf);
-        compute.setParameter('positions', positionsBuf);
+        compute.setParameter('posScalars', posScalarsBuf);
         compute.setParameter('rotR', rotRBuf);
-        compute.setParameter('splatScalars', splatScalarsBuf);
-        compute.setParameter('appearance', appearanceBuf);
+        compute.setParameter('appA', appBufs[0]);
+        compute.setParameter('appB', appBufs[1]);
+        compute.setParameter('appC', appBufs[2]);
         compute.setParameter('costs', outBuf);
 
         this.execute = async (
@@ -357,8 +411,8 @@ class GpuEdgeCost {
 
             if (n > maxN) throw new Error(`GpuEdgeCost: N=${n} exceeds maxN=${maxN}`);
             if (e > maxE) throw new Error(`GpuEdgeCost: E=${e} exceeds maxE=${maxE}`);
-            if (cache.numAppCols > maxAppCols) {
-                throw new Error(`GpuEdgeCost: numAppCols=${cache.numAppCols} exceeds maxAppCols=${maxAppCols}`);
+            if (cache.numAppCols !== maxAppCols) {
+                throw new Error(`GpuEdgeCost: numAppCols=${cache.numAppCols} must equal maxAppCols=${maxAppCols} (baked into the kernel)`);
             }
             if (edgeJ.length !== e || outCosts.length !== e) {
                 throw new Error('GpuEdgeCost: edgeI / edgeJ / outCosts must have same length');
@@ -367,17 +421,18 @@ class GpuEdgeCost {
                 throw new Error('GpuEdgeCost: z must have at least 3 elements');
             }
 
-            // Upload per-splat cache.
-            positionsBuf.write(0, cache.positions, 0, n * 3);
+            // Upload per-splat cache. Each appearance chunk is row-major with
+            // stride = its live column count, so we upload n*width per chunk.
+            posScalarsBuf.write(0, cache.posScalars, 0, n * 8);
             rotRBuf.write(0, cache.rotR, 0, n * 9);
-            splatScalarsBuf.write(0, cache.splatScalars, 0, n * 5);
-            appearanceBuf.write(0, cache.appearance, 0, n * cache.numAppCols);
+            for (let ch = 0; ch < cache.appChunks.length; ch++) {
+                appBufs[ch].write(0, cache.appChunks[ch], 0, n * appStrides[ch]);
+            }
 
             // Upload edges as two parallel u32 buffers — no host-side pack.
             edgesIBuf.write(0, edgeI, 0, e);
             edgesJBuf.write(0, edgeJ, 0, e);
 
-            compute.setParameter('numAppCols', cache.numAppCols);
             compute.setParameter('z0', z[0]);
             compute.setParameter('z1', z[1]);
             compute.setParameter('z2', z[2]);
@@ -401,10 +456,12 @@ class GpuEdgeCost {
         };
 
         this.destroy = () => {
-            positionsBuf.destroy();
+            posScalarsBuf.destroy();
             rotRBuf.destroy();
-            splatScalarsBuf.destroy();
-            appearanceBuf.destroy();
+            for (const buf of appBufs) {
+                if (buf !== appDummy) buf.destroy();
+            }
+            appDummy.destroy();
             edgesIBuf.destroy();
             edgesJBuf.destroy();
             outBuf.destroy();

--- a/src/lib/gpu/gpu-edge-cost.ts
+++ b/src/lib/gpu/gpu-edge-cost.ts
@@ -33,7 +33,6 @@ import {
  */
 const edgeCostWgsl = (strideA: number, strideB: number, strideC: number) => /* wgsl */`
 struct Uniforms {
-    edgeOffset: u32,
     edgeCount: u32,
     z0: f32,
     z1: f32,
@@ -41,8 +40,10 @@ struct Uniforms {
 }
 
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
-// Edge list split into two parallel arrays — avoids the host having to
-// allocate an edgeCount*2 Uint32 scratch to interleave (i, j) on every call.
+// Edge list for the current dispatch batch only, split into two parallel
+// arrays (avoids a host-side (i, j) interleave). The host uploads each batch's
+// slice to offset 0, so we index edgesI/J[bid] directly — keeping these
+// buffers batch-sized instead of N·k keeps them off the per-binding limit.
 @group(0) @binding(1) var<storage, read> edgesI: array<u32>;
 @group(0) @binding(2) var<storage, read> edgesJ: array<u32>;
 // Per-splat geometry, interleaved 8-wide:
@@ -122,10 +123,9 @@ fn logAddExp(a: f32, b: f32) -> f32 {
 fn main(@builtin(global_invocation_id) gid: vec3u) {
     let bid = gid.x;
     if (bid >= uniforms.edgeCount) { return; }
-    let eIdx = bid + uniforms.edgeOffset;
 
-    let i = edgesI[eIdx];
-    let j = edgesJ[eIdx];
+    let i = edgesI[bid];
+    let j = edgesJ[bid];
 
     let i8 = i * 8u;
     let j8 = j * 8u;
@@ -332,7 +332,6 @@ class GpuEdgeCost {
             // @ts-ignore
             computeUniformBufferFormats: {
                 uniforms: new UniformBufferFormat(device, [
-                    new UniformFormat('edgeOffset', UNIFORMTYPE_UINT),
                     new UniformFormat('edgeCount', UNIFORMTYPE_UINT),
                     new UniformFormat('z0', UNIFORMTYPE_FLOAT),
                     new UniformFormat('z1', UNIFORMTYPE_FLOAT),
@@ -343,10 +342,10 @@ class GpuEdgeCost {
             computeBindGroupFormat: bindGroupFormat
         });
 
-        // Pre-flight the largest bindings against the device's storage limit so
-        // we fail with a clear message instead of a driver-side error. After the
-        // split, the widest appearance chunk and the edge buffers are the two
-        // that can still reach the limit (maxN*width*4 and maxE*4 bytes).
+        // Pre-flight the largest per-N bindings against the device's storage
+        // limit so we fail with a clear message instead of a driver-side error.
+        // Edges are uploaded per batch (batch-sized buffers), so they can't hit
+        // the limit; the widest appearance chunk and rotR are the candidates.
         const maxStorage = (device as any).limits?.maxStorageBufferBindingSize;
         if (typeof maxStorage === 'number') {
             const checkLimit = (label: string, bytes: number) => {
@@ -359,7 +358,7 @@ class GpuEdgeCost {
             };
             const maxChunkCols = Math.max(...appStrides);
             checkLimit(`appearance chunk (${maxN} splats × ${maxChunkCols} cols)`, maxN * maxChunkCols * 4);
-            checkLimit(`edge (${maxE} edges)`, maxE * 4);
+            checkLimit(`rotR (${maxN} splats × 9)`, maxN * 9 * 4);
         }
 
         const posScalarsBuf = new StorageBuffer(device, maxN * 8 * 4, BUFFERUSAGE_COPY_DST);
@@ -376,11 +375,13 @@ class GpuEdgeCost {
                 appDummy;
         });
 
-        // Two parallel u32 buffers — uploading `edgeI` / `edgeJ` directly is
-        // ~1 GB cheaper than packing into a single interleaved scratch on a
-        // 17.9M-splat run, since the host never has to materialise the pack.
-        const edgesIBuf = new StorageBuffer(device, maxE * 4, BUFFERUSAGE_COPY_DST);
-        const edgesJBuf = new StorageBuffer(device, maxE * 4, BUFFERUSAGE_COPY_DST);
+        // Two parallel u32 buffers, sized to a single dispatch batch (not the
+        // full N·k edge list): execute uploads each batch's slice before its
+        // dispatch. Batch-sizing keeps these ~256 KB instead of N·k·4 — off the
+        // ~2 GB per-binding limit (so edges never cap scene size) and ~1.6 GB
+        // less VRAM at 13M splats. Two parallel arrays avoid a host-side pack.
+        const edgesIBuf = new StorageBuffer(device, edgesPerBatch * 4, BUFFERUSAGE_COPY_DST);
+        const edgesJBuf = new StorageBuffer(device, edgesPerBatch * 4, BUFFERUSAGE_COPY_DST);
 
         const outBuf = new StorageBuffer(
             device,
@@ -429,10 +430,6 @@ class GpuEdgeCost {
                 appBufs[ch].write(0, cache.appChunks[ch], 0, n * appStrides[ch]);
             }
 
-            // Upload edges as two parallel u32 buffers — no host-side pack.
-            edgesIBuf.write(0, edgeI, 0, e);
-            edgesJBuf.write(0, edgeJ, 0, e);
-
             compute.setParameter('z0', z[0]);
             compute.setParameter('z1', z[1]);
             compute.setParameter('z2', z[2]);
@@ -443,7 +440,11 @@ class GpuEdgeCost {
                 const edgeCount = Math.min(edgesPerBatch, e - edgeOffset);
                 const groups = Math.ceil(edgeCount / workgroupSize);
 
-                compute.setParameter('edgeOffset', edgeOffset);
+                // Upload just this batch's edges to offset 0; the kernel indexes
+                // edgesI/J[bid] within the batch.
+                edgesIBuf.write(0, edgeI, edgeOffset, edgeCount);
+                edgesJBuf.write(0, edgeJ, edgeOffset, edgeCount);
+
                 compute.setParameter('edgeCount', edgeCount);
 
                 compute.setupDispatch(groups);

--- a/test/decimate.test.mjs
+++ b/test/decimate.test.mjs
@@ -278,6 +278,26 @@ describe('simplifyGaussians', () => {
         assertClose(result.getColumnByName('f_dc_2').data[0], 0,   1e-5, 'merged f_dc_2');
     });
 
+    it('should fail loud (throw) when every edge cost is non-finite', async () => {
+        // Degenerate input: finite positions (so the k-NN graph still yields
+        // edges) but non-finite appearance, which drives every edge cost to
+        // NaN. With no finite-cost pair to merge, the no-progress guard must
+        // throw rather than silently return an incompletely-decimated scene —
+        // locking in the fail-loud contract (and, via the CLI, a non-zero exit).
+        const inf = Infinity;
+        const testData = createVisibilityTestData({
+            count: 4,
+            x: new Float32Array([0, 1, 2, 3]),
+            f_dc_0: new Float32Array([inf, inf, inf, inf])
+        });
+
+        await assert.rejects(
+            () => simplifyGaussians(testData, 2),
+            /no valid merge pairs/,
+            'should throw when every edge cost is non-finite'
+        );
+    });
+
     it('should fall back to visibility pruning when rotation columns are missing', async () => {
         const testData = new DataTable([
             new Column('x', new Float32Array([0, 1, 2, 3])),


### PR DESCRIPTION
Fixes two related GPU-decimation problems on large scenes, plus a fail-loud robustness change.
**Problems**
- The edge-cost kernel packed all spherical-harmonic coefficients into a single storage buffer, which exceeds WebGPU's ~2GB per-binding limit (`maxStorageBufferBindingSize`) at ~11.2M splats with 48 SH columns — decimation crashed with `appearance buffer … exceeds device maxStorageBufferBindingSize`.
- A device out-of-memory (hit on an EC2 NVIDIA instance) was swallowed: WebGPU reports OOM asynchronously, so the failed allocation left buffers zeroed, the k-NN graph came back empty, and `simplifyGaussians` silently returned its input. In the streamed-SOG LOD chain (each level decimated from the previous) this cascaded into several identical full-resolution levels with a clean exit code.
**Changes**
- Split the appearance buffer into up to three ≤16-column chunks (variable width, so partial chunks store no padding) and merge positions+scalars into one buffer, keeping the kernel at 8 storage buffers (the WebGPU baseline). Raises the per-binding cap from ~11.2M to ~33.5M splats at 48 SH columns, and ~59.6M for DC-only inputs.
- Upload edges per dispatch batch (256KB) instead of the full N·k list, removing them as a per-binding cap and cutting ~1.6GB of VRAM at 13M splats.
- Centralize GPU error handling in the device factory (`uncapturederror` + device-lost): log the precise cause and escalate to a non-zero exit, so every GPU consumer fails loudly instead of writing degenerate output.
- `simplifyGaussians` now throws if it cannot reach the target (zero k-NN edges or no finite-cost pairs) at any iteration, instead of returning a partial or full-resolution scene.
**Verification**
- GPU output is byte-identical to the previous version on real scenes (910K and 3.3M splats); the chunking and edge-batching changes are behavior-preserving.
- CPU decimation suite passes (41/41); the no-progress guard throws on degenerate input and the centralized handler logs + fails on a forced GPU error.
- Could not reproduce a real device OOM locally (ample memory), so the OOM path is verified via the error-scope/handler mechanism and the no-progress backstop rather than an actual OOM — re-running the failing `.splat` on the EC2 instance is the end-to-end confirmation.