### PR TITLE
Support reading lcc2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 SplatTransform is an open source library and CLI tool for converting and editing Gaussian splats. It can:
 
-📥 Read PLY, Compressed PLY, SOG, SPZ, SPLAT, KSPLAT and LCC formats  
+📥 Read PLY, Compressed PLY, SOG, SPZ, SPLAT, KSPLAT, LCC and LCC2 formats  
 📤 Write PLY, Compressed PLY, SOG, SPZ, GLB, CSV, HTML Viewer, LOD, Voxel and WebP image formats  
 📊 Generate statistical summaries for data analysis  
 🔗 Merge multiple splats  
@@ -65,6 +65,7 @@ splat-transform [GLOBAL] input [ACTIONS]  ...  output [ACTIONS]
 | `.compressed.ply` | ✅ | ✅ | Compressed PLY format (auto-detected and decompressed on read) |
 | `.spz` | ✅ | ✅ | Compressed splat format (Niantic format, v2–4) |
 | `.lcc` | ✅ | ❌ | LCC file format (XGRIDS) |
+| `.lcc2` | ✅ | ❌ | LCC2 file format (XGRIDS, octree) |
 | `.ksplat` | ✅ | ❌ | Compressed splat format (mkkellogg format) |
 | `.splat` | ✅ | ❌ | Compressed splat format (antimatter15 format) |
 | `.mjs` | ✅ | ❌ | Generate a scene using an mjs script (Beta) |
@@ -161,12 +162,12 @@ Apply when writing `.html` outputs.
 > [!NOTE]
 > See the [SuperSplat Viewer Settings Schema](https://github.com/playcanvas/supersplat-viewer?tab=readme-ov-file#settings-schema) for details on how to pass data to the `-E` option.
 
-## LCC Input Options
+## LCC / LCC2 Input Options
 
-Apply when reading `.lcc` files.
+Apply when reading `.lcc` and `.lcc2` files.
 
 ```none
--O, --lod-select       <n,n,...>        Comma-separated LOD levels to read from LCC input
+-O, --lod-select       <n,n,...>        Comma-separated LOD levels to read from LCC / LCC2 input
 ```
 
 ## LOD Output Options

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -721,7 +721,7 @@ USAGE
   • Use 'null' as output to discard file output.
 
 SUPPORTED INPUTS
-    .ply   .compressed.ply   .sog   .spz   meta.json   .ksplat   .splat   .mjs   .lcc
+    .ply   .compressed.ply   .sog   .spz   meta.json   .ksplat   .splat   .mjs   .lcc   .lcc2
 
     Input filenames may also be http(s):// URLs (downloaded on demand;
     .mjs generators are local-only).
@@ -771,8 +771,8 @@ HTML VIEWER OUTPUT (.html)
     -E, --viewer-settings  <settings.json>  HTML viewer settings JSON file
     -U, --unbundled                         Generate unbundled HTML viewer with separate files
 
-LCC INPUT (.lcc)
-    -O, --lod-select       <n,n,...>        Comma-separated LOD levels to read from LCC input
+LCC / LCC2 INPUT (.lcc, .lcc2)
+    -O, --lod-select       <n,n,...>        Comma-separated LOD levels to read from LCC / LCC2 input
 
 LOD OUTPUT (lod-meta.json)
     -C, --lod-chunk-count  <n>              Approximate number of Gaussians per LOD chunk in K. Default: 512

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -44,7 +44,7 @@ export { MemoryFileSystem, ZipFileSystem } from './io/write';
 export type { FileSystem, Writer } from './io/write';
 
 // Individual readers (for advanced use)
-export { readKsplat, readLcc, readMjs, readPly, readSog, readSplat, readSpz } from './readers';
+export { readKsplat, readLcc, readLcc2, readMjs, readPly, readSog, readSplat, readSpz } from './readers';
 
 // Individual writers (for advanced use)
 export { writeSog, writeSpz, writePly, writeCompressedPly, writeCsv, writeHtml, writeImage, writeLod, writeGlb, writeVoxel } from './writers';

--- a/src/lib/read.ts
+++ b/src/lib/read.ts
@@ -1,6 +1,6 @@
 import { DataTable } from './data-table';
 import { ReadFileSystem, ZipReadFileSystem } from './io/read';
-import { readKsplat, readLcc, readMjs, readPly, readSog, readSplat, readSpz } from './readers';
+import { readKsplat, readLcc, readLcc2, readMjs, readPly, readSog, readSplat, readSpz } from './readers';
 import { Options, Param } from './types';
 
 /**
@@ -12,9 +12,10 @@ import { Options, Param } from './types';
  * - `spz` - Niantic Labs compressed format
  * - `sog` - PlayCanvas SOG format (WebP-compressed)
  * - `lcc` - XGrids LCC format
+ * - `lcc2` - XGrids LCC2 (octree) format
  * - `mjs` - JavaScript module generator
  */
