### PR TITLE
Allow --lod -1 to tag an input as the environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Actions execute in the order specified and can be repeated. Any action may appea
                                           Default: res=1.0, opacity=0.999, min=0.1.
                                           Bare flag (no value) uses all defaults.
 -p, --params           <key=val,...>    Pass parameters to .mjs generator script
--l, --lod              <n>              Tag the Gaussians with LOD level n (n >= 0)
+-l, --lod              <n>              Tag the Gaussians with LOD level n (n >= 0, or -1 for environment)
 -m, --summary                           Print per-column statistics to stdout
 -M, --morton-order                      Reorder Gaussians by Morton code (Z-order curve)
 ```

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -632,8 +632,8 @@ const parseArguments = async () => {
                 }
                 case 'lod': {
                     const lod = parseInteger(t.value);
-                    if (lod < 0) {
-                        throw new Error(`Invalid lod value: ${t.value}. Must be a non-negative integer.`);
+                    if (lod < -1) {
+                        throw new Error(`Invalid lod value: ${t.value}. Must be >= 0, or -1 for environment.`);
                     }
                     current.processActions.push({
                         kind: 'lod',
@@ -755,7 +755,7 @@ ACTIONS (executed in order; can be repeated)
     -G, --filter-floaters  [size,op,min]    Remove Gaussians not contributing to any solid voxel. Default: 0.05,0.1,0.004
     -D, --filter-cluster   [res,op,min]     Keep only the connected cluster at --seed-pos. Default: 1.0,0.999,0.1
     -p, --params           <key=val,...>    Pass parameters to .mjs generator script
-    -l, --lod              <n>              Tag the Gaussians with LOD level n (n >= 0)
+    -l, --lod              <n>              Tag the Gaussians with LOD level n (n >= 0, or -1 for environment)
     -m, --summary                           Print per-column statistics to stdout
     -M, --morton-order                      Reorder Gaussians by Morton code (Z-order curve)
 
@@ -1145,6 +1145,10 @@ const main = async () => {
         // special-case the environment dataTable
         const envDataTables = inputDataTables.filter(dt => dt.hasColumn('lod') && dt.getColumnByName('lod').data.every(v => v === -1));
         const nonEnvDataTables = inputDataTables.filter(dt => !dt.hasColumn('lod') || dt.getColumnByName('lod').data.some(v => v !== -1));
+
+        if (envDataTables.length > 0 && outputFormat !== null && outputFormat !== 'lod') {
+            logger.warn(`Environment splats (--lod -1) are only written for lod-meta.json output; they will be discarded for '${outputFormat}' output.`);
+        }
 
         // combine inputs into a single output dataTable
         const dataTable = nonEnvDataTables.length > 0 && await processDataTable(

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -80,4 +80,32 @@ describe('CLI parsing', () => {
 
         assert.strictEqual(result.code, 0, `CLI failed:\n${result.stderr}\n${result.stdout}`);
     });
+
+    it('accepts --lod -1 to tag an input as environment', async () => {
+        const result = await runCli([
+            '--gpu',
+            'cpu',
+            'test/fixtures/splat/minimal.splat',
+            'test/fixtures/splat/minimal.splat',
+            '--lod',
+            '-1',
+            'null'
+        ]);
+
+        assert.strictEqual(result.code, 0, `CLI failed:\n${result.stderr}\n${result.stdout}`);
+    });
+
+    it('rejects --lod values below -1', async () => {
+        const result = await runCli([
+            '--gpu',
+            'cpu',
+            'test/fixtures/splat/minimal.splat',
+            '--lod',
+            '-2',
+            'null'
+        ]);
+
+        assert.notStrictEqual(result.code, 0, 'CLI should reject --lod -2');
+        assert.match(result.stderr, /Must be >= 0, or -1/);
+    });
 });


### PR DESCRIPTION
## Summary

The environment/skybox concept already exists throughout the pipeline as the sentinel `lod === -1` — LCC/LCC2 readers tag environment splats with it, the CLI splits those splats into a separate `envDataTable`, and the LOD writer emits them to `env/meta.json` (referenced from `lod-meta.json` via the `environment` field). The only gap was that there was no way to assign it *manually*: `--lod` validation rejected any negative value, so an arbitrary `.ply`/`.sog`/etc. input could never be marked as the environment.

This change relaxes the validation so `--lod -1` is accepted, unlocking the existing environment path from the CLI.

## Changes

- **Validation** (`src/cli/index.ts`): `--lod` now rejects values `< -1` instead of `< 0`, permitting the `-1` environment sentinel while still rejecting other negatives (only `-1` is recognized; other negatives would be mis-binned by the LOD writer).
- **Warning** (`src/cli/index.ts`): environment splats are only written for `lod-meta.json` output — every other writer ignores `envDataTable`. We now emit a warning when env-tagged splats are present but the output format isn't LOD, so they aren't silently dropped.
- **Docs**: updated the `--lod` help text and README usage block to `(n >= 0, or -1 for environment)`.
- **Tests** (`test/cli.test.mjs`): added coverage for `--lod -1` being accepted and `--lod -2` being rejected.

No change was needed to argument tokenization (`normalizeArgv` already rewrites `--lod -1` → `--lod=-1`) or to `process.ts` (it fills the `lod` column with whatever value, `-1` included).

## Usage

```
splat-transform scene.ply --lod 0 env.ply --lod -1 out/lod-meta.json
```

`--lod` is per-input, so it must follow the input file it tags. Note that for `lod-meta.json` output the scene input must itself carry a `--lod <n>` tag (pre-existing `write-lod` requirement).

## Testing

- `npm run lint` — clean
- `node --test test/cli.test.mjs` — 4/4 pass; `test/write-lod.test.mjs` — 2/2 pass
- End-to-end: `scene --lod 0 env --lod -1 out/lod-meta.json` writes `env/meta.json` + textures and sets `"environment":"env/meta.json"` in the manifest
- End-to-end: same inputs to `out.ply` prints the discard warning and excludes the env splats from the output