### PR TITLE
Fix infinite hang on degenerate splats: O(N²) KD-tree build + decimate stall guard

### DIFF
--- a/src/lib/data-table/decimate.ts
+++ b/src/lib/data-table/decimate.ts
@@ -16,6 +16,17 @@ const MC_SAMPLES = 1;
 const EPS_COV = 1e-8;
 const PROGRESS_TICKS = 100;
 
+// Minimum fraction of the current splats a single merge pass must remove once
+// its disjoint-pair matching is exhausted. A well-formed k-NN graph yields a
+// near-perfect matching — the loop below is built around each pass roughly
+// halving the count (see `estIterations`) — so a productive pass removes ~50%.
+// A pass that removes far less means the graph is degenerate (e.g. many
+// coincident splats collapse every query's neighbours onto a shared handful of
+// indices, starving disjoint pairing), and grinding to the target would take
+// thousands of passes. Set an order of magnitude below the healthy ~50% so
+// legitimate scenes never trip it.
+const MIN_ITERATION_PROGRESS = 0.05;
+
 // ---------- sigmoid / logit ----------
 
 const sigmoid = (x: number) => 1 / (1 + Math.exp(-x));
@@ -1010,6 +1021,28 @@ const simplifyGaussians = async (
                 throw new Error(
                     `decimation found no valid merge pairs among ${edgeCount} edges at ${n} splats (target ${targetCount}) — ` +
                     `${cause}. Refusing to return an incompletely-decimated scene.`
+                );
+            }
+
+            // No-progress guard. `pairs.length < mergesNeeded` means the matching
+            // was exhausted before reaching the target (it didn't hit the break
+            // above). If it also removed less than MIN_ITERATION_PROGRESS of the
+            // current splats, the k-NN graph is too degenerate to decimate — e.g.
+            // many coincident splats collapse every query's neighbours onto a
+            // shared handful of indices, so disjoint pairing starves and progress
+            // crawls (a fully-degenerate 9.84M scene took 130+ passes to halve).
+            // Fail loud rather than grind toward the target across thousands of
+            // passes, consistent with the edgeCount===0 / pairs===0 guards above.
+            // A well-formed scene removes ~half per exhausted pass, so legitimate
+            // multi-pass decimation never trips this.
+            const removedFraction = pairs.length / n;
+            if (pairs.length < mergesNeeded && removedFraction < MIN_ITERATION_PROGRESS) {
+                g.end();
+                throw new Error(
+                    `decimation stalled at ${n} splats (target ${targetCount}): a merge pass removed only ` +
+                    `${pairs.length} splat${pairs.length === 1 ? '' : 's'} (${(removedFraction * 100).toFixed(3)}% of ${n}) — ` +
+                    'the nearest-neighbour graph is too degenerate to merge further (e.g. many coincident splats). ' +
+                    'Refusing to grind toward the target.'
                 );
             }
 

--- a/src/lib/spatial/kd-tree.ts
+++ b/src/lib/spatial/kd-tree.ts
@@ -17,19 +17,31 @@ const nthElement = (arr: Uint32Array, lo: number, hi: number, k: number, values:
         else pivotIdx = hi;
 
         const pivotVal = values[arr[pivotIdx]];
-        let tmp = arr[pivotIdx]; arr[pivotIdx] = arr[hi]; arr[hi] = tmp;
-        let store = lo;
-        for (let i = lo; i < hi; i++) {
-            if (values[arr[i]] < pivotVal) {
-                tmp = arr[i]; arr[i] = arr[store]; arr[store] = tmp;
-                store++;
+
+        // 3-way (Dutch National Flag) partition around pivotVal:
+        //   [lo..lt-1] < pivot, [lt..gt] == pivot, [gt+1..hi] > pivot.
+        // The 2-way Lomuto partition this replaces moved only strictly-less
+        // elements, so an all-equal range shrank by one per pass and degenerated
+        // to O(N^2) — fatal for inputs where many points share a coordinate
+        // (e.g. a splat with every gaussian at the origin).
+        let lt = lo, gt = hi, i = lo;
+        let tmp: number;
+        while (i <= gt) {
+            const v = values[arr[i]];
+            if (v < pivotVal) {
+                tmp = arr[i]; arr[i] = arr[lt]; arr[lt] = tmp;
+                lt++; i++;
+            } else if (v > pivotVal) {
+                tmp = arr[i]; arr[i] = arr[gt]; arr[gt] = tmp;
+                gt--;
+            } else {
+                i++;
             }
         }
-        tmp = arr[store]; arr[store] = arr[hi]; arr[hi] = tmp;
 
-        if (store === k) return;
-        else if (store < k) lo = store + 1;
-        else hi = store - 1;
+        if (k < lt) hi = lt - 1;
+        else if (k > gt) lo = gt + 1;
+        else return; // k within the equal block; arr[k] is the order statistic
     }
 };
 

--- a/test/decimate.test.mjs
+++ b/test/decimate.test.mjs
@@ -298,6 +298,23 @@ describe('simplifyGaussians', () => {
         );
     });
 
