### PR TITLE
Tolerate trailing/duplicate whitespace in PLY headers

### DIFF
--- a/src/lib/readers/read-ply.ts
+++ b/src/lib/readers/read-ply.ts
@@ -66,10 +66,10 @@ const isFloatElement = (element: PlyElement): boolean => {
 // parse the ply header text and return an array of Element structures and a
 // string containing the ply format
 const parseHeader = (data: Uint8Array): PlyHeader => {
-    // decode header and split into lines (tolerate CRLF line endings)
+    // decode header and split into lines
     const strings = new TextDecoder('ascii')
     .decode(data)
-    .split(/\r?\n/)
+    .split('\n')
     .filter(line => line);
 
     const elements: PlyElement[] = [];
@@ -77,7 +77,12 @@ const parseHeader = (data: Uint8Array): PlyHeader => {
     let element;
     for (let i = 1; i < strings.length; ++i) {
         // tolerate trailing/duplicate whitespace (e.g. space-padded counts written by some tools)
-        const words = strings[i].trim().split(/\s+/);
+        const line = strings[i].trim();
+        if (!line) {
+            // skip blank / whitespace-only lines
+            continue;
+        }
+        const words = line.split(/\s+/);
 
         switch (words[0]) {
             case 'ply':
@@ -86,7 +91,7 @@ const parseHeader = (data: Uint8Array): PlyHeader => {
                 // skip
                 break;
             case 'comment':
-                comments.push(strings[i].substring(8)); // skip 'comment '
+                comments.push(line.substring(8)); // skip 'comment '
                 break;
             case 'element': {
                 if (words.length !== 3) {

--- a/src/lib/readers/read-ply.ts
+++ b/src/lib/readers/read-ply.ts
@@ -77,12 +77,11 @@ const parseHeader = (data: Uint8Array): PlyHeader => {
     let element;
     for (let i = 1; i < strings.length; ++i) {
         // tolerate trailing/duplicate whitespace (e.g. space-padded counts written by some tools)
-        const line = strings[i].trim();
-        if (!line) {
+        const words = strings[i].split(' ').filter(Boolean);
+        if (words.length === 0) {
             // skip blank / whitespace-only lines
             continue;
         }
-        const words = line.split(/\s+/);
 
         switch (words[0]) {
             case 'ply':
@@ -91,7 +90,7 @@ const parseHeader = (data: Uint8Array): PlyHeader => {
                 // skip
                 break;
             case 'comment':
-                comments.push(line.substring(8)); // skip 'comment '
+                comments.push(strings[i].substring(8)); // skip 'comment '
                 break;
             case 'element': {
                 if (words.length !== 3) {

--- a/src/lib/readers/read-ply.ts
+++ b/src/lib/readers/read-ply.ts
@@ -66,17 +66,18 @@ const isFloatElement = (element: PlyElement): boolean => {
 // parse the ply header text and return an array of Element structures and a
 // string containing the ply format
 const parseHeader = (data: Uint8Array): PlyHeader => {
-    // decode header and split into lines
+    // decode header and split into lines (tolerate CRLF line endings)
     const strings = new TextDecoder('ascii')
     .decode(data)
-    .split('\n')
+    .split(/\r?\n/)
     .filter(line => line);
 
     const elements: PlyElement[] = [];
     const comments: string[] = [];
     let element;
     for (let i = 1; i < strings.length; ++i) {
-        const words = strings[i].split(' ');
+        // tolerate trailing/duplicate whitespace (e.g. space-padded counts written by some tools)
+        const words = strings[i].trim().split(/\s+/);
 
         switch (words[0]) {
             case 'ply':

--- a/src/lib/readers/read-ply.ts
+++ b/src/lib/readers/read-ply.ts
@@ -78,10 +78,6 @@ const parseHeader = (data: Uint8Array): PlyHeader => {
     for (let i = 1; i < strings.length; ++i) {
         // tolerate trailing/duplicate whitespace (e.g. space-padded counts written by some tools)
         const words = strings[i].split(' ').filter(Boolean);
-        if (words.length === 0) {
-            // skip blank / whitespace-only lines
-            continue;
-        }
 
         switch (words[0]) {
             case 'ply':

--- a/test/formats.test.mjs
+++ b/test/formats.test.mjs
@@ -199,8 +199,10 @@ describe('PLY Format', () => {
         // a space-padded vertex count, duplicate spaces, a whitespace-only line, and a comment
         // with leading whitespace — all of which previously caused 'invalid ply header'.
         const clean = encodePlyBinary(testData);
-        const headerEnd = new TextDecoder('ascii').decode(clean.subarray(0, 4096)).indexOf('end_header\n') + 'end_header\n'.length;
-        const body = clean.subarray(headerEnd);
+        const term = 'end_header\n';
+        const termIdx = new TextDecoder('ascii').decode(clean).indexOf(term);
+        assert(termIdx !== -1, 'end_header terminator not found in encoded PLY');
+        const body = clean.subarray(termIdx + term.length);
 
         const plyType = { float32: 'float', float64: 'double', int8: 'char', uint8: 'uchar', int16: 'short', uint16: 'ushort', int32: 'int', uint32: 'uint' };
         const headerLines = [

--- a/test/formats.test.mjs
+++ b/test/formats.test.mjs
@@ -193,6 +193,34 @@ describe('PLY Format', () => {
         // Compare data tables (should be identical)
         compareDataTables(readBack, testData, 0);
     });
+
+    it('should tolerate trailing/duplicate whitespace and whitespace-only lines in the header', async () => {
+        // reuse the binary body from a clean encode, but prepend a deliberately "messy" header:
+        // a space-padded vertex count, duplicate spaces, a whitespace-only line, and a comment
+        // with leading whitespace — all of which previously caused 'invalid ply header'.
+        const clean = encodePlyBinary(testData);
+        const headerEnd = new TextDecoder('ascii').decode(clean.subarray(0, 4096)).indexOf('end_header\n') + 'end_header\n'.length;
+        const body = clean.subarray(headerEnd);
+
+        const plyType = { float32: 'float', float64: 'double', int8: 'char', uint8: 'uchar', int16: 'short', uint16: 'ushort', int32: 'int', uint32: 'uint' };
+        const headerLines = [
+            'ply',
+            'format binary_little_endian 1.0',
+            '   ',                                                   // whitespace-only line
+            '   comment leading space and  double  spaces',         // leading ws + duplicate spaces
+            `element vertex ${testData.numRows}            `,        // trailing padding spaces
+            ...testData.columns.map(c => `property  ${plyType[c.dataType]}   ${c.name}`), // duplicate spaces
+            'end_header'
+        ];
+        const header = new TextEncoder().encode(`${headerLines.join('\n')}\n`);
+        const messy = new Uint8Array(header.length + body.length);
+        messy.set(header, 0);
+        messy.set(body, header.length);
+
+        const dataTable = await readPly(new BufferReadSource(messy));
+        assert.strictEqual(dataTable.numRows, testData.numRows);
+        assert.strictEqual(dataTable.numColumns, testData.columns.length);
+    });
 });
 
 describe('Compressed PLY Format', () => {

--- a/test/formats.test.mjs
+++ b/test/formats.test.mjs
@@ -194,10 +194,10 @@ describe('PLY Format', () => {
         compareDataTables(readBack, testData, 0);
     });
 
-    it('should tolerate trailing/duplicate whitespace and whitespace-only lines in the header', async () => {
+    it('should tolerate trailing/duplicate whitespace in the header', async () => {
         // reuse the binary body from a clean encode, but prepend a deliberately "messy" header:
-        // a space-padded vertex count, duplicate spaces, a whitespace-only line, and a comment
-        // with leading whitespace — all of which previously caused 'invalid ply header'.
+        // a space-padded vertex count and duplicate spaces between tokens — both of which
+        // previously caused 'invalid ply header'.
         const clean = encodePlyBinary(testData);
         const term = 'end_header\n';
         const termIdx = new TextDecoder('ascii').decode(clean).indexOf(term);
@@ -208,8 +208,6 @@ describe('PLY Format', () => {
         const headerLines = [
             'ply',
             'format binary_little_endian 1.0',
-            '   ',                                                   // whitespace-only line
-            '   comment leading space and  double  spaces',         // leading ws + duplicate spaces
             `element vertex ${testData.numRows}            `,        // trailing padding spaces
             ...testData.columns.map(c => `property  ${plyType[c.dataType]}   ${c.name}`), // duplicate spaces
             'end_header'


### PR DESCRIPTION
`parseHeader` tokenized each header line with `split(' ')` and required `element` / `property` lines to have **exactly 3 tokens**. A space-padded count — e.g. `element vertex 258951032      ` (written by some exporters / large-PLY tools) — or duplicate spaces between tokens produced extra empty tokens, pushing the token count past 3, so the header was rejected with `invalid ply header`.

**Fix:**
- Tokenize with `strings[i].split(' ').filter(Boolean)`, dropping the empty tokens produced by trailing or duplicate spaces.

That's the whole change — one line.

**Scope (deliberately minimal):**
This tolerates only extra spaces *between or after* tokens. It does **not** add support for:
- whitespace-only / blank header lines
- leading whitespace on a line (e.g. an indented `comment`)
- tabs as separators

Those aren't valid per the PLY spec — every header line is defined as "a carriage-return terminated ASCII string that begins with a keyword" ([spec](https://people.math.sc.edu/Burkardt/data/ply/ply.txt)) — so malformed lines like those still throw, as before. Clean headers parse exactly as they did (no behavior change).

**Testing:**
- Added a `formats.test.mjs` case covering a space-padded vertex count and duplicate spaces between tokens.
- All format tests pass; a clean-header PLY still loads unchanged.
