### PR TITLE
Halve LCC2 read peak memory by decoding chunks into a preallocated table

### DIFF
--- a/src/lib/readers/read-lcc2.ts
+++ b/src/lib/readers/read-lcc2.ts
@@ -1,7 +1,7 @@
-import { Column, combine, DataTable } from '../data-table';
+import { Column, DataTable, TypedArray } from '../data-table';
 import { readSog } from './read-sog';
 import { readSpz } from './read-spz';
-import { basename, dirname, join, readFile, ReadFileSystem, ReadSource, ZipReadFileSystem } from '../io/read';
+import { basename, dirname, join, readFile, ReadFileSystem, ReadSource, ReadStream, ZipReadFileSystem } from '../io/read';
 import { Options } from '../types';
 import { logger, Transform } from '../utils';
 
@@ -19,9 +19,11 @@ const LCC2_TRANSFORM = () => new Transform().fromEulers(90, 0, 180);
 // splatFiles / childNum / dataType.
 type RawLcc2Node = {
     // Node data: '3dgs' points to this node's main chunk file index; env
-    // points to the optional environment chunk.
+    // points to the optional environment chunk. A chunk file may be shared by
+    // several nodes (same level), each owning the [start, start + count) range
+    // of its rows.
     data?: {
-        '3dgs'?: { name: number };
+        '3dgs'?: { name: number; start?: number; count?: number };
         env?: { name: number };
         [key: string]: any;
     };
@@ -67,11 +69,11 @@ type RawLcc2Meta = {
 
 // --- Normalized model (post-parse) ------------------------------------------
 
-// Normalized octree node. collectFileIndicesForLod only relies on
-// data['3dgs'].name and child.
+// Normalized octree node. collectChunksByLevel only relies on
+// data['3dgs'] and child.
 type Lcc2TreeNode = {
     data?: {
-        '3dgs'?: { name: number };
+        '3dgs'?: { name: number; start?: number; count?: number };
         env?: { name: number };
         [key: string]: any;
     };
@@ -122,11 +124,58 @@ const getChildren = (node: Lcc2TreeNode): Lcc2TreeNode[] => {
 };
 
 /**
+ * Strip trailing commas before `}` or `]` outside string literals, so
+ * non-strict JSON (as emitted by some LCC2 exporters) still parses. A linear
+ * scan tracking in-string and escape state; string contents (e.g. file names
+ * containing ",}") pass through untouched.
+ *
+ * @param text - The raw (non-strict) JSON text.
+ * @returns The text with trailing commas removed.
+ * @ignore
+ */
+const stripTrailingCommas = (text: string): string => {
+    let result = '';
+    let inString = false;
+    let escaped = false;
+    for (let i = 0; i < text.length; i++) {
+        const c = text[i];
+        if (inString) {
+            if (escaped) {
+                escaped = false;
+            } else if (c === '\\') {
+                escaped = true;
+            } else if (c === '"') {
+                inString = false;
+            }
+            result += c;
+            continue;
+        }
+        if (c === '"') {
+            inString = true;
+            result += c;
+            continue;
+        }
+        if (c === ',') {
+            // Drop the comma when the next non-whitespace char closes the
+            // current object/array.
+            let j = i + 1;
+            while (j < text.length && /\s/.test(text[j])) j++;
+            if (j < text.length && (text[j] === '}' || text[j] === ']')) {
+                continue;
+            }
+        }
+        result += c;
+    }
+    return result;
+};
+
+/**
  * Parse meta.lcc2 text into a normalized {@link Lcc2Meta}.
  *
- * Tolerates trailing commas before `}` (non-strict JSON). Handles both the
- * old protocol (total_splats / lod_3dgs_info / lod_level + files / child_num /
- * datatype) and the new protocol (canonical field names) field naming.
+ * Tolerates trailing commas before `}` / `]` (non-strict JSON). Handles both
+ * the old protocol (total_splats / lod_3dgs_info / lod_level + files /
+ * child_num / datatype) and the new protocol (canonical field names) field
+ * naming.
  *
  * @param metaText - Raw meta.lcc2 file contents.
  * @param filename - Source filename, used to build descriptive parse errors.
@@ -134,16 +183,20 @@ const getChildren = (node: Lcc2TreeNode): Lcc2TreeNode[] => {
  * @ignore
  */
 const parseLcc2Meta = (metaText: string, filename: string): Lcc2Meta => {
-    // 1) Strip trailing commas before `}` so non-strict JSON still parses.
-    const cleaned = metaText.replace(/,\s*\}/g, '}');
+    // 1) Strict parse first (real-world metas are valid JSON); only on failure
+    // retry with trailing commas stripped.
     let meta: RawLcc2Meta;
     try {
-        meta = JSON.parse(cleaned) as RawLcc2Meta;
-    } catch (e) {
-        const reason = (e as Error)?.message ?? String(e);
-        throw new Error(
-            `Failed to parse meta.lcc2 as JSON: ${filename}: ${reason}`
-        );
+        meta = JSON.parse(metaText) as RawLcc2Meta;
+    } catch {
+        try {
+            meta = JSON.parse(stripTrailingCommas(metaText)) as RawLcc2Meta;
+        } catch (e) {
+            const reason = (e as Error)?.message ?? String(e);
+            throw new Error(
+                `Failed to parse meta.lcc2 as JSON: ${filename}: ${reason}`
+            );
+        }
     }
 
     // 2) Old protocol compatibility branch: only triggered when all three
@@ -226,34 +279,47 @@ const parseLcc2Meta = (metaText: string, filename: string): Lcc2Meta => {
 };
 
 /**
- * Collect the chunk file indices belonging to a target LOD level by traversing
- * the octree.
+ * Collect the chunk files of every LOD level in a single octree traversal,
+ * along with each file's splat count when the meta provides one.
  *
  * Traversal starts from the root's children with `depth` counting from 1; each
  * node's LOD level is `totalLevels - depth`. Only nodes carrying `data['3dgs']`
- * are collected, and indices equal to `envFileIndex` are skipped.
+ * are collected, and indices equal to `envFileIndex` are skipped. A chunk file
+ * may be shared by several nodes of the same level (each owning a row range),
+ * so a file's count is the sum of its nodes' `count` fields; if any
+ * contributing node lacks a valid count, the file's count is `undefined` and
+ * the caller falls back to reading it from the chunk itself.
  *
  * @param tree - The octree root node.
- * @param targetLod - The target LOD level to collect.
  * @param totalLevels - Total LOD level count.
  * @param envFileIndex - Optional environment chunk file index to exclude.
- * @returns Set of chunk file indices for the target LOD.
+ * @returns Map of LOD level to (file index -> splat count or undefined).
  * @ignore
  */
-const collectFileIndicesForLod = (
+const collectChunksByLevel = (
     tree: Lcc2TreeNode,
-    targetLod: number,
     totalLevels: number,
     envFileIndex: number | undefined
-): Set<number> => {
-    const result = new Set<number>();
+): Map<number, Map<number, number | undefined>> => {
+    const result = new Map<number, Map<number, number | undefined>>();
     const traverse = (node: Lcc2TreeNode, depth: number) => {
         for (const child of getChildren(node)) {
-            const level = totalLevels - depth;
-            if (level === targetLod && child.data?.['3dgs']) {
-                const fileIndex = child.data['3dgs'].name;
-                if (fileIndex !== envFileIndex) {
-                    result.add(fileIndex);
+            const data = child.data?.['3dgs'];
+            if (data && data.name !== envFileIndex) {
+                const level = totalLevels - depth;
+                let files = result.get(level);
+                if (!files) {
+                    files = new Map();
+                    result.set(level, files);
+                }
+                const count = data.count;
+                if (!Number.isInteger(count) || (count as number) < 0) {
+                    files.set(data.name, undefined);
+                } else if (files.has(data.name)) {
+                    const prev = files.get(data.name);
+                    files.set(data.name, prev === undefined ? undefined : prev + (count as number));
+                } else {
+                    files.set(data.name, count);
                 }
             }
             traverse(child, depth + 1);
@@ -367,7 +433,10 @@ const decodeChunk = async (
         if (splatType === '.sog') {
             const zipFs = new ZipReadFileSystem(source); // SOG is a ZIP container
             try {
-                return await readSog(zipFs, 'meta.json'); // call readSog directly to avoid circular deps
+                // call readSog directly to avoid circular deps; silence its
+                // internal bar - logger bars are strictly LIFO and chunks
+                // decode concurrently under readLcc2's own bar
+                return await readSog(zipFs, 'meta.json', { logging: 'silent' });
             } finally {
                 zipFs.close(); // close the zip wrapper (also closes the source)
             }
@@ -381,6 +450,162 @@ const decodeChunk = async (
     }
 };
 
+// SPZ header: u32 magic 'NGSP', u32 version, u32 numPoints, u8 shDegree,
+// u8 fractionalBits, u8 flags, u8 reserved. v4 files start with this header
+// in plaintext; v1-3 files are gzip-compressed end-to-end with the same
+// header at the start of the decompressed stream.
+const SPZ_HEADER_SIZE = 16;
+
+// Compressed prefix to pull when gunzipping just the SPZ header. 64KB of
+// compressed input always yields >= 16 decompressed bytes for a real gzip
+// stream while keeping remote range reads small.
+const GZIP_PREFIX_LIMIT = 65536;
+
+/**
+ * Read up to `length` bytes from a stream into a buffer. May return fewer
+ * bytes if the stream ends early. The caller closes the stream.
+ *
+ * @param stream - The stream to read from.
+ * @param length - Maximum number of bytes to read.
+ * @returns The bytes read (length <= `length`).
+ * @ignore
+ */
+const readPrefix = async (stream: ReadStream, length: number): Promise<Uint8Array> => {
+    const result = new Uint8Array(length);
+    let read = 0;
+    while (read < length) {
+        const n = await stream.pull(result.subarray(read));
+        if (n === 0) break;
+        read += n;
+    }
+    return result.subarray(0, read);
+};
+
+/**
+ * Stream-gunzip only the first `length` bytes of a gzip stream, then cancel
+ * the decompressor without consuming the rest of the input.
+ *
+ * @param stream - Stream over the (bounded) compressed input. The caller closes it.
+ * @param length - Number of decompressed bytes wanted.
+ * @returns The first `length` decompressed bytes.
+ * @ignore
+ */
+const gunzipPrefix = async (stream: ReadStream, length: number): Promise<Uint8Array> => {
+    const inputStream = new ReadableStream<Uint8Array>({
+        async pull(controller) {
+            const chunk = new Uint8Array(32768);
+            const n = await stream.pull(chunk);
+            if (n === 0) {
+                controller.close();
+            } else {
+                controller.enqueue(chunk.subarray(0, n));
+            }
+        }
+    });
+    // Type assertion needed due to TypeScript's strict typing of DecompressionStream
+    const reader = inputStream.pipeThrough(
+        new DecompressionStream('gzip') as unknown as TransformStream<Uint8Array, Uint8Array>
+    ).getReader();
+    try {
+        const result = new Uint8Array(length);
+        let read = 0;
+        while (read < length) {
+            const { done, value } = await reader.read();
+            if (done) {
+                throw new Error('Unexpected end of gzip stream');
+            }
+            const n = Math.min(value.length, length - read);
+            result.set(value.subarray(0, n), read);
+            read += n;
+        }
+        return result;
+    } finally {
+        // Stop decompression early; the bounded input is truncated, so
+        // draining it to EOF would throw.
+        await reader.cancel().catch(() => {});
+    }
+};
+
+/**
+ * Validate the 'NGSP' magic and extract numPoints from an SPZ header.
+ *
+ * @param header - The (decompressed) leading bytes of the SPZ data.
+ * @param context - Chunk path, used to build descriptive errors.
+ * @returns The header's numPoints field.
+ * @ignore
+ */
+const parseSpzNumPoints = (header: Uint8Array, context: string): number => {
+    if (header.length < SPZ_HEADER_SIZE ||
+        header[0] !== 0x4e || header[1] !== 0x47 || header[2] !== 0x53 || header[3] !== 0x50) {
+        throw new Error(`Invalid SPZ chunk header: ${context}`);
+    }
+    const view = new DataView(header.buffer, header.byteOffset, header.byteLength);
+    return view.getUint32(8, true);
+};
+
+/**
+ * Read a chunk's exact splat count without decoding it. Used as a fallback
+ * when meta.lcc2 doesn't provide per-node counts: costs one extra open plus a
+ * small read per chunk (noticeable mainly on remote file systems).
+ *
+ * SOG: opens the ZIP and reads only meta.json (`count` for V2,
+ * `means.shape[0]` for V1, mirroring readSog's version dispatch). SPZ: parses
+ * `numPoints` from the 16-byte header (gunzipping just the header for the
+ * gzip-wrapped v1-3 container).
+ *
+ * @param fileSystem - File system to read the chunk from.
+ * @param splatType - Chunk encoding type ('.sog' or '.spz').
+ * @param fullPath - The chunk file path recorded in meta.lcc2.
+ * @returns The chunk's splat count.
+ * @ignore
+ */
+const readChunkCount = async (
+    fileSystem: ReadFileSystem,
+    splatType: string,
+    fullPath: string
+): Promise<number> => {
+    const source = await openChunkSource(fileSystem, fullPath);
+    try {
+        if (splatType === '.sog') {
+            const zipFs = new ZipReadFileSystem(source);
+            try {
+                const sogMeta = JSON.parse(new TextDecoder().decode(await readFile(zipFs, 'meta.json')));
+                const version = sogMeta.version;
+                const count = version === undefined ?
+                    sogMeta.means?.shape?.[0] : // V1: texture shape
+                    (version === 2 ? sogMeta.count : undefined);
+                if (!Number.isInteger(count) || count < 0) {
+                    throw new Error(`Cannot determine SOG chunk splat count: ${fullPath}`);
+                }
+                return count;
+            } finally {
+                zipFs.close();
+            }
+        }
+        if (splatType === '.spz') {
+            const headStream = source.read(0, SPZ_HEADER_SIZE);
+            let header: Uint8Array;
+            try {
+                header = await readPrefix(headStream, SPZ_HEADER_SIZE);
+            } finally {
+                headStream.close();
+            }
+            if (header.length >= 2 && header[0] === 0x1f && header[1] === 0x8b) {
+                const zipped = source.read(0, GZIP_PREFIX_LIMIT);
+                try {
+                    header = await gunzipPrefix(zipped, SPZ_HEADER_SIZE);
+                } finally {
+                    zipped.close();
+                }
+            }
+            return parseSpzNumPoints(header, fullPath);
+        }
+        throw new Error(`Unsupported LCC2 splatType: ${splatType}`);
+    } finally {
+        source.close();
+    }
+};
+
 /**
  * Reads an XGrids LCC2 format containing multi-LOD Gaussian splat data.
  *
@@ -390,9 +615,12 @@ const decodeChunk = async (
  * paths, LOD levels and bounding box.
  *
  * Chunks for the selected LODs are decoded (reusing the internal `readSog` /
- * `readSpz` decoders), tagged with an output `lod` column, combined into a
- * single DataTable and re-tagged with the LCC2 coordinate transform. An
- * optional environment chunk is loaded as an additional table (lod = -1).
+ * `readSpz` decoders) directly into a single preallocated DataTable, tagged
+ * with an output `lod` column and the LCC2 coordinate transform. Output
+ * arrays are sized up front from the per-node splat counts in meta.lcc2
+ * (falling back to reading each chunk's header when absent), so peak memory
+ * stays at ~one copy of the scene plus the chunks currently being decoded.
+ * An optional environment chunk is loaded as an additional table (lod = -1).
  *
  * Behavior (multi-LOD selection, `lod` column, coordinate transform) mirrors
  * `readLcc`.
@@ -424,38 +652,97 @@ const readLcc2 = async (
     }
 
     // 3) Collect decode tasks in deterministic order: by LOD order, then by
-    // ascending file index within each LOD.
-    const tasks: { outputLod: number; fileIndex: number }[] = [];
+    // ascending file index within each LOD. A single traversal yields every
+    // level's chunk files along with their meta-provided splat counts.
+    const byLevel = collectChunksByLevel(tree, totalLevels, envFileIndex);
+    const tasks: { outputLod: number; fileIndex: number; count: number | undefined }[] = [];
     for (let outputLod = 0; outputLod < inputLods.length; outputLod++) {
-        const inputLod = inputLods[outputLod];
-        const indices = Array.from(
-            collectFileIndicesForLod(tree, inputLod, totalLevels, envFileIndex)
-        ).sort((a, b) => a - b);
+        const files = byLevel.get(inputLods[outputLod]);
+        const indices = files ? Array.from(files.keys()).sort((a, b) => a - b) : [];
         for (const fileIndex of indices) {
-            tasks.push({ outputLod, fileIndex });
+            if (!Number.isInteger(fileIndex) || fileIndex < 0 ||
+                fileIndex >= splatFiles.length || !splatFiles[fileIndex]) {
+                throw new Error(
+                    `Invalid chunk file index ${fileIndex} (root.splatFiles has ${splatFiles.length} entries) in LCC2 input file: ${filename}`
+                );
+            }
+            tasks.push({ outputLod, fileIndex, count: files.get(fileIndex) });
         }
     }
 
     // No decodable chunks for the selected LODs: bail out with a descriptive
-    // error rather than letting combine() throw on an empty array below.
+    // error rather than producing an empty table below.
     if (tasks.length === 0) {
         throw new Error(
             `No chunks found for selected LODs in LCC2 input file: ${filename} lods: ${JSON.stringify(inputLods)}`
         );
     }
 
-    // 4) Pre-allocate output slots so combine input order stays reproducible.
-    // Every slot is filled by exactly one worker below; any decode failure
-    // rejects Promise.all and aborts before combine, so there are no holes.
-    const tables: DataTable[] = new Array(tasks.length);
+    // 4) Resolve per-chunk splat counts. Counts from meta.lcc2 are preferred;
+    // chunks lacking one fall back to a cheap header read (no decode). The
+    // fallback costs an extra open plus a small read per chunk - noticeable
+    // mainly on remote file systems - so meta counts are used when present.
+    const counts = new Array<number>(tasks.length);
+    const missing: number[] = [];
+    for (let i = 0; i < tasks.length; i++) {
+        const count = tasks[i].count;
+        if (count === undefined) {
+            missing.push(i);
+        } else {
+            counts[i] = count;
+        }
+    }
+    if (missing.length > 0) {
+        const scanBar = logger.bar('scanning', missing.length);
+        let scanned = 0;
+        let nextScan = 0;
+        const scanWorker = async () => {
+            while (true) {
+                const m = nextScan++;
+                if (m >= missing.length) break;
+                const i = missing[m];
+                counts[i] = await readChunkCount(
+                    fileSystem, splatType, related(splatFiles[tasks[i].fileIndex])
+                );
+                scanBar.update(++scanned);
+            }
+        };
+        await Promise.all(
+            Array.from({ length: Math.min(LOAD_CONCURRENCY, missing.length) }, () => scanWorker())
+        );
+        // Close the bar only on success path (matches the decode bar below).
+        scanBar.end();
+    }
 
-    // 5) One progress bar covering all chunks.
+    // 5) Prefix-sum write offsets in task order: the output layout is fixed
+    // before decoding starts, so workers completing out of order still write
+    // into disjoint regions and the result stays deterministic (mirrors
+    // readLcc's decodeUnitsForLod).
+    const offsets = new Array<number>(tasks.length);
+    let totalRows = 0;
+    for (let i = 0; i < tasks.length; i++) {
+        offsets[i] = totalRows;
+        totalRows += counts[i];
+    }
+
+    // 6) Output columns, preallocated at the final row count. The column set
+    // isn't known until chunks decode (it depends on each chunk's SH bands),
+    // so each column is allocated on first sighting - still a single
+    // exact-size allocation; rows from chunks lacking a column stay zero
+    // (matching combine()'s behavior for missing columns). The first sighting
+    // (task, position) is recorded so the assembled column order is
+    // deterministic regardless of decode completion order.
+    type OutputColumn = { data: TypedArray; task: number; pos: number };
+    const outputs = new Map<string, OutputColumn>();
+    const lodData = new Float32Array(totalRows);
+
+    // 7) Bounded-concurrency decode pool: decode each chunk, validate its row
+    // count against the expected count, copy it into the output arrays at its
+    // precomputed offset and drop it. Any failure propagates: the bar is
+    // intentionally not end()ed on the error path, leaving it open so
+    // logger's error path can mark it as failed instead of finalizing it first.
     const bar = logger.bar('decoding', tasks.length);
     let done = 0;
-
-    // 6) Bounded-concurrency worker pool. Any failure here propagates: the bar
-    // is intentionally not end()ed on the error path, leaving it open so
-    // logger's error path can mark it as failed instead of finalizing it first.
     let next = 0;
     const worker = async () => {
         while (true) {
@@ -464,27 +751,46 @@ const readLcc2 = async (
             const task = tasks[i];
             const fullPath = related(splatFiles[task.fileIndex]);
             const dt = await decodeChunk(fileSystem, splatType, fullPath);
+            if (dt.numRows !== counts[i]) {
+                throw new Error(
+                    `LCC2 chunk splat count mismatch for ${fullPath}: expected ${counts[i]}, decoded ${dt.numRows}`
+                );
+            }
+            for (let pos = 0; pos < dt.columns.length; pos++) {
+                const column = dt.columns[pos];
+                let output = outputs.get(column.name);
+                if (!output) {
+                    const Ctor = column.data.constructor as new (length: number) => TypedArray;
+                    output = { data: new Ctor(totalRows), task: i, pos };
+                    outputs.set(column.name, output);
+                } else if (i < output.task) {
+                    output.task = i;
+                    output.pos = pos;
+                }
+                output.data.set(column.data, offsets[i]);
+            }
             // Write lod column = output LOD index.
-            dt.addColumn(
-                new Column('lod', new Float32Array(dt.numRows).fill(task.outputLod))
-            );
-            tables[i] = dt; // write pre-allocated slot (no push, keeps order)
+            lodData.fill(task.outputLod, offsets[i], offsets[i] + dt.numRows);
             bar.update(++done);
+            // dt goes out of scope here, releasing the chunk's memory.
         }
     };
     await Promise.all(
         Array.from({ length: Math.min(LOAD_CONCURRENCY, tasks.length) }, () => worker())
     );
 
-    // 7) Combine + override transform.
-    const merged = combine(tables);
-    merged.transform = LCC2_TRANSFORM();
+    // 8) Assemble the merged table, columns ordered by first sighting.
+    const columns = [...outputs.entries()]
+    .sort(([, a], [, b]) => (a.task - b.task) || (a.pos - b.pos))
+    .map(([name, output]) => new Column(name, output.data));
+    columns.push(new Column('lod', lodData));
+    const merged = new DataTable(columns, LCC2_TRANSFORM());
     // Close the bar only on success path.
     bar.end();
 
     const result: DataTable[] = [merged];
 
-    // 8) Optional environment chunk (approach B): a missing file is normal.
+    // 9) Optional environment chunk (approach B): a missing file is normal.
     if (envFileIndex !== undefined) {
         try {
             const envFull = related(splatFiles[envFileIndex]);
@@ -508,13 +814,16 @@ const readLcc2 = async (
 export {
     LOAD_CONCURRENCY,
     LCC2_TRANSFORM,
+    stripTrailingCommas,
     parseLcc2Meta,
     getChildren,
-    collectFileIndicesForLod,
+    collectChunksByLevel,
     resolveLodSelection,
     isMissingError,
     openChunkSource,
     decodeChunk,
+    parseSpzNumPoints,
+    readChunkCount,
     readLcc2
 };
 

--- a/src/lib/readers/read-sog-v1.ts
+++ b/src/lib/readers/read-sog-v1.ts
@@ -1,6 +1,7 @@
 import { Column, DataTable } from '../data-table';
 import { join, type ReadFileSystem } from '../io/read';
 import { logger, Transform, WebPCodec } from '../utils';
+import type { ReadSogOptions } from './read-sog';
 
 // V1 (legacy) SOG meta layout. Quantization is a per-channel linear lerp
 // between mins/maxs, with no codebook. The engine's SOG parser still loads
@@ -90,10 +91,11 @@ const v1ShBandsWidths: Record<number, number> = { 192: 1, 512: 2, 960: 3 };
  * @param baseDir - Directory containing the SOG textures (relative paths in
  * meta are resolved from here)
  * @param meta - The parsed V1 meta.json payload
+ * @param options - Options controlling progress reporting.
  * @returns DataTable with Gaussian splat data
  * @ignore
  */
-const readSogV1 = async (fileSystem: ReadFileSystem, baseDir: string, meta: MetaV1): Promise<DataTable> => {
+const readSogV1 = async (fileSystem: ReadFileSystem, baseDir: string, meta: MetaV1, options: ReadSogOptions = {}): Promise<DataTable> => {
     const decoder = await WebPCodec.create();
     const count = meta.means.shape[0];
 
@@ -124,10 +126,10 @@ const readSogV1 = async (fileSystem: ReadFileSystem, baseDir: string, meta: Meta
     ];
 
     const numPasses = 4 + (meta.shN ? 1 : 0);
-    const bar = logger.bar('decoding', numPasses * count);
+    const bar = options.logging === 'silent' ? null : logger.bar('decoding', numPasses * count);
     let passesDone = 0;
     const tickPass = () => {
-        bar.update(++passesDone * count);
+        bar?.update(++passesDone * count);
     };
 
     // means: two textures means_l (low byte) + means_u (high byte) packed as
@@ -274,7 +276,7 @@ const readSogV1 = async (fileSystem: ReadFileSystem, baseDir: string, meta: Meta
     // Close the bar only on success: leaving it open on the error path lets
     // `logger.error() -> unwindAll(true)` mark it as failed instead of
     // finalizing it as a successful bar first.
-    bar.end();
+    bar?.end();
 
     return new DataTable(columns, Transform.PLY);
 };

--- a/src/lib/readers/read-sog.ts
+++ b/src/lib/readers/read-sog.ts
@@ -16,6 +16,16 @@ type MetaV2 = {
     shN?: { count: number; bands: number; codebook: number[]; files: string[] };
 };
 
+type ReadSogOptions = {
+    // Controls how readSog reports its own progress (mirrors writeSog's
+    // `logging` option, reduced to the modes a bar-only reader needs):
+    //   'own'    — open readSog's internal 'decoding' bar (default)
+    //   'silent' — no bar; the caller drives its own progress (e.g. readLcc2
+    //              decoding many chunks concurrently — logger bars are strictly
+    //              LIFO, so concurrent per-chunk bars would corrupt each other)
+    logging?: 'own' | 'silent';
+};
+
 const decodeMeans = (lo: Uint8Array, hi: Uint8Array, count: number) => {
     const xs = new Uint16Array(count);
     const ys = new Uint16Array(count);
@@ -75,10 +85,11 @@ const sigmoidInv = (y: number) => {
  * The basename is used verbatim for the initial meta fetch so
  * any URL querystring/fragment (e.g. presigned `?token=...`)
  * is preserved.
+ * @param options - Options controlling progress reporting.
  * @returns DataTable with Gaussian splat data
  * @ignore
  */
-const readSog = async (fileSystem: ReadFileSystem, filename: string): Promise<DataTable> => {
+const readSog = async (fileSystem: ReadFileSystem, filename: string, options: ReadSogOptions = {}): Promise<DataTable> => {
     const baseDir = dirname(filename);
     const metaName = basename(filename);
     const resolve = (name: string) => (baseDir ? join(baseDir, name) : name);
@@ -94,7 +105,7 @@ const readSog = async (fileSystem: ReadFileSystem, filename: string): Promise<Da
     //     downstream failures (missing `means.shape`, etc.).
     const version = rawMeta.version;
     if (version === undefined) {
-        return readSogV1(fileSystem, baseDir, rawMeta as MetaV1);
+        return readSogV1(fileSystem, baseDir, rawMeta as MetaV1, options);
     }
     if (version !== 2) {
         throw new Error(`Unsupported SOG meta version: ${version}`);
@@ -134,10 +145,10 @@ const readSog = async (fileSystem: ReadFileSystem, filename: string): Promise<Da
     // (means, quats, scales, sh0, plus an optional shN pass). Each pass ticks
     // with `count` once it has finished writing into the output columns.
     const numPasses = 4 + (meta.shN ? 1 : 0);
-    const bar = logger.bar('decoding', numPasses * count);
+    const bar = options.logging === 'silent' ? null : logger.bar('decoding', numPasses * count);
     let passesDone = 0;
     const tickPass = () => {
-        bar.update(++passesDone * count);
+        bar?.update(++passesDone * count);
     };
 
     // means: two textures means_l (low byte) + means_u (high byte) packed as
@@ -271,9 +282,10 @@ const readSog = async (fileSystem: ReadFileSystem, filename: string): Promise<Da
     // Close the bar only on success: leaving it open on the error path lets
     // `logger.error() -> unwindAll(true)` mark it as failed instead of
     // finalizing it as a successful bar first.
-    bar.end();
+    bar?.end();
 
     return new DataTable(columns, Transform.PLY);
 };
 
 export { readSog };
+export type { ReadSogOptions };

--- a/src/lib/utils/webp-codec.ts
+++ b/src/lib/utils/webp-codec.ts
@@ -4,6 +4,8 @@ class WebPCodec {
     /**
      * URL to the webp.wasm file. Set this before any SOG read/write operations
      * in browser environments where the default path resolution doesn't work.
+     * Must be set before the first `create()` call: the compiled module is
+     * cached, so later changes have no effect.
      *
      * @example
      * import { WebPCodec } from '@playcanvas/splat-transform';
@@ -12,18 +14,35 @@ class WebPCodec {
      */
     static wasmUrl: string | null = null;
 
+    private static modulePromise: Promise<any> | null = null;
+
     Module: any;
 
     static async create() {
-        const instance = new WebPCodec();
-        instance.Module = await createModule({
-            locateFile: (path: string) => {
-                if (path.endsWith('.wasm') && WebPCodec.wasmUrl) {
-                    return WebPCodec.wasmUrl;
+        // Compile/instantiate the wasm module once and share it across all
+        // instances; per-call instantiation pays a fresh Emscripten heap each
+        // time (readers like readLcc2 call create() once per chunk). Memoize
+        // the promise so concurrent first calls share a single instantiation,
+        // but reset on rejection so a failed load (e.g. wasmUrl set late in a
+        // browser) can be retried.
+        if (!WebPCodec.modulePromise) {
+            const promise = createModule({
+                locateFile: (path: string) => {
+                    if (path.endsWith('.wasm') && WebPCodec.wasmUrl) {
+                        return WebPCodec.wasmUrl;
+                    }
+                    return new URL(`../lib/${path}`, import.meta.url).toString();
                 }
-                return new URL(`../lib/${path}`, import.meta.url).toString();
-            }
-        });
+            });
+            promise.catch(() => {
+                if (WebPCodec.modulePromise === promise) {
+                    WebPCodec.modulePromise = null;
+                }
+            });
+            WebPCodec.modulePromise = promise;
+        }
+        const instance = new WebPCodec();
+        instance.Module = await WebPCodec.modulePromise;
         return instance;
     }
 

--- a/src/lib/writers/write-image.ts
+++ b/src/lib/writers/write-image.ts
@@ -9,10 +9,6 @@ import { type Projection, type RenderCamera } from '../render/camera';
 import type { DeviceCreator } from '../types';
 import { logger, Transform, WebPCodec } from '../utils';
 
-// Cache the WebP codec across invocations; `WebPCodec.create()` instantiates
-// the WASM module which is expensive to repeat. Same pattern as write-sog.ts.
-let webPCodec: WebPCodec | undefined;
-
 /**
  * Options for writing a rendered splat image.
  */
@@ -350,9 +346,7 @@ const writeImage = async (options: WriteImageOptions, fs: FileSystem): Promise<v
     }
 
     const encodingGroup = logger.group('Encoding');
-    if (!webPCodec) {
-        webPCodec = await WebPCodec.create();
-    }
+    const webPCodec = await WebPCodec.create(); // cheap: create() memoizes the wasm module
     const webp = webPCodec.encodeLosslessRGBA(rgba, width, height);
     encodingGroup.end();
 

--- a/src/lib/writers/write-sog.ts
+++ b/src/lib/writers/write-sog.ts
@@ -44,8 +44,6 @@ const generateIndices = (dataTable: DataTable) => {
     return result;
 };
 
-let webPCodec: WebPCodec;
-
 type WriteSogOptions = {
     filename: string;
     dataTable: DataTable;
@@ -103,10 +101,8 @@ const writeSog = async (options: WriteSogOptions, fs: FileSystem) => {
     const writeWebp = async (filename: string, data: Uint8Array, w = width, h = height) => {
         const pathname = zipFs ? filename : resolve(dirname(outputFilename), filename);
 
-        // construct the encoder on first use
-        if (!webPCodec) {
-            webPCodec = await WebPCodec.create();
-        }
+        // cheap after the first call: create() memoizes the wasm module
+        const webPCodec = await WebPCodec.create();
 
         const webp = await webPCodec.encodeLosslessRGBA(data, w, h);
 

--- a/test/read-lcc2.test.mjs
+++ b/test/read-lcc2.test.mjs
@@ -2,31 +2,69 @@
  * Unit tests for the LCC2 reader.
  *
  * Covers the pure helpers (meta parsing for new/legacy protocols, octree LOD
- * collection, LOD selection) and the main readLcc2 flow (deterministic task
- * ordering, the output lod column, environment-chunk handling and failure
- * modes), exercised against in-memory .spz chunks built with writeSpz.
+ * collection with per-chunk counts, LOD selection, chunk-count fallbacks) and
+ * the main readLcc2 flow (deterministic task ordering, the output lod column,
+ * environment-chunk handling and failure modes), exercised against in-memory
+ * .spz / .sog chunks built with writeSpz / writeSog.
  */
 
 import assert from 'node:assert';
+import { dirname, join } from 'node:path';
 import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import { createTestDataTable } from './helpers/test-utils.mjs';
 import {
     MemoryReadFileSystem,
     MemoryFileSystem,
+    WebPCodec,
+    writeSog,
     writeSpz
 } from '../src/lib/index.js';
 import {
+    stripTrailingCommas,
     parseLcc2Meta,
     getChildren,
-    collectFileIndicesForLod,
+    collectChunksByLevel,
     resolveLodSelection,
     isMissingError,
     openChunkSource,
+    parseSpzNumPoints,
+    readChunkCount,
     readLcc2,
     LOAD_CONCURRENCY
 } from '../src/lib/readers/read-lcc2.js';
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+WebPCodec.wasmUrl = join(__dirname, '..', 'lib', 'webp.wasm');
+
+
+describe('stripTrailingCommas', () => {
+    it('strips trailing commas before } and ]', () => {
+        const text = '{ "a": [1, 2, ], "b": { "c": 3, }, }';
+        assert.deepStrictEqual(
+            JSON.parse(stripTrailingCommas(text)),
+            { a: [1, 2], b: { c: 3 } }
+        );
+    });
+
+    it('preserves string contents containing ",}" and ",]"', () => {
+        const text = '{ "name": "weird,}.sog", "arr": ["x,]" ], }';
+        const parsed = JSON.parse(stripTrailingCommas(text));
+        assert.strictEqual(parsed.name, 'weird,}.sog');
+        assert.deepStrictEqual(parsed.arr, ['x,]']);
+    });
+
+    it('handles escaped quotes inside strings', () => {
+        const text = '{ "a": "q\\",}", }';
+        assert.strictEqual(JSON.parse(stripTrailingCommas(text)).a, 'q",}');
+    });
+
+    it('leaves valid JSON unchanged', () => {
+        const text = JSON.stringify({ a: [1, 2], b: 'x,}' });
+        assert.strictEqual(stripTrailingCommas(text), text);
+    });
+});
 
 describe('parseLcc2Meta', () => {
     it('parses the new protocol verbatim', () => {
@@ -117,6 +155,21 @@ describe('parseLcc2Meta', () => {
         assert.deepStrictEqual(meta.splatFiles, ['a.sog']);
     });
 
+    it('does not corrupt string values containing ",}"', () => {
+        // Valid JSON is parsed strictly, so a file name containing ",}" must
+        // survive (the old regex-based cleanup rewrote it to "}").
+        const meta = parseLcc2Meta(
+            JSON.stringify({
+                totalSplats: 1,
+                lodSplats: [1],
+                totalLevels: 1,
+                root: { splatFiles: ['weird,}.sog'] }
+            }),
+            'meta.lcc2'
+        );
+        assert.deepStrictEqual(meta.splatFiles, ['weird,}.sog']);
+    });
+
     it('throws a descriptive error on invalid JSON', () => {
         assert.throws(
             () => parseLcc2Meta('{ not json', 'bad.lcc2'),
@@ -183,7 +236,7 @@ describe('getChildren', () => {
     });
 });
 
-describe('collectFileIndicesForLod', () => {
+describe('collectChunksByLevel', () => {
     // depth counts from 1 at the root's children; level = totalLevels - depth.
     // totalLevels = 2: depth 1 -> level 1, depth 2 -> level 0 (finest).
     const tree = {
@@ -198,28 +251,67 @@ describe('collectFileIndicesForLod', () => {
         ]
     };
 
-    it('collects the deepest nodes for LOD 0', () => {
-        const set = collectFileIndicesForLod(tree, 0, 2, undefined);
+    it('collects every level in a single traversal', () => {
+        const byLevel = collectChunksByLevel(tree, 2, undefined);
         assert.deepStrictEqual(
-            [...set].sort((a, b) => a - b),
+            [...byLevel.get(0).keys()].sort((a, b) => a - b),
             [1, 2]
         );
-    });
-
-    it('collects shallower nodes for higher LOD', () => {
-        const set = collectFileIndicesForLod(tree, 1, 2, undefined);
-        assert.deepStrictEqual([...set], [0]);
+        assert.deepStrictEqual([...byLevel.get(1).keys()], [0]);
     });
 
     it('skips the environment file index', () => {
-        const set = collectFileIndicesForLod(tree, 0, 2, 2);
-        assert.deepStrictEqual([...set], [1]);
+        const byLevel = collectChunksByLevel(tree, 2, 2);
+        assert.deepStrictEqual([...byLevel.get(0).keys()], [1]);
     });
 
     it('handles object-map children', () => {
         const mapTree = { child: { 0: { data: { '3dgs': { name: 7 } } } } };
-        const set = collectFileIndicesForLod(mapTree, 0, 1, undefined);
-        assert.deepStrictEqual([...set], [7]);
+        const byLevel = collectChunksByLevel(mapTree, 1, undefined);
+        assert.deepStrictEqual([...byLevel.get(0).keys()], [7]);
+    });
+
+    it('has no entry for levels without chunks', () => {
+        const byLevel = collectChunksByLevel(tree, 2, undefined);
+        assert.strictEqual(byLevel.get(5), undefined);
+    });
+
+    it('sums per-file counts across nodes sharing a chunk file', () => {
+        // Real LCC2 metas share one chunk file between several same-level
+        // nodes, each owning a [start, start + count) row range.
+        const shared = {
+            child: [
+                { data: { '3dgs': { name: 0, start: 0, count: 5 } } },
+                { data: { '3dgs': { name: 0, start: 5, count: 7 } } },
+                { data: { '3dgs': { name: 1, count: 3 } } }
+            ]
+        };
+        const byLevel = collectChunksByLevel(shared, 1, undefined);
+        assert.strictEqual(byLevel.get(0).get(0), 12);
+        assert.strictEqual(byLevel.get(0).get(1), 3);
+    });
+
+    it('marks a file count unknown when any node lacks a valid count', () => {
+        const partial = {
+            child: [
+                { data: { '3dgs': { name: 0, count: 5 } } },
+                { data: { '3dgs': { name: 0 } } }, // no count -> file 0 unknown
+                { data: { '3dgs': { name: 1, count: -2 } } } // invalid count
+            ]
+        };
+        const byLevel = collectChunksByLevel(partial, 1, undefined);
+        assert.strictEqual(byLevel.get(0).has(0), true);
+        assert.strictEqual(byLevel.get(0).get(0), undefined);
+        assert.strictEqual(byLevel.get(0).get(1), undefined);
+
+        // An uncounted node arriving before a counted one must also poison.
+        const reversed = {
+            child: [
+                { data: { '3dgs': { name: 0 } } },
+                { data: { '3dgs': { name: 0, count: 5 } } }
+            ]
+        };
+        assert.strictEqual(collectChunksByLevel(reversed, 1, undefined).get(0).get(0), undefined);
     });
 });
 
@@ -243,14 +335,30 @@ describe('resolveLodSelection', () => {
 
 // --- Main readLcc2 flow -----------------------------------------------------
 
-// Build an in-memory .spz chunk with the given number of splats.
-const makeSpzBytes = async (count) => {
+// Build an in-memory .spz chunk with the given number of splats. The default
+// version (4) emits a plaintext NGSP header; version 3 emits the legacy
+// gzip-wrapped container.
+const makeSpzBytes = async (count, { version, includeSH } = {}) => {
     const writeFs = new MemoryFileSystem();
     await writeSpz(
-        { filename: 'chunk.spz', dataTable: createTestDataTable(count) },
+        {
+            filename: 'chunk.spz',
+            dataTable: createTestDataTable(count, includeSH ? { includeSH, shBands: 3 } : {}),
+            ...(version ? { version } : {})
+        },
         writeFs
     );
     return writeFs.results.get('chunk.spz');
+};
+
+// Build an in-memory bundled .sog chunk with the given number of splats.
+const makeSogBytes = async (count) => {
+    const writeFs = new MemoryFileSystem();
+    await writeSog(
+        { filename: 'chunk.sog', dataTable: createTestDataTable(count), bundle: true, iterations: 5 },
+        writeFs
+    );
+    return writeFs.results.get('chunk.sog');
 };
 
 // Default options for readLcc2 (only lodSelect matters here).
@@ -386,6 +494,249 @@ describe('readLcc2 (main flow)', () => {
         fs.set('meta.lcc2', new TextEncoder().encode(JSON.stringify(meta)));
 
         await assert.rejects(() => readLcc2(fs, 'meta.lcc2', opts()));
+    });
+});
+
+describe('parseSpzNumPoints', () => {
+    it('parses numPoints from a v4 SPZ header', async () => {
+        const bytes = await makeSpzBytes(7);
+        assert.strictEqual(parseSpzNumPoints(bytes.subarray(0, 16), 'chunk.spz'), 7);
+    });
+
+    it('throws on garbage or truncated headers', () => {
+        assert.throws(() => parseSpzNumPoints(new Uint8Array(16), 'x.spz'), /Invalid SPZ chunk header/);
+        assert.throws(() => parseSpzNumPoints(new Uint8Array(4), 'x.spz'), /Invalid SPZ chunk header/);
+    });
+});
+
+describe('readChunkCount', () => {
+    it('reads the count from a v4 (plaintext header) SPZ chunk', async () => {
+        const fs = new MemoryReadFileSystem();
+        fs.set('chunk.spz', await makeSpzBytes(9));
+        assert.strictEqual(await readChunkCount(fs, '.spz', 'chunk.spz'), 9);
+    });
+
+    it('reads the count from a v3 (gzip-wrapped) SPZ chunk', async () => {
+        const fs = new MemoryReadFileSystem();
+        const bytes = await makeSpzBytes(9, { version: 3 });
+        assert.strictEqual(bytes[0], 0x1f); // sanity: legacy container is gzip
+        fs.set('chunk.spz', bytes);
+        assert.strictEqual(await readChunkCount(fs, '.spz', 'chunk.spz'), 9);
+    });
+
+    it('reads the count from a SOG chunk meta.json without decoding textures', async () => {
+        const fs = new MemoryReadFileSystem();
+        fs.set('chunk.sog', await makeSogBytes(9));
+        assert.strictEqual(await readChunkCount(fs, '.sog', 'chunk.sog'), 9);
+    });
+
+    it('throws on an unsupported splatType', async () => {
+        const fs = new MemoryReadFileSystem();
+        fs.set('x.ply', new Uint8Array(4));
+        await assert.rejects(() => readChunkCount(fs, '.ply', 'x.ply'), /Unsupported LCC2 splatType/);
+    });
+});
+
+// Wraps a MemoryReadFileSystem, recording every createSource path. Used to
+// prove the meta-count path opens each chunk exactly once (no fallback scan).
+class RecordingFileSystem {
+    constructor(inner) {
+        this.inner = inner;
+        this.attempts = [];
+    }
+
+    createSource(filename) {
+        this.attempts.push(filename);
+        return this.inner.createSource(filename);
+    }
+}
+
+describe('readLcc2 (meta-provided counts)', () => {
+    it('uses meta counts without extra chunk reads', async () => {
+        const inner = new MemoryReadFileSystem();
+        inner.set('chunk1.spz', await makeSpzBytes(5));
+        inner.set('chunk2.spz', await makeSpzBytes(3));
+
+        const meta = {
+            totalSplats: 8,
+            lodSplats: [8],
+            totalLevels: 1,
+            splatType: '.spz',
+            root: {
+                splatFiles: ['chunk1.spz', 'chunk2.spz'],
+                child: [
+                    { data: { '3dgs': { name: 0, start: 0, count: 5 } } },
+                    { data: { '3dgs': { name: 1, start: 0, count: 3 } } }
+                ]
+            }
+        };
+        inner.set('meta.lcc2', new TextEncoder().encode(JSON.stringify(meta)));
+
+        const fs = new RecordingFileSystem(inner);
+        const result = await readLcc2(fs, 'meta.lcc2', opts());
+        assert.strictEqual(result[0].numRows, 8);
+        assert.deepStrictEqual(Array.from(result[0].getColumnByName('lod').data), [0, 0, 0, 0, 0, 0, 0, 0]);
+
+        // Each chunk opened exactly once (decode only - no scanning pass).
+        const chunkOpens = fs.attempts.filter(p => p.endsWith('.spz'));
+        assert.deepStrictEqual(chunkOpens.sort(), ['chunk1.spz', 'chunk2.spz']);
+    });
+
+    it('rejects when a meta count disagrees with the decoded chunk', async () => {
+        const fs = new MemoryReadFileSystem();
+        fs.set('chunk1.spz', await makeSpzBytes(5));
+
+        const meta = {
+            totalSplats: 4,
+            lodSplats: [4],
+            totalLevels: 1,
+            splatType: '.spz',
+            root: {
+                splatFiles: ['chunk1.spz'],
+                child: [{ data: { '3dgs': { name: 0, start: 0, count: 4 } } }] // actual chunk has 5
+            }
+        };
+        fs.set('meta.lcc2', new TextEncoder().encode(JSON.stringify(meta)));
+
+        await assert.rejects(
+            () => readLcc2(fs, 'meta.lcc2', opts()),
+            /splat count mismatch .* expected 4, decoded 5/
+        );
+    });
+});
+
+describe('readLcc2 (chunk format coverage)', () => {
+    it('decodes SOG chunks end-to-end', async () => {
+        const fs = new MemoryReadFileSystem();
+        fs.set('chunk1.sog', await makeSogBytes(5));
+        fs.set('chunk2.sog', await makeSogBytes(3));
+
+        const meta = {
+            totalSplats: 8,
+            lodSplats: [8],
+            totalLevels: 1,
+            splatType: '.sog',
+            root: {
+                splatFiles: ['chunk1.sog', 'chunk2.sog'],
+                child: [
+                    { data: { '3dgs': { name: 0 } } },
+                    { data: { '3dgs': { name: 1 } } }
+                ]
+            }
+        };
+        fs.set('meta.lcc2', new TextEncoder().encode(JSON.stringify(meta)));
+
+        const result = await readLcc2(fs, 'meta.lcc2', opts());
+        const merged = result[0];
+        assert.strictEqual(merged.numRows, 8);
+        assert.ok(merged.getColumnByName('x'));
+        assert.ok(Array.from(merged.getColumnByName('lod').data).every(v => v === 0));
+    });
+
+    it('decodes v3 (gzip-wrapped) SPZ chunks end-to-end', async () => {
+        // No meta counts, so the scanning fallback exercises the gzip header
+        // path on every chunk before decoding.
+        const fs = new MemoryReadFileSystem();
+        fs.set('chunk1.spz', await makeSpzBytes(5, { version: 3 }));
+        fs.set('chunk2.spz', await makeSpzBytes(3, { version: 3 }));
+
+        const meta = {
+            totalSplats: 8,
+            lodSplats: [8],
+            totalLevels: 1,
+            splatType: '.spz',
+            root: {
+                splatFiles: ['chunk1.spz', 'chunk2.spz'],
+                child: [
+                    { data: { '3dgs': { name: 0 } } },
+                    { data: { '3dgs': { name: 1 } } }
+                ]
+            }
+        };
+        fs.set('meta.lcc2', new TextEncoder().encode(JSON.stringify(meta)));
+
+        const result = await readLcc2(fs, 'meta.lcc2', opts());
+        assert.strictEqual(result[0].numRows, 8);
+    });
+
+    it('zero-fills columns missing from some chunks (heterogeneous SH)', async () => {
+        const fs = new MemoryReadFileSystem();
+        fs.set('plain.spz', await makeSpzBytes(3));
+        fs.set('sh.spz', await makeSpzBytes(4, { includeSH: true }));
+
+        const meta = {
+            totalSplats: 7,
+            lodSplats: [7],
+            totalLevels: 1,
+            splatType: '.spz',
+            root: {
+                splatFiles: ['plain.spz', 'sh.spz'],
+                child: [
+                    { data: { '3dgs': { name: 0 } } },
+                    { data: { '3dgs': { name: 1 } } }
+                ]
+            }
+        };
+        fs.set('meta.lcc2', new TextEncoder().encode(JSON.stringify(meta)));
+
+        const result = await readLcc2(fs, 'meta.lcc2', opts());
+        const merged = result[0];
+        assert.strictEqual(merged.numRows, 7);
+
+        const fRest = merged.getColumnByName('f_rest_0');
+        assert.ok(fRest, 'merged table has SH columns');
+        // Rows of the SH-less chunk (task order: plain.spz first) stay zero.
+        assert.deepStrictEqual(Array.from(fRest.data.slice(0, 3)), [0, 0, 0]);
+        // The SH chunk's region carries actual (quantized, nonzero) SH data
+        // in at least one coefficient.
+        let nonzero = false;
+        for (let c = 0; c < 45 && !nonzero; c++) {
+            const col = merged.getColumnByName(`f_rest_${c}`);
+            nonzero = Array.from(col.data.slice(3)).some(v => v !== 0);
+        }
+        assert.ok(nonzero, 'SH chunk region contains nonzero SH data');
+    });
+});
+
+describe('readLcc2 (file index validation)', () => {
+    it('rejects an out-of-range chunk file index', async () => {
+        const fs = new MemoryReadFileSystem();
+        const meta = {
+            totalSplats: 1,
+            lodSplats: [1],
+            totalLevels: 1,
+            splatType: '.spz',
+            root: {
+                splatFiles: ['a.spz'],
+                child: [{ data: { '3dgs': { name: 5 } } }]
+            }
+        };
+        fs.set('meta.lcc2', new TextEncoder().encode(JSON.stringify(meta)));
+
+        await assert.rejects(
+            () => readLcc2(fs, 'meta.lcc2', opts()),
+            /Invalid chunk file index 5/
+        );
+    });
+
+    it('rejects an empty chunk file path', async () => {
+        const fs = new MemoryReadFileSystem();
+        const meta = {
+            totalSplats: 1,
+            lodSplats: [1],
+            totalLevels: 1,
+            splatType: '.spz',
+            root: {
+                splatFiles: [''],
+                child: [{ data: { '3dgs': { name: 0 } } }]
+            }
+        };
+        fs.set('meta.lcc2', new TextEncoder().encode(JSON.stringify(meta)));
+
+        await assert.rejects(
+            () => readLcc2(fs, 'meta.lcc2', opts()),
+            /Invalid chunk file index 0/
+        );
     });
 });
 

--- a/test/webp-codec.test.mjs
+++ b/test/webp-codec.test.mjs
@@ -1,0 +1,48 @@
+/**
+ * Unit tests for WebPCodec.
+ *
+ * Verifies that the wasm module is compiled/instantiated once and shared
+ * across instances (per-chunk readers like readLcc2 call create() per chunk),
+ * including under concurrent first calls, and that codec instances still
+ * round-trip data correctly. Node's test runner isolates files into separate
+ * processes, so the static module cache cannot leak into other test files.
+ */
+
+import assert from 'node:assert';
+import { dirname, join } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { WebPCodec } from '../src/lib/index.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+WebPCodec.wasmUrl = join(__dirname, '..', 'lib', 'webp.wasm');
+
+describe('WebPCodec', () => {
+    it('shares one wasm module across sequential create() calls', async () => {
+        const a = await WebPCodec.create();
+        const b = await WebPCodec.create();
+        assert.ok(a !== b, 'create() returns distinct instances');
+        assert.strictEqual(a.Module, b.Module, 'instances share the same wasm module');
+    });
+
+    it('shares one wasm module across concurrent create() calls', async () => {
+        const [a, b] = await Promise.all([WebPCodec.create(), WebPCodec.create()]);
+        assert.strictEqual(a.Module, b.Module, 'concurrent first calls share one instantiation');
+    });
+
+    it('round-trips RGBA data losslessly', async () => {
+        const codec = await WebPCodec.create();
+        const width = 4;
+        const height = 4;
+        const rgba = new Uint8Array(width * height * 4);
+        for (let i = 0; i < rgba.length; i++) {
+            rgba[i] = (i * 37) & 0xff;
+        }
+        const webp = codec.encodeLosslessRGBA(rgba, width, height);
+        const decoded = codec.decodeRGBA(webp);
+        assert.strictEqual(decoded.width, width);
+        assert.strictEqual(decoded.height, height);
+        assert.deepStrictEqual(Array.from(decoded.rgba), Array.from(rgba));
+    });
+});


### PR DESCRIPTION
Reading an LCC2 scene currently holds every decoded chunk DataTable in memory and then `combine()` allocates a second full-size copy, so peak memory is ~2× the decoded scene (~53GB for a real 110M-splat scene with 3-band SH). This PR replaces decode-then-combine with a preallocate-and-copy scheme and fixes several smaller inefficiencies found in the same path.

### Changes

- **Preallocated output (the main fix).** Per-chunk splat counts are read from the meta's `data['3dgs'].count` fields (summed across nodes sharing a chunk file, matching real XGrids exports). When a count is missing (old-protocol files), a cheap fallback reads just the chunk header: SOG `meta.json` `count`/`means.shape[0]`, or SPZ `numPoints` (including streaming-gunzip of just the 16-byte header for gzip-wrapped v1–3 containers). Prefix-summed offsets fix the output layout before decoding, so workers completing out of order still write into disjoint regions and the result stays deterministic. Each decoded chunk is validated against its expected count, copied into the output arrays at its offset and released. Output columns are allocated once at exact final size on first sighting, preserving `combine()`'s zero-fill semantics for heterogeneous chunks. Peak memory is now ~1× the scene plus the chunks in flight.
- **WebP WASM module memoized.** `WebPCodec.create()` previously compiled and instantiated a fresh Emscripten module (with its own heap) on every call — once per SOG chunk via `readSog`. The module promise is now cached, mirroring the existing `getSpzModule()` pattern.
- **Progress bar fix.** Logger bars are strictly LIFO, but readLcc2 ran 4 concurrent `readSog` calls each opening its own bar, corrupting the display (sibling bars popped as failed, outer bar suppressed). `readSog`/`readSogV1` now accept `{ logging: 'own' | 'silent' }` (mirroring `writeSog`) and readLcc2 silences the per-chunk bars under its own single bar.
- **Single octree traversal.** `collectChunksByLevel` gathers every level's chunk files (with counts) in one pass, replacing the per-LOD `collectFileIndicesForLod` traversals.
- **Safer tolerant JSON parsing.** Strict `JSON.parse` is tried first; only on failure is a string-aware trailing-comma stripper applied. The old `,\s*}` regex corrupted string values containing `",}"` and missed trailing commas before `]`.
- **Chunk file index validation.** Out-of-range or empty `splatFiles` references now fail with a descriptive error instead of crashing in `join()`.

### Verification

- Full test suite passes (548 tests), including 20 new LCC2 tests (meta-count path, count-mismatch rejection, SPZ v3 gzip and SOG header fallbacks, SOG/SPZ end-to-end, heterogeneous-SH zero-fill, index validation) and 3 new WebPCodec memoization tests.
- Outputs verified byte-identical to the previous implementation on two real XGrids scenes (110.3M-splat Cecil_Ivar across single- and multi-LOD selections, and a 44.3M-splat scene).
- Measured peak RSS on Cecil_Ivar (read-only, `null` output): LOD 3 (6.8M splats) 3.50GB → 2.51GB, LOD 2 (13.7M splats) 6.71GB → 4.48GB, with run time at parity. The gap grows with scene size since the overhead beyond 1× is now a constant ~`LOAD_CONCURRENCY` chunks.