-type InputFormat = 'mjs' | 'ksplat' | 'splat' | 'sog' | 'ply' | 'spz' | 'lcc';
+type InputFormat = 'mjs' | 'ksplat' | 'splat' | 'sog' | 'ply' | 'spz' | 'lcc' | 'lcc2';
 
 /**
  * Determines the input format based on file extension.
@@ -60,6 +61,8 @@ const getInputFormat = (filename: string): InputFormat => {
         return 'ply';
     } else if (lowerFilename.endsWith('.spz')) {
         return 'spz';
+    } else if (lowerFilename.endsWith('.lcc2')) {
+        return 'lcc2';
     } else if (lowerFilename.endsWith('.lcc')) {
         return 'lcc';
     }
@@ -135,6 +138,8 @@ const readFile = async (readFileOptions: ReadFileOptions): Promise<DataTable[]> 
         }
     } else if (inputFormat === 'lcc') {
         result = await readLcc(fileSystem, filename, options);
+    } else if (inputFormat === 'lcc2') {
+        result = await readLcc2(fileSystem, filename, options);
     } else {
         const source = await fileSystem.createSource(filename);
         try {

--- a/src/lib/readers/index.ts
+++ b/src/lib/readers/index.ts
@@ -1,5 +1,6 @@
 export { readKsplat } from './read-ksplat';
 export { readLcc } from './read-lcc';
+export { readLcc2 } from './read-lcc2';
 export { readMjs } from './read-mjs';
 export { readPly } from './read-ply';
 export type { PlyData } from './read-ply';

--- a/src/lib/readers/read-lcc2.ts
+++ b/src/lib/readers/read-lcc2.ts
@@ -1,0 +1,461 @@
+import { Column, combine, DataTable } from '../data-table';
+import { readSog } from './read-sog';
+import { readSpz } from './read-spz';
+import { basename, dirname, join, readFile, ReadFileSystem, ZipReadFileSystem } from '../io/read';
+import { Options } from '../types';
+import { logger, Transform } from '../utils';
+
+// Bounded concurrency for chunk decoding. SOG/SPZ decoding is heavier than
+// LCC v1's range reads (WebP decode / WASM calls), so we stay conservative.
+const LOAD_CONCURRENCY = 4;
+
+// LCC2 coordinate transform (matches readLcc).
+const LCC2_TRANSFORM = () => new Transform().fromEulers(90, 0, 180);
+
+// --- Raw meta.lcc2 shapes (pre-normalization, mixed new/old protocol) -------
+
+// Raw octree node. `child` may be an array or a string-keyed object map.
+// Old protocol uses files / child_num / datatype; new protocol uses
+// splatFiles / childNum / dataType.
+type RawLcc2Node = {
+    // Node data: '3dgs' points to this node's main chunk file index; env
+    // points to the optional environment chunk.
+    data?: {
+        '3dgs'?: { name: number };
+        env?: { name: number };
+        [key: string]: any;
+    };
+    // Children: array or { "0": node, "1": node, ... } object map.
+    child?: RawLcc2Node[] | Record<string, RawLcc2Node>;
+
+    // Old protocol fields (need mapping).
+    files?: string[];
+    child_num?: number;
+    datatype?: any;
+
+    // New protocol fields (used directly).
+    splatFiles?: string[];
+    childNum?: number;
+    dataType?: any;
+
+    [key: string]: any;
+};
+
+// Top-level meta.lcc2 raw shape.
+type RawLcc2Meta = {
+    // Old protocol trio (all three must exist to trigger the old branch).
+    total_splats?: number;
+    lod_3dgs_info?: number[];
+    lod_level?: number;
+
+    // New protocol fields.
+    totalSplats?: number;
+    lodSplats?: number[];
+    totalLevels?: number;
+
+    // Unified chunk encoding type; missing is treated as '.sog'.
+    splatType?: '.sog' | '.spz';
+
+    // Bounding box (passed through for downstream/debug use).
+    boundingBox?: any;
+
+    // Octree root node.
+    root: RawLcc2Node;
+
+    [key: string]: any;
+};
+
+// --- Normalized model (post-parse) ------------------------------------------
+
+// Normalized octree node. collectFileIndicesForLod only relies on
+// data['3dgs'].name and child.
+type Lcc2TreeNode = {
+    data?: {
+        '3dgs'?: { name: number };
+        env?: { name: number };
+        [key: string]: any;
+    };
+    child?: Lcc2TreeNode[] | Record<string, Lcc2TreeNode>;
+    splatFiles?: string[];
+    childNum?: number;
+    dataType?: any;
+    [key: string]: any;
+};
+
+// Return value of parseLcc2Meta.
+type Lcc2Meta = {
+    /** Total splat count for the whole scene (old protocol total_splats). */
+    totalSplats: number;
+    /** Per-LOD splat counts (old protocol lod_3dgs_info reversed). */
+    lodSplats: number[];
+    /** Total LOD level count (old protocol lod_level). Basis for LOD_Level = totalLevels - depth. */
+    totalLevels: number;
+    /** Chunk file paths, addressed by file index (root.splatFiles). */
+    splatFiles: string[];
+    /** Unified chunk encoding type, defaults to '.sog'. */
+    splatType: '.sog' | '.spz';
+    /** Bounding box (passed through). */
+    boundingBox: any;
+    /** Optional environment chunk file index (root.data.env.name); undefined if absent. */
+    envFileIndex: number | undefined;
+    /** Octree root node (normalized). */
+    tree: Lcc2TreeNode;
+};
+
+/**
+ * Return the children of an octree node, tolerating both array and
+ * string-keyed object map shapes (and null/undefined).
+ *
+ * @param node - The octree node.
+ * @returns Child nodes as an array (empty when there are none).
+ * @ignore
+ */
+const getChildren = (node: Lcc2TreeNode): Lcc2TreeNode[] => {
+    const c = node.child;
+    if (c === null || c === undefined) {
+        return [];
+    }
+    if (Array.isArray(c)) {
+        return c;
+    }
+    return Object.values(c);
+};
+
+/**
+ * Parse meta.lcc2 text into a normalized {@link Lcc2Meta}.
+ *
+ * Tolerates trailing commas before `}` (non-strict JSON). Handles both the
+ * old protocol (total_splats / lod_3dgs_info / lod_level + files / child_num /
+ * datatype) and the new protocol (canonical field names) field naming.
+ *
+ * @param metaText - Raw meta.lcc2 file contents.
+ * @param filename - Source filename, used to build descriptive parse errors.
+ * @returns Normalized LCC2 meta model.
+ * @ignore
+ */
+const parseLcc2Meta = (metaText: string, filename: string): Lcc2Meta => {
+    // 1) Strip trailing commas before `}` so non-strict JSON still parses.
+    const cleaned = metaText.replace(/,\s*\}/g, '}');
+    let meta: RawLcc2Meta;
+    try {
+        meta = JSON.parse(cleaned) as RawLcc2Meta;
+    } catch (e) {
+        const reason = (e as Error)?.message ?? String(e);
+        throw new Error(
+            `Failed to parse meta.lcc2 as JSON: ${filename}: ${reason}`
+        );
+    }
+
+    // 2) Old protocol compatibility branch: only triggered when all three
+    // legacy fields are present.
+    if (meta.total_splats && meta.lod_3dgs_info && meta.lod_level) {
+        // Recursively normalize node field names.
+        const normalizeNode = (node: RawLcc2Node) => {
+            if (node.datatype !== undefined) {
+                node.dataType = node.datatype;
+            }
+            if (node.child_num !== undefined) {
+                node.childNum = node.child_num;
+            }
+            for (const child of getChildren(node as Lcc2TreeNode)) {
+                normalizeNode(child as RawLcc2Node);
+            }
+        };
+
+        meta.totalSplats = meta.total_splats;
+        meta.lodSplats = [...meta.lod_3dgs_info].reverse();
+        meta.totalLevels = meta.lod_level;
+        // root.files -> root.splatFiles: drop leading '/', append '.sog'.
+        meta.root.splatFiles = (meta.root.files ?? []).map((f) => {
+            let p = f.startsWith('/') ? f.slice(1) : f;
+            if (!p.endsWith('.sog')) {
+                p = `${p}.sog`;
+            }
+            return p;
+        });
+        normalizeNode(meta.root);
+    }
+
+    // 3) env detection.
+    const envFileIndex = meta.root?.data?.env ?
+        meta.root.data.env.name :
+        undefined;
+
+    // 4) Return normalized model.
+    return {
+        totalSplats: meta.totalSplats as number,
+        lodSplats: meta.lodSplats as number[],
+        totalLevels: meta.totalLevels as number,
+        splatFiles: meta.root.splatFiles as string[],
+        splatType: meta.splatType ?? '.sog',
+        boundingBox: meta.boundingBox,
+        envFileIndex,
+        tree: meta.root as Lcc2TreeNode
+    };
+};
+
+/**
+ * Collect the chunk file indices belonging to a target LOD level by traversing
+ * the octree.
+ *
+ * Traversal starts from the root's children with `depth` counting from 1; each
+ * node's LOD level is `totalLevels - depth`. Only nodes carrying `data['3dgs']`
+ * are collected, and indices equal to `envFileIndex` are skipped.
+ *
+ * @param tree - The octree root node.
+ * @param targetLod - The target LOD level to collect.
+ * @param totalLevels - Total LOD level count.
+ * @param envFileIndex - Optional environment chunk file index to exclude.
+ * @returns Set of chunk file indices for the target LOD.
+ * @ignore
+ */
+const collectFileIndicesForLod = (
+    tree: Lcc2TreeNode,
+    targetLod: number,
+    totalLevels: number,
+    envFileIndex: number | undefined
+): Set<number> => {
+    const result = new Set<number>();
+    const traverse = (node: Lcc2TreeNode, depth: number) => {
+        for (const child of getChildren(node)) {
+            const level = totalLevels - depth;
+            if (level === targetLod && child.data?.['3dgs']) {
+                const fileIndex = child.data['3dgs'].name;
+                if (fileIndex !== envFileIndex) {
+                    result.add(fileIndex);
+                }
+            }
+            traverse(child, depth + 1);
+        }
+    };
+    traverse(tree, 1);
+    return result;
+};
+
+/**
+ * Resolve the final ordered list of LOD levels to read.
+ *
+ * Mirrors readLcc's LOD selection, using `totalLevels` as the valid-LOD basis.
+ * Negative indices count from the end; out-of-range indices are filtered out.
+ * An empty selection means "all" levels.
+ *
+ * @param lodSelect - Requested LOD levels (may include negative indices).
+ * @param totalLevels - Total LOD level count.
+ * @returns Ordered list of input LOD levels. Its index is the output LOD index.
+ * @ignore
+ */
+const resolveLodSelection = (
+    lodSelect: number[],
+    totalLevels: number
+): number[] => {
+    if (lodSelect.length > 0) {
+        return lodSelect
+        .map(lod => (lod < 0 ? totalLevels + lod : lod)) // negative -> from end
+        .filter(lod => lod >= 0 && lod < totalLevels); // drop out-of-range
+    }
+    // empty = all [0, totalLevels)
+    return Array.from({ length: totalLevels }, (_, i) => i);
+};
+
+/**
+ * Resolve a chunk file's path, falling back to its basename when the full path
+ * cannot be opened (e.g. drag-and-drop imports that only provide filenames).
+ *
+ * @param fileSystem - File system used to probe the path.
+ * @param fullPath - The full path recorded in meta.lcc2.
+ * @returns The full path if it opens, otherwise its basename.
+ * @ignore
+ */
+const resolveChunkPath = async (
+    fileSystem: ReadFileSystem,
+    fullPath: string
+): Promise<string> => {
+    try {
+        const probe = await fileSystem.createSource(fullPath); // probe whether it opens
+        probe.close(); // close the probe source
+        return fullPath;
+    } catch {
+        return basename(fullPath); // fall back to bare filename
+    }
+};
+
+/**
+ * Decode a single LCC2 chunk file into a {@link DataTable}.
+ *
+ * SOG chunks are ZIP containers decoded via {@link readSog} (wrapped in a
+ * {@link ZipReadFileSystem}); SPZ chunks are raw binaries decoded via
+ * {@link readSpz}. Both return a `Transform.PLY` DataTable.
+ *
+ * @param fileSystem - File system to read the chunk from.
+ * @param splatType - Chunk encoding type ('.sog' or '.spz').
+ * @param path - Resolved chunk file path.
+ * @returns Decoded DataTable.
+ * @ignore
+ */
+const decodeChunk = async (
+    fileSystem: ReadFileSystem,
+    splatType: string,
+    path: string
+): Promise<DataTable> => {
+    if (splatType === '.sog') {
+        const source = await fileSystem.createSource(path);
+        try {
+            const zipFs = new ZipReadFileSystem(source); // SOG is a ZIP container
+            return await readSog(zipFs, 'meta.json'); // call readSog directly to avoid circular deps
+        } finally {
+            source.close();
+        }
+    } else if (splatType === '.spz') {
+        const source = await fileSystem.createSource(path);
+        try {
+            return await readSpz(source); // SPZ is a raw binary
+        } finally {
+            source.close();
+        }
+    }
+    throw new Error(`Unsupported LCC2 splatType: ${splatType}`);
+};
+
+/**
+ * Reads an XGrids LCC2 format containing multi-LOD Gaussian splat data.
+ *
+ * Unlike LCC v1 (quadtree + single data.bin/shcoef.bin), LCC2 uses an octree
+ * spatial structure where each node's data is an independent `.sog` / `.spz`
+ * chunk file, described by a `meta.lcc2` (JSON) file listing the tree, file
+ * paths, LOD levels and bounding box.
+ *
+ * Chunks for the selected LODs are decoded (reusing the internal `readSog` /
+ * `readSpz` decoders), tagged with an output `lod` column, combined into a
+ * single DataTable and re-tagged with the LCC2 coordinate transform. An
+ * optional environment chunk is loaded as an additional table (lod = -1).
+ *
+ * Behavior (multi-LOD selection, `lod` column, coordinate transform) mirrors
+ * `readLcc`.
+ *
+ * @param fileSystem - File system for reading the LCC2 files.
+ * @param filename - Path to the meta.lcc2 file.
+ * @param options - Options including LOD selection via `lodSelect`.
+ * @returns Promise resolving to an array of DataTables (combined LODs + optional environment).
+ * @ignore
+ */
+const readLcc2 = async (
+    fileSystem: ReadFileSystem,
+    filename: string,
+    options: Options
+): Promise<DataTable[]> => {
+    // 1) Read and parse meta.lcc2.
+    const baseDir = dirname(filename);
+    const related = (name: string) => (baseDir ? join(baseDir, name) : name);
+    const metaBytes = await readFile(fileSystem, filename);
+    const meta = parseLcc2Meta(new TextDecoder().decode(metaBytes), filename);
+    const { totalLevels, splatFiles, splatType, envFileIndex, tree } = meta;
+
+    // 2) Resolve LOD selection.
+    const inputLods = resolveLodSelection(options.lodSelect, totalLevels);
+    if (inputLods.length === 0) {
+        throw new Error(
+            `No valid LODs selected for LCC2 input file: ${filename} lods: ${JSON.stringify(options.lodSelect)}`
+        );
+    }
+
+    // 3) Collect decode tasks in deterministic order: by LOD order, then by
+    // ascending file index within each LOD.
+    const tasks: { outputLod: number; fileIndex: number }[] = [];
+    for (let outputLod = 0; outputLod < inputLods.length; outputLod++) {
+        const inputLod = inputLods[outputLod];
+        const indices = Array.from(
+            collectFileIndicesForLod(tree, inputLod, totalLevels, envFileIndex)
+        ).sort((a, b) => a - b);
+        for (const fileIndex of indices) {
+            tasks.push({ outputLod, fileIndex });
+        }
+    }
+
+    // No decodable chunks for the selected LODs: bail out with a descriptive
+    // error rather than letting combine() throw on an empty array below.
+    if (tasks.length === 0) {
+        throw new Error(
+            `No chunks found for selected LODs in LCC2 input file: ${filename} lods: ${JSON.stringify(inputLods)}`
+        );
+    }
+
+    // 4) Pre-allocate output slots so combine input order stays reproducible.
+    // Every slot is filled by exactly one worker below; any decode failure
+    // rejects Promise.all and aborts before combine, so there are no holes.
+    const tables: DataTable[] = new Array(tasks.length);
+
+    // 5) One progress bar covering all chunks.
+    const bar = logger.bar('decoding', tasks.length);
+    let done = 0;
+
+    // 6) Bounded-concurrency worker pool. Any failure here propagates: the bar
+    // is intentionally not end()ed on the error path, leaving it open so
+    // logger's error path can mark it as failed instead of finalizing it first.
+    let next = 0;
+    const worker = async () => {
+        while (true) {
+            const i = next++;
+            if (i >= tasks.length) break;
+            const task = tasks[i];
+            const fullPath = related(splatFiles[task.fileIndex]);
+            const path = await resolveChunkPath(fileSystem, fullPath);
+            const dt = await decodeChunk(fileSystem, splatType, path);
+            // Write lod column = output LOD index.
+            dt.addColumn(
+                new Column('lod', new Float32Array(dt.numRows).fill(task.outputLod))
+            );
+            tables[i] = dt; // write pre-allocated slot (no push, keeps order)
+            bar.update(++done);
+        }
+    };
+    await Promise.all(
+        Array.from({ length: Math.min(LOAD_CONCURRENCY, tasks.length) }, () => worker())
+    );
+
+    // 7) Combine + override transform.
+    const merged = combine(tables);
+    merged.transform = LCC2_TRANSFORM();
+    // Close the bar only on success path.
+    bar.end();
+
+    const result: DataTable[] = [merged];
+
+    // 8) Optional environment chunk (approach B): a missing file is normal.
+    if (envFileIndex !== undefined) {
+        try {
+            const envFull = related(splatFiles[envFileIndex]);
+            const envPath = await resolveChunkPath(fileSystem, envFull);
+            const envTable = await decodeChunk(fileSystem, splatType, envPath);
+            envTable.addColumn(
+                new Column('lod', new Float32Array(envTable.numRows).fill(-1))
+            );
+            envTable.transform = LCC2_TRANSFORM();
+            result.push(envTable);
+        } catch (err) {
+            const code = (err as { code?: string })?.code;
+            const message = (err as Error)?.message ?? '';
+            const isMissing = code === 'ENOENT' ||
+                message.startsWith('Entry not found') ||
+                message.startsWith('HTTP error 404');
+            if (!isMissing) {
+                logger.warn(`failed to load LCC2 environment chunk: ${message || err}`);
+            }
+        }
+    }
+
+    return result;
+};
+
+export {
+    LOAD_CONCURRENCY,
+    LCC2_TRANSFORM,
+    parseLcc2Meta,
+    getChildren,
+    collectFileIndicesForLod,
+    resolveLodSelection,
+    resolveChunkPath,
+    decodeChunk,
+    readLcc2
+};
+
+export type { RawLcc2Node, RawLcc2Meta, Lcc2TreeNode, Lcc2Meta };