+    it('should fail loud (throw) when the scene is too degenerate to decimate', async () => {
+        // Every splat coincident at the origin with finite, valid columns. The
+        // k-NN graph collapses onto a shared handful of neighbours, so the
+        // disjoint-pair matching can only merge a sliver per pass and decimation
+        // can't make real progress. The no-progress guard must throw rather than
+        // grind toward the target across thousands of passes — this exact shape
+        // (millions of coincident splats) wedged the production pipeline. 600
+        // rows → 300 trips the guard on the first pass.
+        const testData = createVisibilityTestData({ count: 600 });
+
+        await assert.rejects(
+            () => simplifyGaussians(testData, 300),
+            /too degenerate to merge further/,
+            'should throw when coincident splats starve the matching'
+        );
+    });
+
     it('should fall back to visibility pruning when rotation columns are missing', async () => {
         const testData = new DataTable([
             new Column('x', new Float32Array([0, 1, 2, 3])),

--- a/test/kd-tree.test.mjs
+++ b/test/kd-tree.test.mjs
@@ -22,24 +22,28 @@ const buildTree = (xs, ys, zs) => new KdTree(new DataTable([
 
 describe('KdTree', () => {
     it('builds in sub-quadratic time over a large all-identical point set', { timeout: 5000 }, () => {
-        // Pre-fix the 2-way Lomuto partition degenerated to O(N^2) here
-        // (~5e9 ops at N=100k → tens of seconds), which is exactly how the prod
-        // GPU pipeline pod hung on a splat with every gaussian at the origin.
+        // Pre-fix the 2-way Lomuto partition degenerated to O(N^2) in the KD-tree
+        // *build* (~5e9 ops at N=100k → tens of seconds), which is exactly how the
+        // prod GPU pipeline pod hung on a splat with every gaussian at the origin.
         // Post-fix the 3-way partition keeps the build O(N log N): milliseconds.
+        // Time the build (plus one query) so a regression in build time — the
+        // actual fault — trips this assertion explicitly, not just the 5s timeout.
         const N = 100_000;
+
+        const start = performance.now();
         const tree = new KdTree(new DataTable([
             new Column('x', new Float32Array(N)),
             new Column('y', new Float32Array(N)),
             new Column('z', new Float32Array(N))
         ]));
-
-        const start = performance.now();
         const { indices, distances } = tree.findKNearest(new Float32Array([0, 0, 0]), 8);
         const elapsed = performance.now() - start;
 
-        // A single KNN query must not pay O(N) per node either; generous ceiling
-        // so this is a hang detector, not a perf microbenchmark.
-        assert.ok(elapsed < 1000, `KNN query took ${elapsed.toFixed(0)}ms; expected < 1000ms`);
+        // Generous ceiling, far below the multi-second O(N^2) build but well above
+        // the O(N log N) build's few-ms cost — a hang detector, not a microbenchmark.
+        assert.ok(elapsed < 2000,
+            `KD-tree build + KNN over ${N} coincident points took ${elapsed.toFixed(0)}ms; ` +
+            `expected < 2000ms (O(N^2) build regression)`);
 
         // KNN still returns k valid neighbours, all co-located at distance 0.
         assert.strictEqual(indices.length, 8);

--- a/test/kd-tree.test.mjs
+++ b/test/kd-tree.test.mjs
@@ -1,0 +1,112 @@
+/**
+ * KdTree tests for splat-transform.
+ *
+ * Regression coverage for the O(N^2) build hang on degenerate inputs where many
+ * points share a coordinate (e.g. a splat with every gaussian at the origin):
+ * the build must stay O(N log N), and nearest-neighbour queries must remain
+ * correct when ties are present.
+ */
+
+import assert from 'node:assert';
+import { performance } from 'node:perf_hooks';
+import { describe, it } from 'node:test';
+
+import { Column, DataTable } from '../src/lib/index.js';
+import { KdTree } from '../src/lib/spatial/kd-tree.js';
+
+const buildTree = (xs, ys, zs) => new KdTree(new DataTable([
+    new Column('x', Float32Array.from(xs)),
+    new Column('y', Float32Array.from(ys)),
+    new Column('z', Float32Array.from(zs))
+]));
+
+describe('KdTree', () => {
+    it('builds in sub-quadratic time over a large all-identical point set', { timeout: 5000 }, () => {
+        // Pre-fix the 2-way Lomuto partition degenerated to O(N^2) here
+        // (~5e9 ops at N=100k → tens of seconds), which is exactly how the prod
+        // GPU pipeline pod hung on a splat with every gaussian at the origin.
+        // Post-fix the 3-way partition keeps the build O(N log N): milliseconds.
+        const N = 100_000;
+        const tree = new KdTree(new DataTable([
+            new Column('x', new Float32Array(N)),
+            new Column('y', new Float32Array(N)),
+            new Column('z', new Float32Array(N))
+        ]));
+
+        const start = performance.now();
+        const { indices, distances } = tree.findKNearest(new Float32Array([0, 0, 0]), 8);
+        const elapsed = performance.now() - start;
+
+        // A single KNN query must not pay O(N) per node either; generous ceiling
+        // so this is a hang detector, not a perf microbenchmark.
+        assert.ok(elapsed < 1000, `KNN query took ${elapsed.toFixed(0)}ms; expected < 1000ms`);
+
+        // KNN still returns k valid neighbours, all co-located at distance 0.
+        assert.strictEqual(indices.length, 8);
+        for (let i = 0; i < 8; i++) {
+            assert.ok(indices[i] >= 0 && indices[i] < N, `index ${indices[i]} out of range`);
+            assert.strictEqual(distances[i], 0);
+        }
+    });
+
+    it('returns correct neighbours when the set contains duplicate coordinates', () => {
+        // Five duplicates at the origin plus distinct points along +x. Exercises
+        // the equal-block handling while keeping a well-defined nearest result.
+        const xs = [0, 0, 0, 0, 0, 1, 2, 5];
+        const ys = [0, 0, 0, 0, 0, 0, 0, 0];
+        const zs = [0, 0, 0, 0, 0, 0, 0, 0];
+        const tree = buildTree(xs, ys, zs);
+
+        // Nearest to (1.9, 0, 0) is index 6 at (2,0,0), dist^2 = 0.01.
+        const near = tree.findNearest(new Float32Array([1.9, 0, 0]));
+        assert.strictEqual(near.index, 6);
+        assert.ok(Math.abs(near.distanceSqr - 0.01) < 1e-5, `distanceSqr=${near.distanceSqr}`);
+
+        // 3 nearest to (5,0,0): idx7 (0), idx6 (9), idx5 (16) — distinct dists.
+        const { indices, distances } = tree.findKNearest(new Float32Array([5, 0, 0]), 3);
+        assert.deepStrictEqual(Array.from(indices), [7, 6, 5]);
+        assert.ok(Math.abs(distances[0] - 0) < 1e-5);
+        assert.ok(Math.abs(distances[1] - 9) < 1e-5);
+        assert.ok(Math.abs(distances[2] - 16) < 1e-5);
+    });
+
+    it('matches brute-force KNN on a mixed set with frequent ties', () => {
+        // Deterministic pseudo-random points drawn from a small coordinate set
+        // (0 over-represented → frequent duplicates) compared to brute force.
+        const N = 500;
+        const coords = [-2, -1, 0, 0, 0, 1, 2];
+        let seed = 12345;
+        const rand = () => {
+            seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+            return coords[seed % coords.length];
+        };
+        const xs = [], ys = [], zs = [];
+        for (let i = 0; i < N; i++) {
+            xs.push(rand());
+            ys.push(rand());
+            zs.push(rand());
+        }
+        const tree = buildTree(xs, ys, zs);
+
+        const k = 5;
+        for (const qi of [0, 17, 199, 333, 499]) {
+            const q = new Float32Array([xs[qi], ys[qi], zs[qi]]);
+            const { distances } = tree.findKNearest(q, k);
+
+            // Brute-force k smallest squared distances (self included, as the CPU
+            // findKNearest does not exclude the query point).
+            const all = [];
+            for (let i = 0; i < N; i++) {
+                const dx = xs[i] - q[0], dy = ys[i] - q[1], dz = zs[i] - q[2];
+                all.push(dx * dx + dy * dy + dz * dz);
+            }
+            all.sort((a, b) => a - b);
+
+            // Distances must equal the true k smallest (indices may differ on ties).
+            for (let i = 0; i < k; i++) {
+                assert.ok(Math.abs(distances[i] - all[i]) < 1e-5,
+                    `query ${qi} neighbour ${i}: got ${distances[i]}, expected ${all[i]}`);
+            }
+        }
+    });
+});


### PR DESCRIPTION
## Problem

`splat-transform --decimate` hangs indefinitely on certain inputs, wedging the production GPU pipeline until its 2h timeout. Reproduced on a 9.84M-gaussian PLY where nearly every gaussian is coincident at the origin (degenerate/uninitialized capture).

There are two independent failures, both triggered by the same degenerate input:

## 1. O(N²) KD-tree build hang

`nthElement` in `src/lib/spatial/kd-tree.ts` used a 2-way Lomuto partition that only moves elements strictly less than the pivot. When a coordinate is all-equal, nothing moves and the selection range shrinks by one per pass — each pass O(N) — so the KD-tree build degrades from O(N log N) to O(N²). At ~10M coincident points that never completes. The stall is on the CPU before any GPU work dispatches, which is why it reproduced on both WebGPU/Vulkan and Metal.

**Fix:** 3-way (Dutch National Flag) partition. Equal elements collapse in a single pass, restoring O(N log N). For distinct coordinates the equal block is one element, so the median index and resulting tree are identical to before — no behavioural change for normal splats, no memory impact (in-place).

## 2. Decimate makes no progress on degenerate input

With every point coincident, all KNN distances are 0 and the traversal returns the same ~K shared neighbour indices for every query, so the directed-edge graph funnels onto a handful of targets. The greedy disjoint-pair matching can then only merge ~K pairs per pass (17, in the repro) instead of ~N/2, so it crawls toward the target across thousands of passes. The existing degenerate guards only fire on zero progress (`edgeCount === 0`, `pairs.length === 0`), so a tiny-but-nonzero matching slips through.

**Fix:** a no-progress guard. When a pass's matching is exhausted before reaching the target (`pairs.length < mergesNeeded`) yet removes less than `MIN_ITERATION_PROGRESS` (5%) of the current splats, throw a clear error rather than grind. A well-formed scene removes ~50% per exhausted pass, so legitimate multi-pass decimation never trips it; it's gated on matching exhaustion, so single-pass decimation can't trip it either.

## Testing

- New `test/kd-tree.test.mjs`: builds a tree over 100k coincident points (would hang pre-fix) in milliseconds; brute-force KNN correctness on sets with frequent ties.
- New `test/decimate.test.mjs` case: a fully-coincident scene now throws the stall error instead of grinding.
- Full suite green (566 tests) incl. render-golden — no tie-break or behavioural shift on valid scenes. Lint clean.
- End-to-end on the original 9.84M PLY: previously hung 30+ min (136+ passes, never finishing); now fails in ~10s with a clear message and non-zero exit.