### PR TITLE
Rationalize CLI flag names

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Actions execute in the order specified and can be repeated. Any action may appea
                                           opacity, scale_*, f_dc_* use transformed values
                                           (linear opacity 0-1, linear scale, linear color 0-1).
                                           Append _raw for raw PLY values (e.g. opacity_raw).
--F, --decimate         <n|n%>           Simplify to n Gaussians via merge-based decimation
+-d, --decimate         <n|n%>           Simplify to n Gaussians via merge-based decimation
                                           Use n% to keep a percentage of Gaussians.
                                           Memory-bounded and streaming: scales to scenes of 100M+
                                           Gaussians. Must be the final action, and the output must
@@ -117,19 +117,19 @@ Actions execute in the order specified and can be repeated. Any action may appea
                                           temporary files to --scratch-dir (default: the output
                                           file's directory).
     --scratch-dir      <path>           Directory for decimation spill files
--G, --filter-floaters  [size,op,min]    Remove Gaussians not contributing to any solid voxel.
+-F, --filter-floaters  [size,op,min]    Remove Gaussians not contributing to any solid voxel.
                                           Evaluates each Gaussian at occupied voxel centers.
                                           Default: size=0.05, opacity=0.1, min=0.004 (1/255).
                                           Bare flag (no value) uses all defaults.
--D, --filter-cluster   [res,op,min]     Keep only the connected cluster at --seed-pos.
+-C, --filter-cluster   [res,op,min]     Keep only the connected cluster at --seed-pos.
                                           GPU-voxelizes at coarse resolution (res world units/voxel).
                                           Default: res=1.0, opacity=0.999, min=0.1.
                                           Bare flag (no value) uses all defaults.
 -p, --params           <key=val,...>    Pass parameters to .mjs generator script
--l, --lod              <n>              Tag the Gaussians with LOD level n (n >= 0, or -1 for environment)
--m, --stats            [text|json]      Print file info and per-column statistics to stdout. Default: text
--I, --info             [text|json]      Print structural metadata (per-LOD counts, columns) to stdout. Default: text
--M, --morton-order                      Reorder Gaussians by Morton code (Z-order curve)
+-l, --tag-lod          <n>              Tag the Gaussians with LOD level n (n >= 0, or -1 for environment)
+    --stats            [text|json]      Print file info and per-column statistics to stdout. Default: text
+    --info             [text|json]      Print structural metadata (per-LOD counts, columns) to stdout. Default: text
+-m, --morton-order                      Reorder Gaussians by Morton code (Z-order curve)
 ```
 
 ## General Options
@@ -139,7 +139,7 @@ Actions execute in the order specified and can be repeated. Any action may appea
 -v, --version                           Show version and exit
 -q, --quiet                             Suppress non-error output
     --verbose                           Show debug-level diagnostics
-    --mem                               Show peak memory in progress output
+    --memory                            Show peak memory in progress output
     --tty                               Interactive bar rendering (default on a TTY; --no-tty to disable)
 -w, --overwrite                         Overwrite output file if it exists
 ```
@@ -149,7 +149,7 @@ Actions execute in the order specified and can be repeated. Any action may appea
 Used by SOG compression and GPU voxelization (`--filter-cluster`, `--filter-floaters`, `.voxel.json` output).
 
 ```none
--L, --list-gpus                         List available GPU adapters and exit
+    --list-gpus                         List available GPU adapters and exit
 -g, --gpu              <n|cpu>          Device for GPU operations: GPU adapter index | 'cpu'
                                           ('cpu' disables GPU and is incompatible with
                                           GPU-only features like --filter-cluster)
@@ -160,7 +160,7 @@ Used by SOG compression and GPU voxelization (`--filter-cluster`, `--filter-floa
 Apply when writing `.sog`, `meta.json`, `lod-meta.json`, or `.html` outputs.
 
 ```none
--i, --iterations       <n>              Iterations for SH compression (more=better). Default: 10
+-i, --sh-iterations    <n>              Iterations for SH compression (more=better). Default: 10
     --max-workers      <n>              Worker threads for SOG encoding (0 = inline/serial). Default: 4
 ```
 
@@ -177,19 +177,19 @@ Apply when writing `.spz` outputs.
 Apply when writing `.html` outputs.
 
 ```none
--E, --viewer-settings  <settings.json>  HTML viewer settings JSON file
--U, --unbundled                         Generate unbundled HTML viewer with separate files
+    --viewer-settings  <settings.json>  HTML viewer settings JSON file
+    --unbundled                         Generate unbundled HTML viewer with separate files
 ```
 
 > [!NOTE]
-> See the [SuperSplat Viewer Settings Schema](https://github.com/playcanvas/supersplat-viewer?tab=readme-ov-file#settings-schema) for details on how to pass data to the `-E` option.
+> See the [SuperSplat Viewer Settings Schema](https://github.com/playcanvas/supersplat-viewer?tab=readme-ov-file#settings-schema) for details on how to pass data to the `--viewer-settings` option.
 
 ## LCC / LCC2 Input Options
 
 Apply when reading `.lcc` and `.lcc2` files.
 
 ```none
--O, --lod-select       <n,n,...>        Comma-separated LOD levels to read from LCC / LCC2 input
+-L, --select-lod       <n,n,...>        Comma-separated LOD levels to read from LCC / LCC2 input
 ```
 
 ## LOD Output Options
@@ -197,8 +197,8 @@ Apply when reading `.lcc` and `.lcc2` files.
 Apply when writing `lod-meta.json` (multi-LOD streaming SOG bundle).
 
 ```none
--C, --lod-chunk-count  <n>              Approximate number of Gaussians per LOD chunk in K. Default: 512
--X, --lod-chunk-extent <n>              Approximate size of an LOD chunk in world units (m). Default: 16
+    --lod-chunk-count  <n>              Approximate number of Gaussians per LOD chunk in K. Default: 512
+    --lod-chunk-extent <n>              Approximate size of an LOD chunk in world units (m). Default: 16
 ```
 
 See [Generating Streamed SOG](https://developer.playcanvas.com/user-manual/splat-transform/#generating-lod-format) for an end-to-end walkthrough.
@@ -208,7 +208,8 @@ See [Generating Streamed SOG](https://developer.playcanvas.com/user-manual/splat
 Apply when writing `.voxel.json` (sparse voxel octree for collision detection). See the [Collision Mesh Guide](https://developer.playcanvas.com/user-manual/splat-transform/collision/) for a deep dive on each step and tuning.
 
 ```none
-    --voxel-params     [size,opacity]   Voxel size and opacity threshold. Default: 0.05,0.1
+    --voxel-size       <n>              Voxel size for .voxel.json. Default: 0.05
+    --voxel-opacity    <n>              Voxel opacity threshold for .voxel.json. Default: 0.1
     --voxel-external-fill [size]        Seal exterior voxels via boundary flood fill (interior scenes).
                                           [size] (world units) is the dilation distance applied
                                           before the flood fill to bridge small wall gaps.
@@ -224,7 +225,7 @@ Apply when writing `.voxel.json` (sparse voxel octree for collision detection). 
                                           Default: height=1.6, radius=0.2
     --seed-pos         <x,y,z>          Seed position for voxel fill/carve and --filter-cluster.
                                           Default: 0,0,0
--K, --collision-mesh   [smooth|faces]   Generate collision mesh (.collision.glb). Default: smooth
+    --collision-mesh   [smooth|faces]   Generate collision mesh (.collision.glb). Default: smooth
 ```
 
 ## Image Output Options
@@ -233,31 +234,31 @@ Apply when writing `.webp` (lossless WebP rendered via GPU rasterizer).
 
 ```none
     --projection       <pinhole|equirect>  Camera projection. Default: pinhole.
-                                        equirect = 360°×180° panorama from --camera; --fov must be
+                                        equirect = 360°×180° panorama from --camera-pos; --camera-fov must be
                                         omitted; --resolution must be 2:1 (default 2048x1024).
-    --camera           <x,y,z>          Camera position in world space. Default: 2,1,-2
-    --look-at          <x,y,z>          Camera target point. Default: 0,0,0
-    --up               <x,y,z>          World up vector. Default: 0,1,0
-    --fov              <degrees>        Vertical field of view in degrees. Default: 60. Rejected with --projection equirect.
+    --camera-pos       <x,y,z>          Camera position in world space. Default: 2,1,-2
+    --camera-target    <x,y,z>          Camera target point. Default: 0,0,0
+    --camera-up        <x,y,z>          World up vector. Default: 0,1,0
+    --camera-fov       <degrees>        Vertical field of view in degrees. Default: 60. Rejected with --projection equirect.
     --resolution       <WxH>            Output resolution, e.g. 1920x1080. Default: 1280x720 (pinhole) or 2048x1024 (equirect)
-    --near             <n>              Near clip distance. Default: 0.2 (matches reference 3DGS)
+    --camera-near      <n>              Near clip distance. Default: 0.2 (matches reference 3DGS)
     --background       <r,g,b[,a]>      Background color in [0,1]. Default: 0,0,0,1
     --f-stop           <N>              Aperture as a photographic f-stop (e.g. 2.8, 5.6, 11). Enables defocus blur;
                                         smaller = more blur. Pinhole only. Default: disabled (no defocus).
-    --focus-distance   <n>              Camera-space Z of the focus plane (world units). Default: distance to --look-at.
+    --focus-distance   <n>              Camera-space Z of the focus plane (world units). Default: distance to --camera-target.
                                         Pinhole only; only meaningful with --f-stop.
     --sensor-size      <n>              Vertical sensor height in world units. Gives --f-stop a physical meaning.
                                         Default: 0.024 (35mm full-frame, world units = meters). Scale to your world:
                                         world unit = decimeter → 0.24, world unit = millimeter → 24.
-    --camera-end       <x,y,z>          End camera position. When set, enables camera motion blur: the renderer
-                                        averages sub-frames with the camera interpolated from --camera (shutter open)
-                                        to --camera-end (shutter close). Default: disabled (no motion blur).
-    --look-at-end      <x,y,z>          End camera target. Default: same as --look-at. Only with --camera-end.
-    --up-end           <x,y,z>          End up vector. Default: same as --up. Only with --camera-end.
+    --camera-pos-end   <x,y,z>          End camera position. When set, enables camera motion blur: the renderer
+                                        averages sub-frames with the camera interpolated from --camera-pos (shutter open)
+                                        to --camera-pos-end (shutter close). Default: disabled (no motion blur).
+    --camera-target-end <x,y,z>         End camera target. Default: same as --camera-target. Only with --camera-pos-end.
+    --camera-up-end    <x,y,z>          End up vector. Default: same as --camera-up. Only with --camera-pos-end.
     --shutter          <0..1>           Fraction of the start→end segment integrated, centered on the midpoint
-                                        (1.0 = full motion; 0.5 = 180° shutter). Default: 1. Only with --camera-end.
+                                        (1.0 = full motion; 0.5 = 180° shutter). Default: 1. Only with --camera-pos-end.
     --motion-samples   <n>              Sub-frames to accumulate for motion blur. Cost is N× a single render.
-                                        Default: 16. Only with --camera-end.
+                                        Default: 16. Only with --camera-pos-end.
 ```
 
 ## Examples
@@ -297,10 +298,10 @@ splat-transform output/meta.json restored.ply
 splat-transform input.ply output.html
 
 # Convert to unbundled HTML viewer (separate CSS, JS, and SOG files)
-splat-transform -U input.ply output.html
+splat-transform --unbundled input.ply output.html
 
 # Convert to HTML viewer with custom settings
-splat-transform -E settings.json input.ply output.html
+splat-transform --viewer-settings settings.json input.ply output.html
 ```
 
 ### Transformations
@@ -332,7 +333,7 @@ splat-transform input.ply --filter-harmonics 2 output.ply
 splat-transform input.ply --decimate 50000 output.ply
 
 # Simplify to 25% of original splat count
-splat-transform input.ply -F 25% output.ply
+splat-transform input.ply -d 25% output.ply
 ```
 
 ### Advanced Usage
@@ -354,7 +355,7 @@ Generate per-column statistics for data analysis or test validation:
 splat-transform input.ply --stats output.ply
 
 # Print stats without writing a file (discard output)
-splat-transform input.ply -m null
+splat-transform input.ply --stats null
 
 # Print stats as JSON for scripting
 splat-transform input.ply --stats json null
@@ -375,7 +376,7 @@ splat-transform gen-grid.mjs -p width=10,height=10,scale=10,color=0.1 scenes/gri
 
 ### Voxel Format
 
-The voxel format stores sparse voxel octree data for collision detection. It consists of two files: `.voxel.json` (metadata) and `.voxel.bin` (binary octree data). Pass `-K` to also emit a `.collision.glb` mesh derived from the voxel grid.
+The voxel format stores sparse voxel octree data for collision detection. It consists of two files: `.voxel.json` (metadata) and `.voxel.bin` (binary octree data). Pass `--collision-mesh` to also emit a `.collision.glb` mesh derived from the voxel grid.
 
 For a step-by-step walkthrough of each option (with illustrations), see the [Collision Mesh Guide](https://developer.playcanvas.com/user-manual/splat-transform/collision/).
 
@@ -385,7 +386,7 @@ For a step-by-step walkthrough of each option (with illustrations), see the [Col
 splat-transform input.ply \
     --filter-cluster --seed-pos x,y,z \
     [--voxel-external-fill | --voxel-floor-fill] [--voxel-carve] \
-    [-K [smooth|faces]] \
+    [--collision-mesh [smooth|faces]] \
     output.voxel.json
 ```
 
@@ -399,7 +400,7 @@ Use `--voxel-external-fill` to seal the void around the room interior, then `--v
 splat-transform room.ply \
     --filter-cluster --seed-pos 0,1,0 \
     --voxel-external-fill --voxel-carve \
-    -K room.voxel.json
+    --collision-mesh room.voxel.json
 ```
 
 #### Exterior scenes (outdoor objects, terrain)
@@ -410,20 +411,20 @@ Use `--voxel-floor-fill` to fill the ground beneath surfaces, optionally followe
 splat-transform terrain.ply \
     --filter-cluster --seed-pos 0,0,0 \
     --voxel-floor-fill \
-    -K terrain.voxel.json
+    --collision-mesh terrain.voxel.json
 ```
 
 #### Other examples
 
 ```bash
 # Voxelize with custom resolution and opacity threshold
-splat-transform --voxel-params 0.1,0.3 input.ply output.voxel.json
+splat-transform --voxel-size 0.1 --voxel-opacity 0.3 input.ply output.voxel.json
 
 # Custom carve capsule (height, radius)
 splat-transform --seed-pos 1,0,0 --voxel-carve 2.0,0.3 input.ply output.voxel.json
 
 # Watertight voxel-face collision mesh
-splat-transform -K faces input.ply output.voxel.json
+splat-transform --collision-mesh faces input.ply output.voxel.json
 ```
 
 ### Image Rendering
@@ -436,13 +437,13 @@ splat-transform input.ply view.webp
 
 # Custom camera and resolution
 splat-transform input.ply view.webp \
-    --camera 2,1,-2 --look-at 0,0,0 \
-    --fov 50 --resolution 1920x1080
+    --camera-pos 2,1,-2 --camera-target 0,0,0 \
+    --camera-fov 50 --resolution 1920x1080
 
 # Transparent background
 splat-transform input.ply view.webp --background 0,0,0,0
 
-# Defocus blur (focus on look-at, f/2.8 aperture)
+# Defocus blur (focus on camera-target, f/2.8 aperture)
 splat-transform input.ply view.webp --f-stop 2.8
 
 # Defocus with explicit focus distance and a smaller world scale
@@ -451,11 +452,11 @@ splat-transform input.ply view.webp \
 
 # 360° equirectangular panorama from camera position
 splat-transform input.ply pano.webp \
-    --projection equirect --camera 0,1,0 --look-at 0,1,1
+    --projection equirect --camera-pos 0,1,0 --camera-target 0,1,1
 
 # Camera motion blur (dolly from start to end pose over the shutter)
 splat-transform input.ply view.webp \
-    --camera 2,1,-2 --camera-end 3,1,-2 \
+    --camera-pos 2,1,-2 --camera-pos-end 3,1,-2 \
     --motion-samples 16 --shutter 1
 ```
 
@@ -479,7 +480,7 @@ splat-transform -g cpu input.ply output.sog
 ```
 
 > [!NOTE]
-> When `-g` is not specified, WebGPU automatically selects the best available GPU. Use `-L` to list available adapters with their indices and names. The order and availability of adapters depends on your system and GPU drivers. Use `-g <index>` to select a specific adapter, or `-g cpu` to force CPU computation.
+> When `-g` is not specified, WebGPU automatically selects the best available GPU. Use `--list-gpus` to list available adapters with their indices and names. The order and availability of adapters depends on your system and GPU drivers. Use `-g <index>` to select a specific adapter, or `-g cpu` to force CPU computation.
 
 > [!WARNING]
 > CPU compression can be significantly slower than GPU compression (often 5-10x slower). Use CPU mode only if GPU drivers are unavailable or problematic.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -117,7 +117,7 @@ const resolveInput = (arg: string): ResolvedInput => {
     };
 };
 
-// CLI action list: the library's ProcessAction plus the CLI-only `--lod`
+// CLI action list: the library's ProcessAction plus the CLI-only `--tag-lod`
 // grouping tag (consumed while assembling the LOD writer's level stack —
 // never dispatched as a data operation).
 type CliAction = ProcessAction | { kind: 'lod'; value: number };
@@ -139,38 +139,39 @@ const cliOptionsConfig = {
     version: { type: 'boolean', short: 'v', default: false },
     quiet: { type: 'boolean', short: 'q', default: false },
     verbose: { type: 'boolean', default: false },
-    mem: { type: 'boolean', default: false },
+    memory: { type: 'boolean', default: false },
     tty: { type: 'boolean' },
-    iterations: { type: 'string', short: 'i', default: '10' },
+    'sh-iterations': { type: 'string', short: 'i', default: '10' },
     'max-workers': { type: 'string' },
-    'list-gpus': { type: 'boolean', short: 'L', default: false },
+    'list-gpus': { type: 'boolean', default: false },
     gpu: { type: 'string', short: 'g', default: '-1' },
-    'lod-select': { type: 'string', short: 'O', default: '' },
-    'viewer-settings': { type: 'string', short: 'E', default: '' },
-    'lod-chunk-count': { type: 'string', short: 'C', default: '512' },
-    'lod-chunk-extent': { type: 'string', short: 'X', default: '16' },
+    'select-lod': { type: 'string', short: 'L', default: '' },
+    'viewer-settings': { type: 'string', default: '' },
+    'lod-chunk-count': { type: 'string', default: '512' },
+    'lod-chunk-extent': { type: 'string', default: '16' },
     'spz-version': { type: 'string', default: '4' },
-    unbundled: { type: 'boolean', short: 'U', default: false },
-    'voxel-params': { type: 'string', default: '' },
+    unbundled: { type: 'boolean', default: false },
+    'voxel-size': { type: 'string' },
+    'voxel-opacity': { type: 'string' },
     'voxel-external-fill': { type: 'string' },
     'voxel-floor-fill': { type: 'string' },
     'voxel-carve': { type: 'string' },
     'seed-pos': { type: 'string', default: '' },
-    'collision-mesh': { type: 'string', short: 'K' },
+    'collision-mesh': { type: 'string' },
     'projection': { type: 'string' },
-    'camera': { type: 'string' },
-    'look-at': { type: 'string' },
-    'up': { type: 'string' },
-    'fov': { type: 'string' },
+    'camera-pos': { type: 'string' },
+    'camera-target': { type: 'string' },
+    'camera-up': { type: 'string' },
+    'camera-fov': { type: 'string' },
     'resolution': { type: 'string' },
-    'near': { type: 'string' },
+    'camera-near': { type: 'string' },
     'background': { type: 'string' },
     'f-stop': { type: 'string' },
     'focus-distance': { type: 'string' },
     'sensor-size': { type: 'string' },
-    'camera-end': { type: 'string' },
-    'look-at-end': { type: 'string' },
-    'up-end': { type: 'string' },
+    'camera-pos-end': { type: 'string' },
+    'camera-target-end': { type: 'string' },
+    'camera-up-end': { type: 'string' },
     'shutter': { type: 'string' },
     'motion-samples': { type: 'string' },
 
@@ -185,14 +186,14 @@ const cliOptionsConfig = {
     'filter-harmonics': { type: 'string', short: 'H', multiple: true },
     'filter-box': { type: 'string', short: 'B', multiple: true },
     'filter-sphere': { type: 'string', short: 'S', multiple: true },
-    'decimate': { type: 'string', short: 'F', multiple: true },
-    'filter-cluster': { type: 'string', short: 'D', multiple: true },
-    'filter-floaters': { type: 'string', short: 'G', multiple: true },
+    'decimate': { type: 'string', short: 'd', multiple: true },
+    'filter-cluster': { type: 'string', short: 'C', multiple: true },
+    'filter-floaters': { type: 'string', short: 'F', multiple: true },
     params: { type: 'string', short: 'p', multiple: true },
-    lod: { type: 'string', short: 'l', multiple: true },
-    stats: { type: 'string', short: 'm', multiple: true },
-    info: { type: 'string', short: 'I', multiple: true },
-    'morton-order': { type: 'boolean', short: 'M', multiple: true }
+    'tag-lod': { type: 'string', short: 'l', multiple: true },
+    stats: { type: 'string', multiple: true },
+    info: { type: 'string', multiple: true },
+    'morton-order': { type: 'boolean', short: 'm', multiple: true }
 } as const;
 
 const stringOptionNames = new Set(Object.entries(cliOptionsConfig)
@@ -210,19 +211,15 @@ const isTextJsonFormat = (s: string) => /^(?:text|json)$/i.test(s);
 type OptionalValueValidator = (next: string) => boolean;
 const optionalValueOptions: Map<string, OptionalValueValidator> = new Map([
     ['--filter-cluster', isNumericValue],
-    ['-D', isNumericValue],
+    ['-C', isNumericValue],
     ['--filter-floaters', isNumericValue],
-    ['-G', isNumericValue],
+    ['-F', isNumericValue],
     ['--voxel-external-fill', isNumericValue],
     ['--voxel-floor-fill', isNumericValue],
     ['--voxel-carve', isNumericValue],
-    ['--voxel-params', isNumericValue],
     ['--collision-mesh', isCollisionMeshShape],
-    ['-K', isCollisionMeshShape],
     ['--info', isTextJsonFormat],
-    ['-I', isTextJsonFormat],
-    ['--stats', isTextJsonFormat],
-    ['-m', isTextJsonFormat]
+    ['--stats', isTextJsonFormat]
 ]);
 
 const shortToLong = new Map<string, string>(
@@ -368,21 +365,19 @@ const parseArguments = async () => {
     const viewerSettingsPath = v['viewer-settings'];
 
     // Parse voxel processing options
-    const voxelParamsStr = v['voxel-params'];
+    const voxelSizeStr = v['voxel-size'];
+    const voxelOpacityStr = v['voxel-opacity'];
     const externalFillStr = v['voxel-external-fill'];
     const carveStr = v['voxel-carve'];
     const seedPosStr = v['seed-pos'];
 
     let voxelResolution = 0.05;
     let opacityCutoff = 0.1;
-    if (voxelParamsStr) {
-        const parts = voxelParamsStr.split(',').map((p: string) => p.trim());
-        if (parts.length >= 1 && parts[0] !== '') {
-            voxelResolution = parseNumber(parts[0], 0);
-        }
-        if (parts.length >= 2) {
-            opacityCutoff = parseNumber(parts[1], 0);
-        }
+    if (voxelSizeStr) {
+        voxelResolution = parseNumber(voxelSizeStr, 0);
+    }
+    if (voxelOpacityStr) {
+        opacityCutoff = parseNumber(voxelOpacityStr, 0);
     }
 
     let navExteriorRadius: number | undefined;
@@ -433,21 +428,21 @@ const parseArguments = async () => {
         renderProjection = v.projection;
     }
     let renderCameraPosition: { x: number; y: number; z: number } | undefined;
-    if (v.camera !== undefined) {
-        const [cx, cy, cz] = parseVec(v.camera, 3);
+    if (v['camera-pos'] !== undefined) {
+        const [cx, cy, cz] = parseVec(v['camera-pos'], 3);
         renderCameraPosition = { x: cx, y: cy, z: cz };
     }
     let renderLookAt: { x: number; y: number; z: number } | undefined;
-    if (v['look-at'] !== undefined) {
-        const [lx, ly, lz] = parseVec(v['look-at'], 3);
+    if (v['camera-target'] !== undefined) {
+        const [lx, ly, lz] = parseVec(v['camera-target'], 3);
         renderLookAt = { x: lx, y: ly, z: lz };
     }
     let renderUp: { x: number; y: number; z: number } | undefined;
-    if (v.up !== undefined) {
-        const [ux, uy, uz] = parseVec(v.up, 3);
+    if (v['camera-up'] !== undefined) {
+        const [ux, uy, uz] = parseVec(v['camera-up'], 3);
         renderUp = { x: ux, y: uy, z: uz };
     }
-    const renderFov = v.fov !== undefined ? parseNumber(v.fov, 0) : undefined;
+    const renderFov = v['camera-fov'] !== undefined ? parseNumber(v['camera-fov'], 0) : undefined;
     let renderWidth: number | undefined;
     let renderHeight: number | undefined;
     if (v.resolution !== undefined) {
@@ -458,7 +453,7 @@ const parseArguments = async () => {
         renderWidth = parseInteger(m[1]);
         renderHeight = parseInteger(m[2]);
     }
-    const renderNear = v.near !== undefined ? parseNumber(v.near, 0) : undefined;
+    const renderNear = v['camera-near'] !== undefined ? parseNumber(v['camera-near'], 0) : undefined;
     const renderFStop = v['f-stop'] !== undefined ? parseNumber(v['f-stop'], 0) : undefined;
     if (renderFStop !== undefined && renderFStop <= 0) {
         throw new Error(`Invalid --f-stop value: ${v['f-stop']}. Must be > 0.`);
@@ -472,18 +467,18 @@ const parseArguments = async () => {
         throw new Error(`Invalid --sensor-size value: ${v['sensor-size']}. Must be > 0.`);
     }
     let renderCameraEndPosition: { x: number; y: number; z: number } | undefined;
-    if (v['camera-end'] !== undefined) {
-        const [cx, cy, cz] = parseVec(v['camera-end'], 3);
+    if (v['camera-pos-end'] !== undefined) {
+        const [cx, cy, cz] = parseVec(v['camera-pos-end'], 3);
         renderCameraEndPosition = { x: cx, y: cy, z: cz };
     }
     let renderLookAtEnd: { x: number; y: number; z: number } | undefined;
-    if (v['look-at-end'] !== undefined) {
-        const [lx, ly, lz] = parseVec(v['look-at-end'], 3);
+    if (v['camera-target-end'] !== undefined) {
+        const [lx, ly, lz] = parseVec(v['camera-target-end'], 3);
         renderLookAtEnd = { x: lx, y: ly, z: lz };
     }
     let renderUpEnd: { x: number; y: number; z: number } | undefined;
-    if (v['up-end'] !== undefined) {
-        const [ux, uy, uz] = parseVec(v['up-end'], 3);
+    if (v['camera-up-end'] !== undefined) {
+        const [ux, uy, uz] = parseVec(v['camera-up-end'], 3);
         renderUpEnd = { x: ux, y: uy, z: uz };
     }
     const renderShutter = v.shutter !== undefined ? parseNumber(v.shutter) : undefined;
@@ -515,13 +510,13 @@ const parseArguments = async () => {
         version: v.version,
         quiet: v.quiet,
         verbose: v.verbose,
-        mem: v.mem,
+        mem: v.memory,
         noTty: v.tty === undefined ? undefined : !v.tty,
-        iterations: parseInteger(v.iterations),
+        iterations: parseInteger(v['sh-iterations']),
         listGpus: v['list-gpus'],
         deviceIdx,
         scratchDir: v['scratch-dir'],
-        lodSelect: v['lod-select'].split(',').filter(v => !!v).map(parseInteger),
+        lodSelect: v['select-lod'].split(',').filter(v => !!v).map(parseInteger),
         viewerSettingsJson: viewerSettingsPath && await readJsonFile(viewerSettingsPath),
         unbundled: v.unbundled,
         lodChunkCount: parseInteger(v['lod-chunk-count']),
@@ -663,10 +658,10 @@ const parseArguments = async () => {
                     }
                     break;
                 }
-                case 'lod': {
+                case 'tag-lod': {
                     const lod = parseInteger(t.value);
                     if (lod < -1) {
-                        throw new Error(`Invalid lod value: ${t.value}. Must be >= 0, or -1 for environment.`);
+                        throw new Error(`Invalid --tag-lod value: ${t.value}. Must be >= 0, or -1 for environment.`);
                     }
                     current.processActions.push({
                         kind: 'lod',
@@ -791,85 +786,86 @@ ACTIONS (executed in order; can be repeated)
     -S, --filter-sphere    <x,y,z,radius>   Remove Gaussians outside sphere
     -V, --filter-value     <name,cmp,value> Keep Gaussians where <name> <cmp> <value>;
                                               cmp ∈ {lt,lte,gt,gte,eq,neq}
-    -F, --decimate         <n|n%>           Simplify to n (or n%) Gaussians via merge-based decimation.
+    -d, --decimate         <n|n%>           Simplify to n (or n%) Gaussians via merge-based decimation.
                                               Must be the final action, and the output must be .ply
         --scratch-dir      <path>           Directory for decimation spill files (deep targets on huge
                                               scenes). Default: the output file's directory
-    -G, --filter-floaters  [size,op,min]    Remove Gaussians not contributing to any solid voxel. Default: 0.05,0.1,0.004
-    -D, --filter-cluster   [res,op,min]     Keep only the connected cluster at --seed-pos. Default: 1.0,0.999,0.1
+    -F, --filter-floaters  [size,op,min]    Remove Gaussians not contributing to any solid voxel. Default: 0.05,0.1,0.004
+    -C, --filter-cluster   [res,op,min]     Keep only the connected cluster at --seed-pos. Default: 1.0,0.999,0.1
     -p, --params           <key=val,...>    Pass parameters to .mjs generator script
-    -l, --lod              <n>              Tag the Gaussians with LOD level n (n >= 0, or -1 for environment)
-    -m, --stats            [text|json]      Print file info and per-column statistics to stdout. Default: text
-    -I, --info             [text|json]      Print structural metadata (per-LOD counts, columns) to stdout. Default: text
-    -M, --morton-order                      Reorder Gaussians by Morton code (Z-order curve)
+    -l, --tag-lod          <n>              Tag the Gaussians with LOD level n (n >= 0, or -1 for environment)
+        --stats            [text|json]      Print file info and per-column statistics to stdout. Default: text
+        --info             [text|json]      Print structural metadata (per-LOD counts, columns) to stdout. Default: text
+    -m, --morton-order                      Reorder Gaussians by Morton code (Z-order curve)
 
 GENERAL
     -h, --help                              Show this help and exit
     -v, --version                           Show version and exit
     -q, --quiet                             Suppress non-error output
         --verbose                           Show debug-level diagnostics
-        --mem                               Show peak memory in progress output
+        --memory                            Show peak memory in progress output
         --tty                               Interactive bar rendering (--no-tty to disable)
     -w, --overwrite                         Overwrite output file if it exists
 
 GPU (used by SOG compression and GPU voxelization: --filter-cluster, --filter-floaters, .voxel.json output)
-    -L, --list-gpus                         List available GPU adapters and exit
+        --list-gpus                         List available GPU adapters and exit
     -g, --gpu              <n|cpu>          Device for GPU operations: GPU adapter index | 'cpu'
                                               ('cpu' disables GPU and is incompatible with GPU-only features)
 
 SOG COMPRESSION (.sog, meta.json, lod-meta.json, .html outputs)
-    -i, --iterations       <n>              SH compression iterations (more=better). Default: 10
+    -i, --sh-iterations    <n>              SH compression iterations (more=better). Default: 10
         --max-workers      <n>              Worker threads for SOG encoding (0 = inline/serial). Default: 4
 
 SPZ OUTPUT (.spz)
         --spz-version      <3|4>            The SPZ format version to write. Default: 4
 
 HTML VIEWER OUTPUT (.html)
-    -E, --viewer-settings  <settings.json>  HTML viewer settings JSON file
-    -U, --unbundled                         Generate unbundled HTML viewer with separate files
+        --viewer-settings  <settings.json>  HTML viewer settings JSON file
+        --unbundled                         Generate unbundled HTML viewer with separate files
 
 LCC / LCC2 INPUT (.lcc, .lcc2)
-    -O, --lod-select       <n,n,...>        Comma-separated LOD levels to read from LCC / LCC2 input
+    -L, --select-lod       <n,n,...>        Comma-separated LOD levels to read from LCC / LCC2 input
 
 LOD OUTPUT (lod-meta.json)
-    -C, --lod-chunk-count  <n>              Approximate number of Gaussians per LOD chunk in K. Default: 512
-    -X, --lod-chunk-extent <n>              Approximate size of an LOD chunk in world units (m). Default: 16
+        --lod-chunk-count  <n>              Approximate number of Gaussians per LOD chunk in K. Default: 512
+        --lod-chunk-extent <n>              Approximate size of an LOD chunk in world units (m). Default: 16
 
 VOXEL OUTPUT (.voxel.json)
-        --voxel-params     [size,opacity]   Voxel size and opacity threshold for .voxel.json. Default: 0.05,0.1
+        --voxel-size       <n>              Voxel size for .voxel.json. Default: 0.05
+        --voxel-opacity    <n>              Voxel opacity threshold for .voxel.json. Default: 0.1
         --voxel-external-fill [size]        Fill exterior voxels via boundary flood fill (interior scenes). Default: 1.6
         --voxel-floor-fill [size]           Fill columns upward from bottom (exterior scenes). Default: 1.6
         --voxel-carve [h,r]                 Carve navigable space using capsule flood fill from seed. Default: 1.6,0.2
         --seed-pos         <x,y,z>          Seed position for voxel processing and --filter-cluster. Default: 0,0,0
-    -K, --collision-mesh   [smooth|faces]   Generate collision mesh (.collision.glb). Default shape: smooth
+        --collision-mesh   [smooth|faces]   Generate collision mesh (.collision.glb). Default shape: smooth
 
 IMAGE OUTPUT (.webp) — lossless WebP rendered via GPU rasterizer
         --projection       <pinhole|equirect>  Camera projection. Default: pinhole.
-                                            equirect = 360°×180° panorama from --camera; --fov must be omitted;
+                                            equirect = 360°×180° panorama from --camera-pos; --camera-fov must be omitted;
                                             --resolution must be 2:1 (default 2048x1024).
-        --camera           <x,y,z>          Camera position in world space. Default: 2,1,-2
-        --look-at          <x,y,z>          Camera target point. Default: 0,0,0
-        --up               <x,y,z>          World up vector. Default: 0,1,0
-        --fov              <degrees>        Vertical field of view in degrees. Default: 60. Rejected with --projection equirect.
+        --camera-pos       <x,y,z>          Camera position in world space. Default: 2,1,-2
+        --camera-target    <x,y,z>          Camera target point. Default: 0,0,0
+        --camera-up        <x,y,z>          World up vector. Default: 0,1,0
+        --camera-fov       <degrees>        Vertical field of view in degrees. Default: 60. Rejected with --projection equirect.
         --resolution       <WxH>            Output resolution, e.g. 1920x1080. Default: 1280x720 (pinhole) or 2048x1024 (equirect)
-        --near             <n>              Near clip distance. Default: 0.2 (matches reference 3DGS)
+        --camera-near      <n>              Near clip distance. Default: 0.2 (matches reference 3DGS)
         --background       <r,g,b[,a]>      Background color in [0,1]. Default: 0,0,0,1
         --f-stop           <N>              Aperture as a photographic f-stop (e.g. 2.8, 5.6, 11). Enables defocus blur;
                                             smaller = more blur. Pinhole only. Default: disabled (no defocus).
-        --focus-distance   <n>              Camera-space Z of the focus plane (world units). Default: distance to --look-at.
+        --focus-distance   <n>              Camera-space Z of the focus plane (world units). Default: distance to --camera-target.
                                             Pinhole only; only meaningful with --f-stop.
         --sensor-size      <n>              Vertical sensor height in world units. Gives --f-stop a physical meaning.
                                             Default: 0.024 (35mm full-frame, world units = meters). Scale to your world:
                                             world unit = decimeter → 0.24, world unit = millimeter → 24.
-        --camera-end       <x,y,z>          End camera position. When set, enables camera motion blur: the renderer
-                                            averages sub-frames with the camera interpolated from --camera (shutter open)
-                                            to --camera-end (shutter close). Default: disabled (no motion blur).
-        --look-at-end      <x,y,z>          End camera target. Default: same as --look-at. Only with --camera-end.
-        --up-end           <x,y,z>          End up vector. Default: same as --up. Only with --camera-end.
+        --camera-pos-end   <x,y,z>          End camera position. When set, enables camera motion blur: the renderer
+                                            averages sub-frames with the camera interpolated from --camera-pos (shutter open)
+                                            to --camera-pos-end (shutter close). Default: disabled (no motion blur).
+        --camera-target-end <x,y,z>         End camera target. Default: same as --camera-target. Only with --camera-pos-end.
+        --camera-up-end    <x,y,z>          End up vector. Default: same as --camera-up. Only with --camera-pos-end.
         --shutter          <0..1>           Fraction of the start→end segment integrated, centered on the midpoint
-                                            (1.0 = full motion; 0.5 = 180° shutter). Default: 1. Only with --camera-end.
+                                            (1.0 = full motion; 0.5 = 180° shutter). Default: 1. Only with --camera-pos-end.
         --motion-samples   <n>              Sub-frames to accumulate for motion blur. Cost is N× a single render.
-                                            Default: 16. Only with --camera-end.
+                                            Default: 16. Only with --camera-pos-end.
 
 EXAMPLES
     # Convert formats
@@ -1117,13 +1113,13 @@ const main = async () => {
 
         // LODs are overlapping representations of the *same* scene — alternatives,
         // not additive layers. A single-scene WRITER takes exactly one LOD: the
-        // finest (LOD 0) by default, or the one --lod-select picks (reject multiple).
+        // finest (LOD 0) by default, or the one --select-lod picks (reject multiple).
         // Selection is applied as a selectLod node right after the reader (below),
         // so the pipeline operates on that single level. `null` output has no
         // writer, so it keeps the full multi-LOD source — `--info`/`--stats`
         // there report every level. lod-meta output keeps every level (path below).
         if (outputFormat !== null && outputFormat !== 'lod' && options.lodSelect.length > 1) {
-            throw new Error('Cannot write multiple LOD levels (--lod-select) to a single-scene output; select one level, or output lod-meta.json.');
+            throw new Error('Cannot write multiple LOD levels (--select-lod) to a single-scene output; select one level, or output lod-meta.json.');
         }
 
         // Single-scene pipeline (one chunk-native path for every non-lod output).
@@ -1137,7 +1133,7 @@ const main = async () => {
         // ply/sog/compressed-ply; materialize-at-the-writer for csv/glb/html/image/
         // voxel/spz). LOD output has its own structural path below; this pipeline
         // also handles null output (processing for side-effects, skipping the
-        // write). A --lod tag on single-scene output is rejected after the LOD path.
+        // write). A --tag-lod tag on single-scene output is rejected after the LOD path.
         const singleSceneActions = [...inputArgs.flatMap(a => a.processActions), ...outputArg.processActions];
 
         // v1 decimation is terminal: the merge stream writes straight into the
@@ -1213,7 +1209,7 @@ const main = async () => {
             // A real single-LOD writer collapses each multi-LOD input to the
             // selected level (finest by default) via a selectLod node, so
             // transforms operate on one LOD; null output keeps every level (so an
-            // --info/--stats action there reports the whole source). `--lod`
+            // --info/--stats action there reports the whole source). `--tag-lod`
             // actions are lod-meta grouping metadata (never data ops), so strip them.
             const selectSingleLod = outputFormat !== null;
             const processed: ChunkSource[] = [];
@@ -1274,7 +1270,7 @@ const main = async () => {
 
         // LOD-meta output: keep every level, structurally separate — LODs are
         // overlapping surfaces and are NEVER combined. Levels come from a single
-        // lcc/lcc2's intrinsic LODs, or from --lod-tagged PLY inputs (env = -1,
+        // lcc/lcc2's intrinsic LODs, or from PLY inputs tagged with --tag-lod (env = -1,
         // untagged = level 0). Each level (and the env) is processed independently
         // via processSourceBridged, the levels are stacked, and writeLodSource
         // streams them. With no actions this matches the previous streaming-LOD
@@ -1300,11 +1296,11 @@ const main = async () => {
                 envSource = single === 'lcc2' ?
                     await readLcc2EnvironmentSource(fileSystem, inFile, pool) :
                     await readLccEnvironmentSource(fileSystem, inFile, pool);
-                // --lod-select picks which levels go into the lod-meta (default all).
+                // --select-lod picks which levels go into the lod-meta (default all).
                 perLevel = resolveLodLevels(options.lodSelect, multi.meta.numLods).map(lvl => selectLod(multi, lvl));
                 inputActions = inputArgs[0].processActions;
             } else {
-                // PLY inputs grouped by --lod tag (env = -1, untagged = level 0);
+                // PLY inputs grouped by --tag-lod tag (env = -1, untagged = level 0);
                 // each input's own actions applied before grouping.
                 const tagged = inputArgs.map((a) => {
                     const ply = !isHttpUrl(a.filename) && getInputFormat(resolveInput(a.filename).classifyName) === 'ply';
@@ -1314,7 +1310,7 @@ const main = async () => {
                     return { arg: a, ply, tag, rest };
                 });
                 if (!tagged.every(t => t.ply)) {
-                    throw new Error('lod-meta.json output requires a single LCC/LCC2 input, or local PLY input(s) (optionally --lod tagged).');
+                    throw new Error('lod-meta.json output requires a single LCC/LCC2 input, or local PLY input(s) (optionally --tag-lod tagged).');
                 }
                 const opened = await Promise.all(tagged.map(async (t) => {
                     const { filename: inFile, fileSystem } = resolveInput(t.arg.filename);
@@ -1380,11 +1376,11 @@ const main = async () => {
             exit(0);
         }
 
-        // Anything reaching here is a single-scene (non-lod) output carrying --lod
+        // Anything reaching here is a single-scene (non-lod) output carrying --tag-lod
         // *tags*: tags build lod-meta.json levels and don't apply to single-scene
         // output. (Tag-free non-lod conversions and null output ran the single-scene
         // pipeline above; lod-meta output ran the LOD path.)
-        throw new Error('--lod tags apply to lod-meta.json output; for single-scene output choose a level with --lod-select (-O).');
+        throw new Error('--tag-lod tags apply to lod-meta.json output; for single-scene output choose a level with --select-lod (-L).');
     } catch (err) {
         failExit(err);
     }

--- a/src/lib/decimate/decimate-source.ts
+++ b/src/lib/decimate/decimate-source.ts
@@ -130,7 +130,7 @@ const decimateSource = async (
 
     if (inputMeta.numLods > 1) {
         throw new Error(
-            `decimate requires a single-LOD source (got ${inputMeta.numLods} LODs); select a level first (--lod-select / selectLod)`
+            `decimate requires a single-LOD source (got ${inputMeta.numLods} LODs); select a level first (--select-lod / selectLod)`
         );
     }
     for (const layer of ['position', 'geometric', 'color'] as const) {

--- a/src/lib/ops/select-lod.ts
+++ b/src/lib/ops/select-lod.ts
@@ -38,7 +38,7 @@ const selectLod = (src: ChunkSource, level: number): ChunkSource => {
 };
 
 /**
- * Resolve a user `lodSelect` (from `--lod-select`) into concrete level indices
+ * Resolve a user `lodSelect` (from `--select-lod`) into concrete level indices
  * against a source's actual level count: negative indices count from the end,
  * out-of-range entries are dropped, and an empty selection means all levels.
  * Used by the CLI to drive {@link selectLod} nodes — LOD selection is a pipeline

--- a/src/lib/ops/stack-lods.ts
+++ b/src/lib/ops/stack-lods.ts
@@ -14,7 +14,7 @@ const LAYERS: ChunkLayer[] = ['position', 'geometric', 'color', 'other'];
  * `sources[i]`'s gaussian count.
  *
  * This is how per-detail-level inputs become one structural scene for the LOD
- * writer — multi-PLY `--lod` tags (one source per tagged level) or a DataTable
+ * writer — multi-PLY `--tag-lod` tags (one source per tagged level) or a DataTable
  * split by its `lod` column — replacing the old per-gaussian lod tag array. LOD
  * is a structural axis here; no source carries a per-gaussian LOD tag.
  *

--- a/src/lib/utils/text-renderer.ts
+++ b/src/lib/utils/text-renderer.ts
@@ -34,7 +34,7 @@ interface TextRendererOptions {
     /**
      * Optional peak GPU memory probe in bytes (monotonic, like
      * `getPeakCpuMemory`). When supplied alongside `getPeakCpuMemory` and
-     * reporting a non-zero value, the `--mem` overlay gains a `gpu=Y`
+     * reporting a non-zero value, the `--memory` overlay gains a `gpu=Y`
      * entry: `[peak cpu=X gpu=Y]`. Zero suppresses the entry, so runs
      * that never touch the GPU keep the CPU-only overlay. In the CLI this
      * is fed by the engine's VRAM counters (see node-device.ts).

--- a/src/lib/writers/write-image.ts
+++ b/src/lib/writers/write-image.ts
@@ -165,7 +165,7 @@ const writeImage = async (options: WriteImageOptions, fs: FileSystem): Promise<v
     let { fov, width, height } = options;
     if (projection === 'equirect') {
         if (fov !== undefined) {
-            throw new Error('writeImage: --fov is not valid with --projection equirect (the projection covers a full 360°×180° sphere).');
+            throw new Error('writeImage: --camera-fov is not valid with --projection equirect (the projection covers a full 360°×180° sphere).');
         }
         if (fStop !== undefined) {
             throw new Error('writeImage: --f-stop is not valid with --projection equirect (defocus blur needs a focal length, which the equirect projection does not have).');
@@ -203,8 +203,8 @@ const writeImage = async (options: WriteImageOptions, fs: FileSystem): Promise<v
         }
     }
 
-    // Motion blur: enabled iff `--camera-end` is supplied. The end pose
-    // for missing `look-at-end` / `up-end` defaults to the start pose so
+    // Motion blur: enabled iff `--camera-pos-end` is supplied. The end pose
+    // for missing `camera-target-end` / `camera-up-end` defaults to the start pose so
     // pure translations don't need redundant flags.
     const motionBlur = cameraEndPosition !== undefined;
     const motionN = motionBlur ? (motionSamples ?? 16) : 1;
@@ -259,7 +259,7 @@ const writeImage = async (options: WriteImageOptions, fs: FileSystem): Promise<v
             } else {
                 const fwdLen = Math.hypot(tgt.x - pos.x, tgt.y - pos.y, tgt.z - pos.z);
                 if (fwdLen === 0) {
-                    throw new Error('writeImage: cannot derive default --focus-distance because --camera equals --look-at.');
+                    throw new Error('writeImage: cannot derive default --focus-distance because --camera-pos equals --camera-target.');
                 }
                 fDist = fwdLen;
             }

--- a/src/lib/writers/write-lod.ts
+++ b/src/lib/writers/write-lod.ts
@@ -290,7 +290,7 @@ type WriteLodSourceOptions = {
     filename: string;
     /**
      * The scene as a structural multi-LOD source: LOD `i` is output detail level
-     * `i`. lcc/lcc2 expose this intrinsically; multi-PLY `--lod` inputs are stacked
+     * `i`. lcc/lcc2 expose this intrinsically; multi-PLY `--tag-lod` inputs are stacked
      * by tag via {@link stackLods}. No per-gaussian lod tag — LOD is structural.
      */
     mainSource: ChunkSource;

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -81,13 +81,13 @@ describe('CLI parsing', () => {
         assert.strictEqual(result.code, 0, `CLI failed:\n${result.stderr}\n${result.stdout}`);
     });
 
-    it('accepts --lod -1 to tag an input as environment', async () => {
+    it('accepts --tag-lod -1 to tag an input as environment', async () => {
         const result = await runCli([
             '--gpu',
             'cpu',
             'test/fixtures/splat/minimal.splat',
             'test/fixtures/splat/minimal.splat',
-            '--lod',
+            '--tag-lod',
             '-1',
             'null'
         ]);
@@ -95,17 +95,17 @@ describe('CLI parsing', () => {
         assert.strictEqual(result.code, 0, `CLI failed:\n${result.stderr}\n${result.stdout}`);
     });
 
-    it('rejects --lod values below -1', async () => {
+    it('rejects --tag-lod values below -1', async () => {
         const result = await runCli([
             '--gpu',
             'cpu',
             'test/fixtures/splat/minimal.splat',
-            '--lod',
+            '--tag-lod',
             '-2',
             'null'
         ]);
 
-        assert.notStrictEqual(result.code, 0, 'CLI should reject --lod -2');
+        assert.notStrictEqual(result.code, 0, 'CLI should reject --tag-lod -2');
         assert.match(result.stderr, /Must be >= 0, or -1/);
     });
 });

--- a/test/render-golden.cases.mjs
+++ b/test/render-golden.cases.mjs
@@ -21,9 +21,9 @@ const CASES = [
         args: [
             'test/fixtures/generator.mjs',
             '-p', 'width=20,height=20,spacing=1.0,scale=0.1',
-            '--camera', '0,5,-8',
-            '--look-at', '0,0,0',
-            '--fov', '60',
+            '--camera-pos', '0,5,-8',
+            '--camera-target', '0,0,0',
+            '--camera-fov', '60',
             '--resolution', '320x240'
         ],
         goldenPath: 'fixtures/golden-render/tiny.webp'
@@ -36,9 +36,9 @@ const CASES = [
         args: [
             'test/fixtures/generator.mjs',
             '-p', 'width=220,height=220,spacing=0.3,scale=0.05',
-            '--camera', '0,10,-15',
-            '--look-at', '0,0,0',
-            '--fov', '60',
+            '--camera-pos', '0,10,-15',
+            '--camera-target', '0,0,0',
+            '--camera-fov', '60',
             '--resolution', '640x360'
         ],
         goldenPath: 'fixtures/golden-render/mid.webp'
@@ -55,9 +55,9 @@ const CASES = [
         args: [
             'test/fixtures/generator.mjs',
             '-p', 'width=20,height=20,spacing=1.0,scale=0.1',
-            '--camera', '0,5,-8',
-            '--look-at', '0,0,0',
-            '--fov', '60',
+            '--camera-pos', '0,5,-8',
+            '--camera-target', '0,0,0',
+            '--camera-fov', '60',
             '--resolution', '320x240',
             '--f-stop', '2.8',
             '--sensor-size', '0.5'

--- a/tools/bench.mjs
+++ b/tools/bench.mjs
@@ -2,7 +2,7 @@
 /**
  * Benchmark harness: runs the BUILT CLI (bin/cli.mjs -> dist/cli.mjs) against
  * real scenes, one warmup + N timed repetitions per workload, and reports the
- * median wall time and peak memory (parsed from the CLI's --mem output).
+ * median wall time and peak memory (parsed from the CLI's --memory output).
  *
  * Build first (`npm run build`), then:
  *
@@ -57,11 +57,11 @@ const WORKLOADS = [
     // lcc2 (sog sub-files) -> streamed SOG over 4 levels (~9.1M rows, 0 SH
     // bands so k-means is skipped); exercises containerSource/concatSource
     // gathers and the sog sub-file decode
-    { name: 'lcc2-lod', reps: 2, input: lcc2, out: 'lod-meta.json', args: ['-O', '2,3,4,5'] },
+    { name: 'lcc2-lod', reps: 2, input: lcc2, out: 'lod-meta.json', args: ['-L', '2,3,4,5'] },
 
     // merge-based decimation to 50% (6.1M rows); exercises the priority pass,
     // moment-match merges, and the merge stream terminal
-    { name: 'decimate', reps: 2, input: join(scenes, 'decimate-pill.ply'), out: 'out.ply', args: ['-F', '50%'] },
+    { name: 'decimate', reps: 2, input: join(scenes, 'decimate-pill.ply'), out: 'out.ply', args: ['-d', '50%'] },
 
     // v1 lcc (5 LODs, 6.18M finest, 0 SH bands so no k-means) -> streamed SOG;
     // GPU-free, dominated by the LOD writer's random-index gathers against
@@ -71,7 +71,7 @@ const WORKLOADS = [
     // big-scene decimation (53.2M rows, 0 SH bands): the per-block scratch
     // churn in the priority pass only shows at this scale. One cold run per
     // side (no warmup) — a warmup would double a very long workload.
-    { name: 'decimate-big', reps: 1, warmup: false, input: join(scenes, 'andrii-lod1.ply'), out: 'out.ply', args: ['-F', '50%'] }
+    { name: 'decimate-big', reps: 1, warmup: false, input: join(scenes, 'andrii-lod1.ply'), out: 'out.ply', args: ['-d', '50%'] }
 ];
 
 // ---- helpers ------------------------------------------------------------
@@ -96,7 +96,7 @@ const median = (xs) => {
 const runOnce = (w, outDir) => {
     rmSync(outDir, { recursive: true, force: true });
     mkdirSync(outDir, { recursive: true });
-    const args = ['bin/cli.mjs', w.input, ...w.args, join(outDir, w.out), '-w', '--mem'];
+    const args = ['bin/cli.mjs', w.input, ...w.args, join(outDir, w.out), '-w', '--memory'];
     const t0 = performance.now();
     const res = spawnSync(process.execPath, args, { cwd: repoRoot, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
     const wallMs = performance.now() - t0;

--- a/tools/compat-suite.mjs
+++ b/tools/compat-suite.mjs
@@ -3,8 +3,8 @@
  * Compatibility + performance suite: runs the same matrix of code paths through
  * BOTH the globally-installed prod CLI (v1.10.1) and the local built CLI
  * (v2.7.1, bin/cli.mjs -> dist), under `/usr/bin/time -l` so peak RSS and wall
- * time are measured uniformly (prod has no --mem). v2 also reports its own peak
- * cpu/gpu via --mem.
+ * time are measured uniformly (prod has no --memory). v2 also reports its own peak
+ * cpu/gpu via --memory.
  *
  * Coverage: every reader (input format), every writer (output format), every
  * action, info/stats, plus a few chained/merge cases. Outputs are compared by
@@ -64,7 +64,7 @@ const CASES = [
     { group: 'writer', name: 'csv', input: S.plySH0, args: [], out: 'o.csv', cmp: 'exists', mode: 'both' },
     { group: 'writer', name: 'glb', input: S.plySH0, args: [], out: 'o.glb', cmp: 'exists', mode: 'both' },
     { group: 'writer', name: 'html-bundle', input: S.plySH0, args: [], out: 'o.html', cmp: 'exists', mode: 'both' },
-    { group: 'writer', name: 'voxel', input: S.plySH0, args: ['--voxel-params', '0.2'], v1Args: ['-R', '0.2'], out: 'o.voxel.json', cmp: 'exists', mode: 'both', note: 'GPU; v1 uses -R, v2 --voxel-params' },
+    { group: 'writer', name: 'voxel', input: S.plySH0, args: ['--voxel-size', '0.2'], v1Args: ['-R', '0.2'], out: 'o.voxel.json', cmp: 'exists', mode: 'both', note: 'GPU; v1 uses -R, v2 --voxel-size' },
     { group: 'writer', name: 'spz', input: S.spzSH3, args: [], out: 'o.spz', cmp: 'count', mode: 'v2only', note: 'v2-only output' },
     { group: 'writer', name: 'webp-image', input: S.plySH0, args: [], out: 'o.webp', cmp: 'exists', mode: 'v2only', note: 'v2-only output, GPU' },
     { group: 'writer', name: 'lod-from-lcc', input: S.lcc, args: [], out: 'lod/lod-meta.json', cmp: 'exists', mode: 'both', note: 'lod-selection semantics changed' },
@@ -78,13 +78,13 @@ const CASES = [
     { group: 'action', name: 'filter-sphere', input: S.plySH0, args: ['-S', '0,0,0,2'], out: 'o.ply', cmp: 'count', mode: 'both' },
     { group: 'action', name: 'filter-value', input: S.plySH0, args: ['-V', 'opacity,gt,0.1'], out: 'o.ply', cmp: 'count', mode: 'both' },
     { group: 'action', name: 'filter-harmonics', input: S.spzSH3, args: ['-H', '1'], out: 'o.ply', cmp: 'count', mode: 'both', note: 'SH3->1' },
-    { group: 'action', name: 'morton-order', input: S.plySH0, args: ['-M'], out: 'o.ply', cmp: 'count', mode: 'both' },
-    { group: 'action', name: 'decimate-50pct', input: S.plySH0, args: ['-F', '50%'], out: 'o.ply', cmp: 'count', mode: 'both', note: 'new decimator; quality differs' },
-    { group: 'action', name: 'filter-floaters', input: S.plySH0, args: ['-G'], out: 'o.ply', cmp: 'count', mode: 'v2only', note: 'v2-only, GPU' },
+    { group: 'action', name: 'morton-order', input: S.plySH0, args: ['-m'], v1Args: ['-M'], out: 'o.ply', cmp: 'count', mode: 'both' },
+    { group: 'action', name: 'decimate-50pct', input: S.plySH0, args: ['-d', '50%'], v1Args: ['-F', '50%'], out: 'o.ply', cmp: 'count', mode: 'both', note: 'new decimator; quality differs' },
+    { group: 'action', name: 'filter-floaters', input: S.plySH0, args: ['-F'], out: 'o.ply', cmp: 'count', mode: 'v2only', note: 'v2-only, GPU' },
 
     // ---- info / stats ----
-    { group: 'info', name: 'stats-summary', input: S.plySH0, args: ['-m'], out: 'null', cmp: 'none', mode: 'both', note: 'v1 --summary vs v2 --stats; output format differs' },
-    { group: 'info', name: 'info', input: S.plySH0, args: ['-I'], out: 'null', cmp: 'none', mode: 'v2only', note: 'v2-only' },
+    { group: 'info', name: 'stats-summary', input: S.plySH0, args: ['--stats'], v1Args: ['-m'], out: 'null', cmp: 'none', mode: 'both', note: 'v1 --summary vs v2 --stats; output format differs' },
+    { group: 'info', name: 'info', input: S.plySH0, args: ['--info'], out: 'null', cmp: 'none', mode: 'v2only', note: 'v2-only' },
 
     // ---- chained / merge ----
     { group: 'chain', name: 'transform-to-sog', input: S.plySH0, args: ['-t', '1,0,0', '-s', '2'], out: 'o.sog', cmp: 'count', mode: 'both' },
@@ -126,7 +126,7 @@ const timeRun = (bin, args, mem) => {
 // meta.json / lod-meta.json inside an output dir.
 const countOf = (path) => {
     if (!existsSync(path)) return null;
-    const res = spawnSync(V2NODE, ['bin/cli.mjs', path, '-I', 'null'], { cwd: repoRoot, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, timeout: 300_000 });
+    const res = spawnSync(V2NODE, ['bin/cli.mjs', path, '--info', 'null'], { cwd: repoRoot, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, timeout: 300_000 });
     if (res.status !== 0) return null;
     const m = /gaussians:\s*(\d+)/.exec(res.stdout ?? '');
     // lod-meta reports per-lod; fall back to summed lod counts
@@ -141,7 +141,7 @@ const dirNonEmpty = (p) => { try { return statSync(p).isDirectory() ? readdirSyn
 const buildArgs = (c, outPath, mem, label) => {
     const inputs = Array.isArray(c.input) ? c.input : [c.input];
     const parts = ['-w'];
-    if (mem) parts.push('--mem');
+    if (mem) parts.push('--memory');
     inputs.forEach((inp, i) => {
         parts.push(inp);
         if (c.perInputArgs?.[i]) parts.push(...c.perInputArgs[i]);

--- a/tools/lod-pyramid.mjs
+++ b/tools/lod-pyramid.mjs
@@ -4,7 +4,7 @@
  * to <= --target gaussians, then stack all levels (finest = the original, LOD 0)
  * into a single lod-meta.json. Runs the whole recipe through one CLI version and
  * times every step under /usr/bin/time -l (wall + peak RSS). v2 also emits its
- * own peak cpu/gpu via --mem.
+ * own peak cpu/gpu via --memory.
  *
  *   node tools/lod-pyramid.mjs --ver v2 --input <big.ply> [--target 1000000]
  *   node tools/lod-pyramid.mjs --ver v1 --input <big.ply>   # prod, 32GB heap
@@ -49,7 +49,7 @@ const run = (args) => {
 // count via v2 --info (fast, reads every format), on a file or lod-meta.json.
 const countOf = (p) => {
     if (!existsSync(p)) return null;
-    const r = spawnSync(V2NODE, ['bin/cli.mjs', p, '-I', 'null'], { cwd: repoRoot, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, timeout: 300_000 });
+    const r = spawnSync(V2NODE, ['bin/cli.mjs', p, '--info', 'null'], { cwd: repoRoot, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, timeout: 300_000 });
     const g = /gaussians:\s*(\d+)/.exec(r.stdout ?? '');
     if (g) return parseInt(g[1], 10);
     const lc = /lod counts:\s*([\d,\s]+)/.exec(r.stdout ?? '');
@@ -72,9 +72,9 @@ let i = 0;
 while (curCount != null && curCount > target) {
     i++;
     const out = join(wd, `L${i}.ply`);
-    const memArgs = cfg.mem ? ['--mem'] : [];
-    process.stdout.write(`  decimate L${i - 1}->L${i} (${curCount} -F 50%) ...`);
-    const r = run(['-w', ...memArgs, cur, '-F', '50%', out]);
+    const memArgs = cfg.mem ? ['--memory'] : [];
+    process.stdout.write(`  decimate L${i - 1}->L${i} (${curCount} -d 50%) ...`);
+    const r = run(['-w', ...memArgs, cur, '-d', '50%', out]);
     const n = r.ok ? countOf(out) : null;
     steps.push({ step: `dec-L${i}`, ...r, count: n });
     console.log(` ${r.ok ? 'ok' : `FAIL(${r.status}${r.timedOut ? ' TIMEOUT' : ''})`} ${(r.wallMs / 1000).toFixed(1)}s rss=${r.rssMB}MB${r.gpuMB ? ` gpu=${r.gpuMB}MB` : ''} -> ${n}`);
@@ -87,7 +87,7 @@ let stack = null;
 if (levels.length > 1 && steps.every(s => s.ok)) {
     const lodOut = join(wd, 'lod', 'lod-meta.json');
     mkdirSync(dirname(lodOut), { recursive: true });
-    const memArgs = cfg.mem ? ['--mem'] : [];
+    const memArgs = cfg.mem ? ['--memory'] : [];
     const stackArgs = ['-w', ...memArgs];
     levels.forEach((L, idx) => { stackArgs.push(L.path, '-l', String(idx)); });
     stackArgs.push(lodOut);


### PR DESCRIPTION
## Summary

Fixes #265.

This change rationalizes the CLI option surface with a breaking cleanup of short flags and several long option names:
- remaps mnemonic short flags for common actions, including `--decimate` to `-d`, `--filter-cluster` to `-C`, `--filter-floaters` to `-F`, and `--morton-order` to `-m`
- renames ambiguous long flags such as `--lod` to `--tag-lod`, `--lod-select` to `--select-lod`, `--mem` to `--memory`, and `--iterations` to `--sh-iterations`
- splits `--voxel-params` into `--voxel-size` and `--voxel-opacity`
- renames image camera geometry flags to the `--camera-*` family
- drops short aliases for rare or format-specific options
- updates help text, README examples, user-facing error strings, and tests

## List of breaking changes
 
| Area | v2.7.1 flag | Latest flag | Change |
|---|---|---|---|
| General | `--mem` | `--memory` | Long option renamed |
| SOG compression | `-i, --iterations <n>` | `-i, --sh-iterations <n>` | Long option renamed; short stays `-i` |
| GPU | `-L, --list-gpus` | `--list-gpus` | Short `-L` removed |
| LCC/LCC2 input | `-O, --lod-select <n,n,...>` | `-L, --select-lod <n,n,...>` | Long renamed; short changed `-O` to `-L` |
| HTML output | `-E, --viewer-settings <settings.json>` | `--viewer-settings <settings.json>` | Short `-E` removed |
| HTML output | `-U, --unbundled` | `--unbundled` | Short `-U` removed |
| LOD output | `-C, --lod-chunk-count <n>` | `--lod-chunk-count <n>` | Short `-C` removed |
| LOD output | `-X, --lod-chunk-extent <n>` | `--lod-chunk-extent <n>` | Short `-X` removed |
| Voxel output | `--voxel-params [size,opacity]` | `--voxel-size <n>` + `--voxel-opacity <n>` | Tuple option split into two options |
| Voxel output | `-K, --collision-mesh [smooth\|faces]` | `--collision-mesh [smooth\|faces]` | Short `-K` removed |
| Image output | `--camera <x,y,z>` | `--camera-pos <x,y,z>` | Long option renamed |
| Image output | `--look-at <x,y,z>` | `--camera-target <x,y,z>` | Long option renamed |
| Image output | `--up <x,y,z>` | `--camera-up <x,y,z>` | Long option renamed |
| Image output | `--fov <degrees>` | `--camera-fov <degrees>` | Long option renamed |
| Image output | `--near <n>` | `--camera-near <n>` | Long option renamed |
| Image output | `--camera-end <x,y,z>` | `--camera-pos-end <x,y,z>` | Long option renamed |
| Image output | `--look-at-end <x,y,z>` | `--camera-target-end <x,y,z>` | Long option renamed |
| Image output | `--up-end <x,y,z>` | `--camera-up-end <x,y,z>` | Long option renamed |
| Actions | `-F, --decimate <n\|n%>` | `-d, --decimate <n\|n%>` | Short changed `-F` to `-d` |
| Actions | `-D, --filter-cluster [res,op,min]` | `-C, --filter-cluster [res,op,min]` | Short changed `-D` to `-C` |
| Actions | `-G, --filter-floaters [size,op,min]` | `-F, --filter-floaters [size,op,min]` | Short changed `-G` to `-F` |
| Actions | `-l, --lod <n>` | `-l, --tag-lod <n>` | Long option renamed; short stays `-l` |
| Diagnostics | `-m, --summary` | `--stats [text\|json]` | Renamed/replaced; now accepts optional output format; short removed |
| Diagnostics | None | `--info [text\|json]` | New option |
| Actions | `-M, --morton-order` | `-m, --morton-order` | Short changed `-M` to `-m` |
| Decimation | None | `--scratch-dir <path>` | New option |