--- a/src/lib/readers/read-lcc2.ts
+++ b/src/lib/readers/read-lcc2.ts
@@ -1,7 +1,7 @@
 import { Column, combine, DataTable } from '../data-table';
 import { readSog } from './read-sog';
 import { readSpz } from './read-spz';
-import { basename, dirname, join, readFile, ReadFileSystem, ZipReadFileSystem } from '../io/read';
+import { basename, dirname, join, readFile, ReadFileSystem, ReadSource, ZipReadFileSystem } from '../io/read';
 import { Options } from '../types';
 import { logger, Transform } from '../utils';
 
@@ -147,8 +147,14 @@ const parseLcc2Meta = (metaText: string, filename: string): Lcc2Meta => {
     }
 
     // 2) Old protocol compatibility branch: only triggered when all three
-    // legacy fields are present.
-    if (meta.total_splats && meta.lod_3dgs_info && meta.lod_level) {
+    // legacy fields are present. Use explicit presence checks (not truthiness)
+    // so legitimate zero values (e.g. total_splats: 0, lod_level: 0) don't
+    // incorrectly skip the legacy normalization branch.
+    if (
+        meta.total_splats !== undefined &&
+        meta.lod_3dgs_info !== undefined &&
+        meta.lod_level !== undefined
+    ) {
         // Recursively normalize node field names.
         const normalizeNode = (node: RawLcc2Node) => {
             if (node.datatype !== undefined) {
@@ -181,12 +187,37 @@ const parseLcc2Meta = (metaText: string, filename: string): Lcc2Meta => {
         meta.root.data.env.name :
         undefined;
 
-    // 4) Return normalized model.
+    // 4) Validate required fields rather than masking absence with type
+    // assertions. totalLevels and root.splatFiles are mandatory for the reader
+    // to resolve LODs and address chunk files; totalSplats / lodSplats are
+    // scene metadata that downstream consumers may rely on.
+    if (typeof meta.totalLevels !== 'number') {
+        throw new Error(
+            `Invalid meta.lcc2 (missing or non-numeric totalLevels): ${filename}`
+        );
+    }
+    if (!Array.isArray(meta.root?.splatFiles)) {
+        throw new Error(
+            `Invalid meta.lcc2 (missing root.splatFiles): ${filename}`
+        );
+    }
+    if (typeof meta.totalSplats !== 'number') {
+        throw new Error(
+            `Invalid meta.lcc2 (missing or non-numeric totalSplats): ${filename}`
+        );
+    }
+    if (!Array.isArray(meta.lodSplats)) {
+        throw new Error(
+            `Invalid meta.lcc2 (missing lodSplats): ${filename}`
+        );
+    }
+
+    // 5) Return normalized model.
     return {
-        totalSplats: meta.totalSplats as number,
-        lodSplats: meta.lodSplats as number[],
-        totalLevels: meta.totalLevels as number,
-        splatFiles: meta.root.splatFiles as string[],
+        totalSplats: meta.totalSplats,
+        lodSplats: meta.lodSplats,
+        totalLevels: meta.totalLevels,
+        splatFiles: meta.root.splatFiles,
         splatType: meta.splatType ?? '.sog',
         boundingBox: meta.boundingBox,
         envFileIndex,
@@ -258,24 +289,57 @@ const resolveLodSelection = (
 };
 
 /**
- * Resolve a chunk file's path, falling back to its basename when the full path
- * cannot be opened (e.g. drag-and-drop imports that only provide filenames).
+ * Whether an error from opening/decoding a chunk indicates the file is simply
+ * missing (as opposed to a permission, I/O or corruption error). Covers Node's
+ * `ENOENT`, the zip/memory file systems' "Entry not found" and HTTP 404.
  *
- * @param fileSystem - File system used to probe the path.
- * @param fullPath - The full path recorded in meta.lcc2.
- * @returns The full path if it opens, otherwise its basename.
+ * @param err - The thrown error.
+ * @returns True if the error means the file was not found.
  * @ignore
  */
-const resolveChunkPath = async (
+const isMissingError = (err: unknown): boolean => {
+    const code = (err as { code?: string })?.code;
+    const message = (err as Error)?.message ?? '';
+    return code === 'ENOENT' ||
+        message.startsWith('Entry not found') ||
+        message.startsWith('HTTP error 404');
+};
+
+/**
+ * Open a chunk file's read source, trying the full path first and falling back
+ * to its basename only when the full path is not found (e.g. drag-and-drop
+ * imports that provide filenames without directories).
+ *
+ * The happy path opens the file exactly once. The basename retry only runs when
+ * the full path is missing, so remote/HTTP file systems avoid a redundant probe
+ * round-trip per chunk. Non-"missing" failures (permission, I/O, corruption)
+ * are surfaced immediately rather than masked by a basename retry. If the
+ * fallback also fails, the original (full-path) error is surfaced as it is the
+ * more informative one.
+ *
+ * @param fileSystem - File system used to open the chunk.
+ * @param fullPath - The full path recorded in meta.lcc2.
+ * @returns An open {@link ReadSource} for the chunk.
+ * @ignore
+ */
+const openChunkSource = async (
     fileSystem: ReadFileSystem,
     fullPath: string
-): Promise<string> => {
+): Promise<ReadSource> => {
     try {
-        const probe = await fileSystem.createSource(fullPath); // probe whether it opens
-        probe.close(); // close the probe source
-        return fullPath;
-    } catch {
-        return basename(fullPath); // fall back to bare filename
+        return await fileSystem.createSource(fullPath);
+    } catch (err) {
+        const base = basename(fullPath);
+        // Only retry with the bare filename when the full path is genuinely
+        // missing; other failures are real and must not be masked.
+        if (!isMissingError(err) || base === fullPath) {
+            throw err;
+        }
+        try {
+            return await fileSystem.createSource(base); // fall back to bare filename
+        } catch {
+            throw err; // surface the original full-path error
+        }
     }
 };
 
@@ -284,36 +348,37 @@ const resolveChunkPath = async (
  *
  * SOG chunks are ZIP containers decoded via {@link readSog} (wrapped in a
  * {@link ZipReadFileSystem}); SPZ chunks are raw binaries decoded via
- * {@link readSpz}. Both return a `Transform.PLY` DataTable.
+ * {@link readSpz}. Both return a `Transform.PLY` DataTable. The chunk source is
+ * opened once (full path, with a basename fallback) and always closed.
  *
  * @param fileSystem - File system to read the chunk from.
  * @param splatType - Chunk encoding type ('.sog' or '.spz').
- * @param path - Resolved chunk file path.
+ * @param fullPath - The chunk file path recorded in meta.lcc2.
  * @returns Decoded DataTable.
  * @ignore
  */
 const decodeChunk = async (
     fileSystem: ReadFileSystem,
     splatType: string,
-    path: string
+    fullPath: string
 ): Promise<DataTable> => {
-    if (splatType === '.sog') {
-        const source = await fileSystem.createSource(path);
-        try {
+    const source = await openChunkSource(fileSystem, fullPath);
+    try {
+        if (splatType === '.sog') {
             const zipFs = new ZipReadFileSystem(source); // SOG is a ZIP container
-            return await readSog(zipFs, 'meta.json'); // call readSog directly to avoid circular deps
-        } finally {
-            source.close();
+            try {
+                return await readSog(zipFs, 'meta.json'); // call readSog directly to avoid circular deps
+            } finally {
+                zipFs.close(); // close the zip wrapper (also closes the source)
+            }
         }
-    } else if (splatType === '.spz') {
-        const source = await fileSystem.createSource(path);
-        try {
+        if (splatType === '.spz') {
             return await readSpz(source); // SPZ is a raw binary
-        } finally {
-            source.close();
         }
+        throw new Error(`Unsupported LCC2 splatType: ${splatType}`);
+    } finally {
+        source.close(); // idempotent; safe even after zipFs closed it
     }
-    throw new Error(`Unsupported LCC2 splatType: ${splatType}`);
 };
 
 /**
@@ -398,8 +463,7 @@ const readLcc2 = async (
             if (i >= tasks.length) break;
             const task = tasks[i];
             const fullPath = related(splatFiles[task.fileIndex]);
-            const path = await resolveChunkPath(fileSystem, fullPath);
-            const dt = await decodeChunk(fileSystem, splatType, path);
+            const dt = await decodeChunk(fileSystem, splatType, fullPath);
             // Write lod column = output LOD index.
             dt.addColumn(
                 new Column('lod', new Float32Array(dt.numRows).fill(task.outputLod))
@@ -424,20 +488,15 @@ const readLcc2 = async (
     if (envFileIndex !== undefined) {
         try {
             const envFull = related(splatFiles[envFileIndex]);
-            const envPath = await resolveChunkPath(fileSystem, envFull);
-            const envTable = await decodeChunk(fileSystem, splatType, envPath);
+            const envTable = await decodeChunk(fileSystem, splatType, envFull);
             envTable.addColumn(
                 new Column('lod', new Float32Array(envTable.numRows).fill(-1))
             );
             envTable.transform = LCC2_TRANSFORM();
             result.push(envTable);
         } catch (err) {
-            const code = (err as { code?: string })?.code;
-            const message = (err as Error)?.message ?? '';
-            const isMissing = code === 'ENOENT' ||
-                message.startsWith('Entry not found') ||
-                message.startsWith('HTTP error 404');
-            if (!isMissing) {
+            if (!isMissingError(err)) {
+                const message = (err as Error)?.message ?? '';
                 logger.warn(`failed to load LCC2 environment chunk: ${message || err}`);
             }
         }
@@ -453,7 +512,8 @@ export {
     getChildren,
     collectFileIndicesForLod,
     resolveLodSelection,
-    resolveChunkPath,
+    isMissingError,
+    openChunkSource,
     decodeChunk,
     readLcc2
 };

--- a/test/read-lcc2.test.mjs
+++ b/test/read-lcc2.test.mjs
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for the LCC2 reader's pure helpers.
+ * Covers meta parsing (new/legacy protocols), octree LOD collection,
+ * and LOD selection resolution.
+ */
+
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+    parseLcc2Meta,
+    getChildren,
+    collectFileIndicesForLod,
+    resolveLodSelection
+} from '../src/lib/readers/read-lcc2.js';
+
+describe('parseLcc2Meta', () => {
+    it('parses the new protocol verbatim', () => {
+        const meta = parseLcc2Meta(
+            JSON.stringify({
+                totalSplats: 100,
+                lodSplats: [60, 40],
+                totalLevels: 2,
+                splatType: '.sog',
+                root: { splatFiles: ['a.sog', 'b.sog'], data: { env: { name: 1 } } }
+            }),
+            'meta.lcc2'
+        );
+
+        assert.strictEqual(meta.totalSplats, 100);
+        assert.deepStrictEqual(meta.lodSplats, [60, 40]);
+        assert.strictEqual(meta.totalLevels, 2);
+        assert.strictEqual(meta.splatType, '.sog');
+        assert.deepStrictEqual(meta.splatFiles, ['a.sog', 'b.sog']);
+        assert.strictEqual(meta.envFileIndex, 1);
+    });
+
+    it('maps legacy protocol fields and normalizes file names', () => {
+        const meta = parseLcc2Meta(
+            JSON.stringify({
+                total_splats: 50,
+                lod_3dgs_info: [10, 40],
+                lod_level: 2,
+                root: {
+                    files: ['/a', '/b.sog'],
+                    child_num: 1,
+                    child: [{ child_num: 0, datatype: 'x' }]
+                }
+            }),
+            'meta.lcc2'
+        );
+
+        assert.strictEqual(meta.totalSplats, 50);
+        // lod_3dgs_info is reversed
+        assert.deepStrictEqual(meta.lodSplats, [40, 10]);
+        assert.strictEqual(meta.totalLevels, 2);
+        // leading '/' dropped, '.sog' appended when missing
+        assert.deepStrictEqual(meta.splatFiles, ['a.sog', 'b.sog']);
+        // child_num -> childNum recursively; datatype -> dataType
+        assert.strictEqual(meta.tree.childNum, 1);
+        assert.strictEqual(meta.tree.child[0].childNum, 0);
+        assert.strictEqual(meta.tree.child[0].dataType, 'x');
+    });
+
+    it('defaults splatType to .sog when absent', () => {
+        const meta = parseLcc2Meta(
+            JSON.stringify({
+                totalLevels: 1,
+                root: { splatFiles: ['a.sog'] }
+            }),
+            'meta.lcc2'
+        );
+        assert.strictEqual(meta.splatType, '.sog');
+        assert.strictEqual(meta.envFileIndex, undefined);
+    });
+
+    it('tolerates trailing commas before braces', () => {
+        const meta = parseLcc2Meta(
+            '{ "totalLevels": 1, "root": { "splatFiles": ["a.sog"], } , }',
+            'meta.lcc2'
+        );
+        assert.strictEqual(meta.totalLevels, 1);
+        assert.deepStrictEqual(meta.splatFiles, ['a.sog']);
+    });
+
+    it('throws a descriptive error on invalid JSON', () => {
+        assert.throws(
+            () => parseLcc2Meta('{ not json', 'bad.lcc2'),
+            /Failed to parse meta\.lcc2 as JSON: bad\.lcc2/
+        );
+    });
+});
+
+describe('getChildren', () => {
+    it('returns [] when child is absent', () => {
+        assert.deepStrictEqual(getChildren({}), []);
+    });
+
+    it('returns array children as-is', () => {
+        const a = { id: 0 };
+        const b = { id: 1 };
+        assert.deepStrictEqual(getChildren({ child: [a, b] }), [a, b]);
+    });
+
+    it('returns values of an object-map child', () => {
+        const a = { id: 0 };
+        const b = { id: 1 };
+        assert.deepStrictEqual(getChildren({ child: { 0: a, 1: b } }), [a, b]);
+    });
+});
+
+describe('collectFileIndicesForLod', () => {
+    // depth counts from 1 at the root's children; level = totalLevels - depth.
+    // totalLevels = 2: depth 1 -> level 1, depth 2 -> level 0 (finest).
+    const tree = {
+        child: [
+            {
+                data: { '3dgs': { name: 0 } },
+                child: [
+                    { data: { '3dgs': { name: 1 } } },
+                    { data: { '3dgs': { name: 2 } } }
+                ]
+            }
+        ]
+    };
+
+    it('collects the deepest nodes for LOD 0', () => {
+        const set = collectFileIndicesForLod(tree, 0, 2, undefined);
+        assert.deepStrictEqual(
+            [...set].sort((a, b) => a - b),
+            [1, 2]
+        );
+    });
+
+    it('collects shallower nodes for higher LOD', () => {
+        const set = collectFileIndicesForLod(tree, 1, 2, undefined);
+        assert.deepStrictEqual([...set], [0]);
+    });
+
+    it('skips the environment file index', () => {
+        const set = collectFileIndicesForLod(tree, 0, 2, 2);
+        assert.deepStrictEqual([...set], [1]);
+    });
+
+    it('handles object-map children', () => {
+        const mapTree = { child: { 0: { data: { '3dgs': { name: 7 } } } } };
+        const set = collectFileIndicesForLod(mapTree, 0, 1, undefined);
+        assert.deepStrictEqual([...set], [7]);
+    });
+});
+
+describe('resolveLodSelection', () => {
+    it('returns all levels for an empty selection', () => {
+        assert.deepStrictEqual(resolveLodSelection([], 3), [0, 1, 2]);
+    });
+
+    it('maps negative indices from the end', () => {
+        assert.deepStrictEqual(resolveLodSelection([-1], 3), [2]);
+    });
+
+    it('filters out-of-range indices', () => {
+        assert.deepStrictEqual(resolveLodSelection([0, 3, -4], 3), [0]);
+    });
+
+    it('preserves order and duplicates of the selection', () => {
+        assert.deepStrictEqual(resolveLodSelection([2, 0], 3), [2, 0]);
+    });
+});

--- a/test/read-lcc2.test.mjs
+++ b/test/read-lcc2.test.mjs
@@ -1,18 +1,32 @@
 /**
- * Unit tests for the LCC2 reader's pure helpers.
- * Covers meta parsing (new/legacy protocols), octree LOD collection,
- * and LOD selection resolution.
+ * Unit tests for the LCC2 reader.
+ *
+ * Covers the pure helpers (meta parsing for new/legacy protocols, octree LOD
+ * collection, LOD selection) and the main readLcc2 flow (deterministic task
+ * ordering, the output lod column, environment-chunk handling and failure
+ * modes), exercised against in-memory .spz chunks built with writeSpz.
  */
 
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
+import { createTestDataTable } from './helpers/test-utils.mjs';
+import {
+    MemoryReadFileSystem,
+    MemoryFileSystem,
+    writeSpz
+} from '../src/lib/index.js';
 import {
     parseLcc2Meta,
     getChildren,
     collectFileIndicesForLod,
-    resolveLodSelection
+    resolveLodSelection,
+    isMissingError,
+    openChunkSource,
+    readLcc2,
+    LOAD_CONCURRENCY
 } from '../src/lib/readers/read-lcc2.js';
+
 
 describe('parseLcc2Meta', () => {
     it('parses the new protocol verbatim', () => {
@@ -62,9 +76,29 @@ describe('parseLcc2Meta', () => {
         assert.strictEqual(meta.tree.child[0].dataType, 'x');
     });
 
+    it('detects the legacy protocol even when total_splats is 0', () => {
+        // Presence (not truthiness) must drive legacy detection so a genuine
+        // zero count still maps the legacy fields.
+        const meta = parseLcc2Meta(
+            JSON.stringify({
+                total_splats: 0,
+                lod_3dgs_info: [0],
+                lod_level: 1,
+                root: { files: ['/a'] }
+            }),
+            'meta.lcc2'
+        );
+        assert.strictEqual(meta.totalSplats, 0);
+        assert.deepStrictEqual(meta.lodSplats, [0]);
+        assert.strictEqual(meta.totalLevels, 1);
+        assert.deepStrictEqual(meta.splatFiles, ['a.sog']);
+    });
+
     it('defaults splatType to .sog when absent', () => {
         const meta = parseLcc2Meta(
             JSON.stringify({
+                totalSplats: 1,
+                lodSplats: [1],
                 totalLevels: 1,
                 root: { splatFiles: ['a.sog'] }
             }),
@@ -76,7 +110,7 @@ describe('parseLcc2Meta', () => {
 
     it('tolerates trailing commas before braces', () => {
         const meta = parseLcc2Meta(
-            '{ "totalLevels": 1, "root": { "splatFiles": ["a.sog"], } , }',
+            '{ "totalSplats": 1, "lodSplats": [1], "totalLevels": 1, "root": { "splatFiles": ["a.sog"], } , }',
             'meta.lcc2'
         );
         assert.strictEqual(meta.totalLevels, 1);
@@ -87,6 +121,46 @@ describe('parseLcc2Meta', () => {
         assert.throws(
             () => parseLcc2Meta('{ not json', 'bad.lcc2'),
             /Failed to parse meta\.lcc2 as JSON: bad\.lcc2/
+        );
+    });
+
+    it('throws when totalLevels is missing', () => {
+        assert.throws(
+            () => parseLcc2Meta(
+                JSON.stringify({ totalSplats: 1, lodSplats: [1], root: { splatFiles: ['a.sog'] } }),
+                'meta.lcc2'
+            ),
+            /missing or non-numeric totalLevels/
+        );
+    });
+
+    it('throws when root.splatFiles is missing', () => {
+        assert.throws(
+            () => parseLcc2Meta(
+                JSON.stringify({ totalSplats: 1, lodSplats: [1], totalLevels: 1, root: {} }),
+                'meta.lcc2'
+            ),
+            /missing root\.splatFiles/
+        );
+    });
+
+    it('throws when totalSplats is missing', () => {
+        assert.throws(
+            () => parseLcc2Meta(
+                JSON.stringify({ lodSplats: [1], totalLevels: 1, root: { splatFiles: ['a.sog'] } }),
+                'meta.lcc2'
+            ),
+            /missing or non-numeric totalSplats/
+        );
+    });
+
+    it('throws when lodSplats is missing', () => {
+        assert.throws(
+            () => parseLcc2Meta(
+                JSON.stringify({ totalSplats: 1, totalLevels: 1, root: { splatFiles: ['a.sog'] } }),
+                'meta.lcc2'
+            ),
+            /missing lodSplats/
         );
     });
 });
@@ -164,5 +238,293 @@ describe('resolveLodSelection', () => {
 
     it('preserves order and duplicates of the selection', () => {
         assert.deepStrictEqual(resolveLodSelection([2, 0], 3), [2, 0]);
+    });
+});
+
+// --- Main readLcc2 flow -----------------------------------------------------
+
+// Build an in-memory .spz chunk with the given number of splats.
+const makeSpzBytes = async (count) => {
+    const writeFs = new MemoryFileSystem();
+    await writeSpz(
+        { filename: 'chunk.spz', dataTable: createTestDataTable(count) },
+        writeFs
+    );
+    return writeFs.results.get('chunk.spz');
+};
+
+// Default options for readLcc2 (only lodSelect matters here).
+const opts = (lodSelect = []) => ({ lodSelect });
+
+describe('readLcc2 (main flow)', () => {
+    it('orders chunks by LOD then ascending file index and tags the lod column', async () => {
+        // totalLevels = 2. LOD 0 (finest) = depth-2 nodes (files 2, 3);
+        // LOD 1 = depth-1 node (file 1). Distinct splat counts let us verify
+        // both ordering and the per-chunk lod tag.
+        const fs = new MemoryReadFileSystem();
+        fs.set('chunk1.spz', await makeSpzBytes(5)); // LOD 1
+        fs.set('chunk2.spz', await makeSpzBytes(3)); // LOD 0
+        fs.set('chunk3.spz', await makeSpzBytes(4)); // LOD 0
+
+        const meta = {
+            totalSplats: 12,
+            lodSplats: [7, 5],
+            totalLevels: 2,
+            splatType: '.spz',
+            root: {
+                splatFiles: ['', 'chunk1.spz', 'chunk2.spz', 'chunk3.spz'],
+                child: [
+                    {
+                        data: { '3dgs': { name: 1 } },
+                        child: [
+                            { data: { '3dgs': { name: 2 } } },
+                            { data: { '3dgs': { name: 3 } } }
+                        ]
+                    }
+                ]
+            }
+        };
+        fs.set('meta.lcc2', new TextEncoder().encode(JSON.stringify(meta)));
+
+        const result = await readLcc2(fs, 'meta.lcc2', opts());
+        assert.strictEqual(result.length, 1);
+
+        const merged = result[0];
+        // 3 + 4 (LOD 0) + 5 (LOD 1) = 12 splats.
+        assert.strictEqual(merged.numRows, 12);
+
+        // Output order: LOD 0 first (files 2 then 3), then LOD 1 (file 1).
+        const lod = merged.getColumnByName('lod').data;
+        assert.deepStrictEqual(
+            Array.from(lod),
+            [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1]
+        );
+    });
+
+    it('returns the environment chunk as a second table tagged lod = -1', async () => {
+        const fs = new MemoryReadFileSystem();
+        fs.set('main.spz', await makeSpzBytes(4));
+        fs.set('env.spz', await makeSpzBytes(2));
+
+        const meta = {
+            totalSplats: 4,
+            lodSplats: [4],
+            totalLevels: 1,
+            splatType: '.spz',
+            root: {
+                splatFiles: ['main.spz', 'env.spz'],
+                data: { env: { name: 1 } },
+                child: [{ data: { '3dgs': { name: 0 } } }]
+            }
+        };
+        fs.set('meta.lcc2', new TextEncoder().encode(JSON.stringify(meta)));
+
+        const result = await readLcc2(fs, 'meta.lcc2', opts());
+        assert.strictEqual(result.length, 2);
+
+        const env = result[1];
+        assert.strictEqual(env.numRows, 2);
+        assert.ok(Array.from(env.getColumnByName('lod').data).every(v => v === -1));
+    });
+
+    it('ignores a missing environment chunk without throwing', async () => {
+        const fs = new MemoryReadFileSystem();
+        fs.set('main.spz', await makeSpzBytes(4));
+        // env.spz declared in meta but intentionally not provided.
+
+        const meta = {
+            totalSplats: 4,
+            lodSplats: [4],
+            totalLevels: 1,
+            splatType: '.spz',
+            root: {
+                splatFiles: ['main.spz', 'env.spz'],
+                data: { env: { name: 1 } },
+                child: [{ data: { '3dgs': { name: 0 } } }]
+            }
+        };
+        fs.set('meta.lcc2', new TextEncoder().encode(JSON.stringify(meta)));
+
+        const result = await readLcc2(fs, 'meta.lcc2', opts());
+        // Only the main table; the absent env chunk is treated as normal.
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].numRows, 4);
+    });
+
+    it('throws when the selected LODs contain no decodable chunks', async () => {
+        const fs = new MemoryReadFileSystem();
+        // Root has no '3dgs' nodes at all, so no chunk is collected.
+        const meta = {
+            totalSplats: 0,
+            lodSplats: [0],
+            totalLevels: 1,
+            splatType: '.spz',
+            root: { splatFiles: ['main.spz'], child: [] }
+        };
+        fs.set('meta.lcc2', new TextEncoder().encode(JSON.stringify(meta)));
+
+        await assert.rejects(
+            () => readLcc2(fs, 'meta.lcc2', opts()),
+            /No chunks found for selected LODs/
+        );
+    });
+
+    it('propagates a decode failure for a missing main chunk', async () => {
+        const fs = new MemoryReadFileSystem();
+        // meta references main.spz but the file is absent: a main-chunk read
+        // failure must reject (unlike the optional environment chunk).
+        const meta = {
+            totalSplats: 4,
+            lodSplats: [4],
+            totalLevels: 1,
+            splatType: '.spz',
+            root: {
+                splatFiles: ['main.spz'],
+                child: [{ data: { '3dgs': { name: 0 } } }]
+            }
+        };
+        fs.set('meta.lcc2', new TextEncoder().encode(JSON.stringify(meta)));
+
+        await assert.rejects(() => readLcc2(fs, 'meta.lcc2', opts()));
+    });
+});
+
+// A ReadFileSystem stub whose createSource fails with a controllable error,
+// recording which paths were attempted. Lets us verify the fallback policy
+// without real files.
+class FailingReadFileSystem {
+    constructor(error, openable = new Map()) {
+        this.error = error;
+        this.openable = openable; // path -> Uint8Array that opens successfully
+        this.attempts = [];
+    }
+
+    createSource(filename) {
+        this.attempts.push(filename);
+        const data = this.openable.get(filename);
+        if (data) {
+            return Promise.resolve({
+                size: data.length,
+                seekable: true,
+                read: () => {
+                    throw new Error('not used');
+                },
+                close: () => {}
+            });
+        }
+        return Promise.reject(this.error);
+    }
+}
+
+describe('isMissingError', () => {
+    it('recognizes ENOENT, Entry not found and HTTP 404', () => {
+        assert.strictEqual(isMissingError({ code: 'ENOENT' }), true);
+        assert.strictEqual(isMissingError(new Error('Entry not found: a.spz')), true);
+        assert.strictEqual(isMissingError(new Error('HTTP error 404')), true);
+    });
+
+    it('treats other errors as non-missing', () => {
+        assert.strictEqual(isMissingError(new Error('EACCES: permission denied')), false);
+        assert.strictEqual(isMissingError(new Error('HTTP error 500')), false);
+        assert.strictEqual(isMissingError(undefined), false);
+    });
+});
+
+describe('openChunkSource', () => {
+    it('does not fall back to basename on a non-missing error', async () => {
+        const err = new Error('EACCES: permission denied');
+        const fs = new FailingReadFileSystem(err);
+
+        await assert.rejects(() => openChunkSource(fs, 'dir/chunk.spz'), /EACCES/);
+        // Only the full path is attempted; no basename retry on a real error.
+        assert.deepStrictEqual(fs.attempts, ['dir/chunk.spz']);
+    });
+
+    it('falls back to basename only when the full path is missing', async () => {
+        const data = new Uint8Array([1, 2, 3]);
+        const fs = new FailingReadFileSystem(
+            new Error('Entry not found: dir/chunk.spz'),
+            new Map([['chunk.spz', data]])
+        );
+
+        const source = await openChunkSource(fs, 'dir/chunk.spz');
+        assert.strictEqual(source.size, 3);
+        // Full path tried first, then the bare filename.
+        assert.deepStrictEqual(fs.attempts, ['dir/chunk.spz', 'chunk.spz']);
+    });
+
+    it('does not retry when the path has no directory component', async () => {
+        const fs = new FailingReadFileSystem(new Error('Entry not found: chunk.spz'));
+
+        await assert.rejects(() => openChunkSource(fs, 'chunk.spz'), /Entry not found/);
+        // basename === fullPath, so no second attempt.
+        assert.deepStrictEqual(fs.attempts, ['chunk.spz']);
+    });
+});
+
+// Wraps a MemoryReadFileSystem and tracks how many createSource calls are
+// in flight at once, so we can assert the worker pool honours its bound.
+class ConcurrencyTrackingFileSystem {
+    constructor(inner) {
+        this.inner = inner;
+        this.inFlight = 0;
+        this.peak = 0;
+    }
+
+    async createSource(filename) {
+        this.inFlight++;
+        this.peak = Math.max(this.peak, this.inFlight);
+        try {
+            // Yield to the event loop so overlapping workers accumulate before
+            // any single open resolves; this makes the peak observable.
+            await new Promise((resolve) => {
+                setTimeout(resolve, 5);
+            });
+            return await this.inner.createSource(filename);
+        } finally {
+            this.inFlight--;
+        }
+    }
+}
+
+describe('readLcc2 (bounded concurrency)', () => {
+    it('never decodes more than LOAD_CONCURRENCY chunks at once', async () => {
+        const inner = new MemoryReadFileSystem();
+        // More chunks than the concurrency bound so the limit is exercised.
+        const chunkCount = LOAD_CONCURRENCY * 2 + 1;
+        const splatFiles = [];
+        const child = [];
+        // Build all chunk bytes in parallel to avoid awaiting inside the loop.
+        const allBytes = await Promise.all(
+            Array.from({ length: chunkCount }, () => makeSpzBytes(1))
+        );
+        for (let i = 0; i < chunkCount; i++) {
+            const name = `chunk${i}.spz`;
+            inner.set(name, allBytes[i]);
+            splatFiles.push(name);
+            child.push({ data: { '3dgs': { name: i } } });
+        }
+
+        const meta = {
+            totalSplats: chunkCount,
+            lodSplats: [chunkCount],
+            totalLevels: 1,
+            splatType: '.spz',
+            root: { splatFiles, child }
+        };
+        inner.set('meta.lcc2', new TextEncoder().encode(JSON.stringify(meta)));
+
+        const fs = new ConcurrencyTrackingFileSystem(inner);
+        const result = await readLcc2(fs, 'meta.lcc2', opts());
+
+        // All chunks decoded into a single combined table...
+        assert.strictEqual(result[0].numRows, chunkCount);
+        // ...but never more than the bound ran concurrently, and the pool did
+        // actually run in parallel (peak > 1) rather than serially.
+        assert.ok(
+            fs.peak <= LOAD_CONCURRENCY,
+            `peak concurrency ${fs.peak} exceeded bound ${LOAD_CONCURRENCY}`
+        );
+        assert.ok(fs.peak > 1, `expected parallel decoding, peak was ${fs.peak}`);
     });
 });


### PR DESCRIPTION
- Added the `readLcc2` function to parse an XGrids LCC2 scene consisting of a `meta.lcc2` descriptor and separate `.sog/.spz` data block files.

- Added the `src/lib/readers/read-lcc2.ts` file: parses the `meta.lcc2` file (including old and new protocol field names), collects the data block file index for each LOD level, decodes data blocks by reusing `readSog/readSpz`, merges data blocks using the `combine` function, applies LCC v1 coordinate transformations, and loads optional environment data blocks.

- Implemented multi-LOD selection via `options.lodSelect` and the `lod` column, consistent with the behavior of `readLcc`.

- Integrated `lcc2` into the read pipeline (`getInputFormat/InputFormat/readFile`), and exported the `readLcc2` function from `readers/index.ts` and `lib/index.ts`.

- Updated the CLI instructions and README file to document `.lcc2` input.