### PR TITLE
Add streamed SOG loading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,7 @@ type ChunkSource = {
 Two invariants to internalize:
 
 - **Transforms are deferred.** Reads return RAW stored values; `meta.transform` is the pending TRS describing what they mean. Transform actions compose lazily and are applied exactly once by a terminal `bakeTransform(source, targetSpace)` -- any geometry-consuming pass (bounds, partition, morton, writers) must bake first.
-- **LODs are structural and overlapping.** A multi-LOD container (LCC/LCC2) is ONE source with a structural LOD axis (`meta.numLods`, reads dispatch on `request.lod`). Levels are overlapping representations of one scene, so single-scene outputs take exactly one level (`selectLod`) and levels are never concatenated.
+- **LODs are structural and overlapping.** A multi-LOD container (Streamed SOG/LCC/LCC2) is ONE source with a structural LOD axis (`meta.numLods`, reads dispatch on `request.lod`). Levels are overlapping representations of one scene, so single-scene outputs take exactly one level (`selectLod`) and levels are never concatenated.
 
 Sources compose through lazy combinators (`concatSource`, `selectLod`, `stackLods`, `filterSource`, ...), actions run via `processSourceBridged`, and terminals (`writeSource`, `writeLodSource`, `decimateSource`) stream the result.
 
@@ -207,7 +207,7 @@ Read and write operations use abstract interfaces so the same code works in brow
 
 ### Supported Formats
 
-**Input**: PLY, splat, KSplat, SOG, SPZ, LCC, LCC2, MJS
+**Input**: PLY, splat, KSplat, SOG, Streamed SOG, SPZ, LCC, LCC2, MJS
 
 **Output**: PLY, compressed PLY, SOG, SOG-bundle, SPZ, GLB, CSV, HTML, HTML-bundle, LOD, voxel, image (WebP)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 SplatTransform is an open source library and CLI tool for converting and editing Gaussian splats. It can:
 
-📥 Read PLY, Compressed PLY, SOG, SPZ, SPLAT, KSPLAT, LCC and LCC2 formats  
+📥 Read PLY, Compressed PLY, SOG, Streamed SOG, SPZ, SPLAT, KSPLAT, LCC and LCC2 formats\
 📤 Write PLY, Compressed PLY, SOG, SPZ, GLB, CSV, HTML Viewer, LOD, Voxel and WebP image formats  
 📊 Generate statistical summaries for data analysis  
 🔗 Merge multiple splats  
@@ -86,7 +86,7 @@ splat-transform [GLOBAL] input [ACTIONS]  ...  output [ACTIONS]
 | `.csv` | ❌ | ✅ | Comma-separated values spreadsheet |
 | `.html` | ❌ | ✅ | HTML viewer app (single-page or unbundled) based on SOG |
 | `.voxel.json` | ❌ | ✅ | Sparse voxel octree for collision detection |
-| `lod-meta.json` | ❌ | ✅ | Streamed LOD data stored in SOG chunks |
+| `lod-meta.json` | ✅ | ✅ | Streamed LOD data stored in SOG chunks |
 | `.webp` | ❌ | ✅ | Lossless WebP image rendered from a camera view via GPU rasterizer |
 | `null` | ❌ | ✅ | Discard output (useful with `--stats` for analysis-only runs) |
 
@@ -184,12 +184,12 @@ Apply when writing `.html` outputs.
 > [!NOTE]
 > See the [SuperSplat Viewer Settings Schema](https://github.com/playcanvas/supersplat-viewer?tab=readme-ov-file#settings-schema) for details on how to pass data to the `--viewer-settings` option.
 
-## LCC / LCC2 Input Options
+## LOD Input Options
 
-Apply when reading `.lcc` and `.lcc2` files.
+Apply when reading `.lcc`, `.lcc2`, and `lod-meta.json` files.
 
 ```none
--L, --select-lod       <n,n,...>        Comma-separated LOD levels to read from LCC / LCC2 input
+-L, --select-lod       <n,n,...>        Comma-separated LOD levels to read from LCC / LCC2 / streamed SOG input
 ```
 
 ## LOD Output Options

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 SplatTransform is an open source library and CLI tool for converting and editing Gaussian splats. It can:
 
-📥 Read PLY, Compressed PLY, SOG, Streamed SOG, SPZ, SPLAT, KSPLAT, LCC and LCC2 formats\
+📥 Read PLY, Compressed PLY, SOG, Streamed SOG, SPZ, SPLAT, KSPLAT, LCC and LCC2 formats
 📤 Write PLY, Compressed PLY, SOG, SPZ, GLB, CSV, HTML Viewer, LOD, Voxel and WebP image formats  
 📊 Generate statistical summaries for data analysis  
 🔗 Merge multiple splats  

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ splat-transform [GLOBAL] input [ACTIONS]  ...  output [ACTIONS]
 | `.ply` | ✅ | ✅ | Standard PLY format |
 | `.sog` | ✅ | ✅ | Bundled super-compressed format (recommended) |
 | `meta.json` | ✅ | ✅ | Unbundled super-compressed format (accompanied by `.webp` textures) |
+| `lod-meta.json` | ✅ | ✅ | Streamed LOD data stored in SOG chunks |
 | `.compressed.ply` | ✅ | ✅ | Compressed PLY format (auto-detected and decompressed on read) |
 | `.spz` | ✅ | ✅ | Compressed splat format (Niantic format, v2–4) |
 | `.lcc` | ✅ | ❌ | LCC file format (XGRIDS) |
@@ -86,7 +87,6 @@ splat-transform [GLOBAL] input [ACTIONS]  ...  output [ACTIONS]
 | `.csv` | ❌ | ✅ | Comma-separated values spreadsheet |
 | `.html` | ❌ | ✅ | HTML viewer app (single-page or unbundled) based on SOG |
 | `.voxel.json` | ❌ | ✅ | Sparse voxel octree for collision detection |
-| `lod-meta.json` | ✅ | ✅ | Streamed LOD data stored in SOG chunks |
 | `.webp` | ❌ | ✅ | Lossless WebP image rendered from a camera view via GPU rasterizer |
 | `null` | ❌ | ✅ | Discard output (useful with `--stats` for analysis-only runs) |
 
@@ -186,10 +186,10 @@ Apply when writing `.html` outputs.
 
 ## LOD Input Options
 
-Apply when reading `.lcc`, `.lcc2`, and `lod-meta.json` files.
+Apply when reading `lod-meta.json`, `.lcc`, and `.lcc2` files.
 
 ```none
--L, --select-lod       <n,n,...>        Comma-separated LOD levels to read from LCC / LCC2 / streamed SOG input
+-L, --select-lod       <n,n,...>        Comma-separated LOD levels to read from streamed SOG / LCC / LCC2 input
 ```
 
 ## LOD Output Options

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -45,11 +45,12 @@ import {
     logger
 } from '../lib';
 // CLI-only internals (deliberately off the public lib surface): the LOD-path
-// level resolver and the lcc/lcc2 source readers the LOD writer drives
+// level resolver and the container source readers the LOD writer drives
 // directly (single-scene callers get these via readFile).
 import { resolveLodLevels } from '../lib/ops';
 import { readLccSource, readLccEnvironmentSource } from '../lib/readers/read-lcc';
 import { readLcc2Source, readLcc2EnvironmentSource } from '../lib/readers/read-lcc2';
+import { readLodSource, readLodEnvironmentSource } from '../lib/readers/read-lod';
 
 /**
  * CLI-specific options extending library options.
@@ -768,7 +769,7 @@ USAGE
   • Use 'null' as output to discard file output.
 
 SUPPORTED INPUTS
-    .ply   .compressed.ply   .sog   .spz   meta.json   .ksplat   .splat   .mjs   .lcc   .lcc2
+    .ply   .compressed.ply   .sog   .spz   meta.json   lod-meta.json   .ksplat   .splat   .mjs   .lcc   .lcc2
 
     Input filenames may also be http(s):// URLs (downloaded on demand;
     .mjs generators are local-only).
@@ -823,8 +824,8 @@ HTML VIEWER OUTPUT (.html)
         --viewer-settings  <settings.json>  HTML viewer settings JSON file
         --unbundled                         Generate unbundled HTML viewer with separate files
 
-LCC / LCC2 INPUT (.lcc, .lcc2)
-    -L, --select-lod       <n,n,...>        Comma-separated LOD levels to read from LCC / LCC2 input
+LOD INPUT (.lcc, .lcc2, lod-meta.json)
+    -L, --select-lod       <n,n,...>        Comma-separated LOD levels to read from LCC / LCC2 / streamed SOG input
 
 LOD OUTPUT (lod-meta.json)
         --lod-chunk-count  <n>              Approximate number of Gaussians per LOD chunk in K. Default: 512
@@ -1270,7 +1271,7 @@ const main = async () => {
 
         // LOD-meta output: keep every level, structurally separate — LODs are
         // overlapping surfaces and are NEVER combined. Levels come from a single
-        // lcc/lcc2's intrinsic LODs, or from PLY inputs tagged with --tag-lod (env = -1,
+        // lcc/lcc2/streamed-SOG intrinsic LODs, or from PLY inputs tagged with --tag-lod (env = -1,
         // untagged = level 0). Each level (and the env) is processed independently
         // via processSourceBridged, the levels are stacked, and writeLodSource
         // streams them. With no actions this matches the previous streaming-LOD
@@ -1282,20 +1283,24 @@ const main = async () => {
 
             let perLevel: ChunkSource[] = [];
             let envSource: ChunkSource | null = null;
-            let container: ChunkSource | null = null; // shared multi-LOD parent (lcc/lcc2)
+            let container: ChunkSource | null = null; // shared intrinsic multi-LOD parent
             let inputActions: CliAction[] = [];
 
-            if (single === 'lcc' || single === 'lcc2') {
+            if (single === 'lcc' || single === 'lcc2' || single === 'lod') {
                 // Intrinsic multi-LOD: view each level with selectLod (shared parent);
                 // env fetched separately. The input's own actions apply per level.
                 const { filename: inFile, fileSystem } = resolveInput(inputArgs[0].filename);
                 const multi = single === 'lcc2' ?
                     await readLcc2Source(fileSystem, inFile, { ...options, lodSelect: [] }, pool) :
-                    await readLccSource(fileSystem, inFile, { ...options, lodSelect: [] }, pool);
+                    single === 'lod' ?
+                        await readLodSource(fileSystem, inFile, { ...options, lodSelect: [] }, pool) :
+                        await readLccSource(fileSystem, inFile, { ...options, lodSelect: [] }, pool);
                 container = multi;
                 envSource = single === 'lcc2' ?
                     await readLcc2EnvironmentSource(fileSystem, inFile, pool) :
-                    await readLccEnvironmentSource(fileSystem, inFile, pool);
+                    single === 'lod' ?
+                        await readLodEnvironmentSource(fileSystem, inFile, pool) :
+                        await readLccEnvironmentSource(fileSystem, inFile, pool);
                 // --select-lod picks which levels go into the lod-meta (default all).
                 perLevel = resolveLodLevels(options.lodSelect, multi.meta.numLods).map(lvl => selectLod(multi, lvl));
                 inputActions = inputArgs[0].processActions;
@@ -1310,7 +1315,7 @@ const main = async () => {
                     return { arg: a, ply, tag, rest };
                 });
                 if (!tagged.every(t => t.ply)) {
-                    throw new Error('lod-meta.json output requires a single LCC/LCC2 input, or local PLY input(s) (optionally --tag-lod tagged).');
+                    throw new Error('lod-meta.json output requires a single LCC/LCC2/streamed-SOG input, or local PLY input(s) (optionally --tag-lod tagged).');
                 }
                 const opened = await Promise.all(tagged.map(async (t) => {
                     const { filename: inFile, fileSystem } = resolveInput(t.arg.filename);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -824,8 +824,8 @@ HTML VIEWER OUTPUT (.html)
         --viewer-settings  <settings.json>  HTML viewer settings JSON file
         --unbundled                         Generate unbundled HTML viewer with separate files
 
-LOD INPUT (.lcc, .lcc2, lod-meta.json)
-    -L, --select-lod       <n,n,...>        Comma-separated LOD levels to read from LCC / LCC2 / streamed SOG input
+LOD INPUT (lod-meta.json, .lcc, .lcc2)
+    -L, --select-lod       <n,n,...>        Comma-separated LOD levels to read from streamed SOG / LCC / LCC2 input
 
 LOD OUTPUT (lod-meta.json)
         --lod-chunk-count  <n>              Approximate number of Gaussians per LOD chunk in K. Default: 512
@@ -1271,7 +1271,7 @@ const main = async () => {
 
         // LOD-meta output: keep every level, structurally separate — LODs are
         // overlapping surfaces and are NEVER combined. Levels come from a single
-        // lcc/lcc2/streamed-SOG intrinsic LODs, or from PLY inputs tagged with --tag-lod (env = -1,
+        // streamed-SOG/lcc/lcc2 intrinsic LODs, or from PLY inputs tagged with --tag-lod (env = -1,
         // untagged = level 0). Each level (and the env) is processed independently
         // via processSourceBridged, the levels are stacked, and writeLodSource
         // streams them. With no actions this matches the previous streaming-LOD
@@ -1315,7 +1315,7 @@ const main = async () => {
                     return { arg: a, ply, tag, rest };
                 });
                 if (!tagged.every(t => t.ply)) {
-                    throw new Error('lod-meta.json output requires a single LCC/LCC2/streamed-SOG input, or local PLY input(s) (optionally --tag-lod tagged).');
+                    throw new Error('lod-meta.json output requires a single streamed-SOG/LCC/LCC2 input, or local PLY input(s) (optionally --tag-lod tagged).');
                 }
                 const opened = await Promise.all(tagged.map(async (t) => {
                     const { filename: inFile, fileSystem } = resolveInput(t.arg.filename);

--- a/src/lib/read.ts
+++ b/src/lib/read.ts
@@ -4,6 +4,7 @@ import { ReadFileSystem, ZipReadFileSystem } from './io/read';
 import { readKsplat, readMjs, readPly, readSogSource, readSplat, readSpz, statSogSource } from './readers';
 import { readLccSource } from './readers/read-lcc';
 import { readLcc2Source } from './readers/read-lcc2';
+import { readLodSource } from './readers/read-lod';
 import { Options, Param } from './types';
 
 /**
@@ -16,9 +17,10 @@ import { Options, Param } from './types';
  * - `sog` - PlayCanvas SOG format (WebP-compressed)
  * - `lcc` - XGrids LCC format
  * - `lcc2` - XGrids LCC2 (octree) format
+ * - `lod` - Streamed SOG (`lod-meta.json`) format
  * - `mjs` - JavaScript module generator
  */
-type InputFormat = 'mjs' | 'ksplat' | 'splat' | 'sog' | 'ply' | 'spz' | 'lcc' | 'lcc2';
+type InputFormat = 'mjs' | 'ksplat' | 'splat' | 'sog' | 'ply' | 'spz' | 'lcc' | 'lcc2' | 'lod';
 
 /**
  * Determines the input format based on file extension.
@@ -58,6 +60,8 @@ const getInputFormat = (filename: string): InputFormat => {
         return 'ksplat';
     } else if (lowerFilename.endsWith('.splat')) {
         return 'splat';
+    } else if (lowerFilename.endsWith('lod-meta.json')) {
+        return 'lod';
     } else if (lowerFilename.endsWith('.sog') || lowerFilename.endsWith('meta.json')) {
         return 'sog';
     } else if (lowerFilename.endsWith('.ply')) {
@@ -93,7 +97,7 @@ type ReadFileOptions = {
  * Reads a Gaussian splat file and returns its data as {@link ChunkSource}s
  * (usually one; an LCC/LCC2 container yields a single structural multi-LOD source).
  *
- * Readers are chunk-native: `ply`/`splat`/`spz`/`lcc`/`lcc2` return lazy /
+ * Readers are chunk-native: `ply`/`splat`/`spz`/`lcc`/`lcc2`/`lod` return lazy /
  * streaming sources whose `close()` releases the underlying file(s); whole-blob
  * formats (`sog`/`mjs`/`ksplat`) are decoded up front and returned resident.
  * Callers that need a `DataTable` materialize at their own boundary (and call
@@ -152,6 +156,9 @@ const readFile = async (readFileOptions: ReadFileOptions): Promise<ChunkSource[]
     }
     if (inputFormat === 'lcc2') {
         return [await readLcc2Source(fileSystem, filename, options, createChunkDataPool())];
+    }
+    if (inputFormat === 'lod') {
+        return [await readLodSource(fileSystem, filename, options, createChunkDataPool())];
     }
 
     // Single-source binary formats over a seekable ReadSource. Lazy readers

--- a/src/lib/read.ts
+++ b/src/lib/read.ts
@@ -11,13 +11,13 @@ import { Options, Param } from './types';
  * Supported input file formats for Gaussian splat data.
  *
  * - `ply` - PLY format (standard 3DGS training output)
- * - `splat` - Antimatter15 splat format
- * - `ksplat` - Kevin Kwok's compressed splat format
- * - `spz` - Niantic Labs compressed format
  * - `sog` - PlayCanvas SOG format (WebP-compressed)
+ * - `lod` - Streamed SOG (`lod-meta.json`) format
  * - `lcc` - XGrids LCC format
  * - `lcc2` - XGrids LCC2 (octree) format
- * - `lod` - Streamed SOG (`lod-meta.json`) format
+ * - `spz` - Niantic Labs compressed format
+ * - `splat` - Antimatter15 splat format
+ * - `ksplat` - Kevin Kwok's compressed splat format
  * - `mjs` - JavaScript module generator
  */
 type InputFormat = 'mjs' | 'ksplat' | 'splat' | 'sog' | 'ply' | 'spz' | 'lcc' | 'lcc2' | 'lod';
@@ -95,7 +95,7 @@ type ReadFileOptions = {
 
 /**
  * Reads a Gaussian splat file and returns its data as {@link ChunkSource}s
- * (usually one; an LCC/LCC2 container yields a single structural multi-LOD source).
+ * (usually one; a Streamed SOG/LCC/LCC2 container yields a single structural multi-LOD source).
  *
  * Readers are chunk-native: `ply`/`splat`/`spz`/`lcc`/`lcc2`/`lod` return lazy /
  * streaming sources whose `close()` releases the underlying file(s); whole-blob

--- a/src/lib/readers/container-source.ts
+++ b/src/lib/readers/container-source.ts
@@ -19,8 +19,8 @@ type ContainerSegment = {
 };
 
 /**
- * Present a container of lazily-decoded sub-files (LCC / LCC2: many SPZ/SOG
- * chunk files, LOD-grouped) as one **multi-LOD `ChunkSource`**, without ever
+ * Present a container of lazily-decoded sub-files (Streamed SOG / LCC / LCC2:
+ * many SOG/SPZ chunk files, LOD-grouped) as one **multi-LOD `ChunkSource`**, without ever
  * holding the whole scene resident.
  *
  * Each LOD's segments are stitched with {@link concatSource} (the proven

--- a/src/lib/readers/read-lod.ts
+++ b/src/lib/readers/read-lod.ts
@@ -57,6 +57,10 @@ const parseLodMeta = (text: string, filename: string): LodMeta => {
 const collectFilesByLod = (meta: LodMeta, filename: string): Map<number, Map<number, number>> => {
     const result = new Map<number, Map<number, number>>();
     const traverse = (node: LodNode): void => {
+        if (!node || typeof node !== 'object' || Array.isArray(node) ||
+            (node.children !== undefined && !Array.isArray(node.children))) {
+            throw new Error(`Invalid lod-meta.json tree: ${filename}`);
+        }
         for (const [key, ref] of Object.entries(node.lods ?? {})) {
             const lod = Number(key);
             if (!Number.isInteger(lod) || lod < 0 || lod >= meta.lodLevels ||

--- a/src/lib/readers/read-lod.ts
+++ b/src/lib/readers/read-lod.ts
@@ -1,0 +1,164 @@
+import { containerSource, type ContainerSegment } from './container-source';
+import { readSogSource } from './read-sog';
+import { type ChunkDataPool, type ChunkSource } from '../chunk';
+import { dirname, join, readFile, type ReadFileSystem } from '../io/read';
+import { type Options } from '../types';
+
+type LodReference = {
+    file: number;
+    offset: number;
+    count: number;
+};
+
+type LodNode = {
+    children?: LodNode[];
+    lods?: Record<string, LodReference>;
+};
+
+type LodMeta = {
+    version: number;
+    count: number;
+    counts: number[];
+    lodLevels: number;
+    environment?: string;
+    filenames: string[];
+    tree: LodNode;
+};
+
+const parseLodMeta = (text: string, filename: string): LodMeta => {
+    let meta: LodMeta;
+    try {
+        meta = JSON.parse(text) as LodMeta;
+    } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        throw new Error(`Failed to parse lod-meta.json: ${filename}: ${reason}`);
+    }
+
+    if (meta.version !== 1) {
+        throw new Error(`Unsupported lod-meta.json version: ${meta.version}`);
+    }
+    if (!Number.isInteger(meta.lodLevels) || meta.lodLevels <= 0) {
+        throw new Error(`Invalid lod-meta.json lodLevels: ${filename}`);
+    }
+    if (!Array.isArray(meta.counts) || meta.counts.length !== meta.lodLevels ||
+        meta.counts.some(count => !Number.isInteger(count) || count < 0)) {
+        throw new Error(`Invalid lod-meta.json counts: ${filename}`);
+    }
+    if (!Array.isArray(meta.filenames) || meta.filenames.some(name => typeof name !== 'string')) {
+        throw new Error(`Invalid lod-meta.json filenames: ${filename}`);
+    }
+    if (!meta.tree || typeof meta.tree !== 'object') {
+        throw new Error(`Invalid lod-meta.json tree: ${filename}`);
+    }
+
+    return meta;
+};
+
+const collectFilesByLod = (meta: LodMeta, filename: string): Map<number, Map<number, number>> => {
+    const result = new Map<number, Map<number, number>>();
+    const traverse = (node: LodNode): void => {
+        for (const [key, ref] of Object.entries(node.lods ?? {})) {
+            const lod = Number(key);
+            if (!Number.isInteger(lod) || lod < 0 || lod >= meta.lodLevels ||
+                !ref || !Number.isInteger(ref.file) || ref.file < 0 || ref.file >= meta.filenames.length ||
+                !Number.isInteger(ref.offset) || ref.offset < 0 ||
+                !Number.isInteger(ref.count) || ref.count < 0) {
+                throw new Error(`Invalid lod-meta.json LOD reference: ${filename}`);
+            }
+            let files = result.get(lod);
+            if (!files) {
+                files = new Map();
+                result.set(lod, files);
+            }
+            files.set(ref.file, (files.get(ref.file) ?? 0) + ref.count);
+        }
+        for (const child of node.children ?? []) traverse(child);
+    };
+    traverse(meta.tree);
+
+    for (let lod = 0; lod < meta.lodLevels; lod++) {
+        const count = [...(result.get(lod)?.values() ?? [])].reduce((sum, value) => sum + value, 0);
+        if (count !== meta.counts[lod]) {
+            throw new Error(
+                `lod-meta.json LOD ${lod} count mismatch: expected ${meta.counts[lod]}, found ${count}`
+            );
+        }
+    }
+
+    return result;
+};
+
+const resolveLodSelection = (lodSelect: number[], numLods: number): number[] => {
+    if (lodSelect.length === 0) return Array.from({ length: numLods }, (_, i) => i);
+    return lodSelect
+    .map(lod => (lod < 0 ? numLods + lod : lod))
+    .filter(lod => lod >= 0 && lod < numLods);
+};
+
+/**
+ * Open a streamed SOG (`lod-meta.json`) as a lazy, structural multi-LOD source.
+ * Referenced SOG units are decoded on demand and retained in the bounded
+ * {@link containerSource} cache instead of materializing the complete scene.
+ *
+ * @param fileSystem - File system containing lod-meta.json and its SOG units.
+ * @param filename - Path to lod-meta.json.
+ * @param options - Read options, including optional LOD selection.
+ * @param pool - Pool whose chunk size is used by the returned source.
+ * @returns A lazy multi-LOD source over the selected levels.
+ * @ignore
+ */
+const readLodSource = async (
+    fileSystem: ReadFileSystem,
+    filename: string,
+    options: Options,
+    pool: ChunkDataPool
+): Promise<ChunkSource> => {
+    const baseDir = dirname(filename);
+    const related = (name: string) => (baseDir ? join(baseDir, name) : name);
+    const meta = parseLodMeta(new TextDecoder().decode(await readFile(fileSystem, filename)), filename);
+    const inputLods = resolveLodSelection(options.lodSelect ?? [], meta.lodLevels);
+    if (inputLods.length === 0) {
+        throw new Error(
+            `No valid LODs selected for streamed SOG input file: ${filename} lods: ${JSON.stringify(options.lodSelect ?? [])}`
+        );
+    }
+
+    const filesByLod = collectFilesByLod(meta, filename);
+    const segmentsByLod = inputLods.map((lod): ContainerSegment[] => {
+        const files = filesByLod.get(lod);
+        return [...(files?.entries() ?? [])]
+        .sort(([a], [b]) => a - b)
+        .map(([file, count]) => {
+            const path = related(meta.filenames[file]);
+            return {
+                count,
+                decode: () => readSogSource(fileSystem, path, pool, { logging: 'silent' })
+            };
+        });
+    });
+
+    return containerSource(segmentsByLod, pool);
+};
+
+/**
+ * Open the optional environment SOG referenced by a streamed SOG container.
+ *
+ * @param fileSystem - File system containing lod-meta.json and its SOG units.
+ * @param filename - Path to lod-meta.json.
+ * @param pool - Pool whose chunk size is used by the returned source.
+ * @returns The environment source, or `null` when none is referenced.
+ * @ignore
+ */
+const readLodEnvironmentSource = async (
+    fileSystem: ReadFileSystem,
+    filename: string,
+    pool: ChunkDataPool
+): Promise<ChunkSource | null> => {
+    const baseDir = dirname(filename);
+    const related = (name: string) => (baseDir ? join(baseDir, name) : name);
+    const meta = parseLodMeta(new TextDecoder().decode(await readFile(fileSystem, filename)), filename);
+    return meta.environment ? readSogSource(fileSystem, related(meta.environment), pool, { logging: 'silent' }) : null;
+};
+
+export { parseLodMeta, collectFilesByLod, readLodSource, readLodEnvironmentSource };
+export type { LodReference, LodNode, LodMeta };

--- a/src/lib/writers/write-lod.ts
+++ b/src/lib/writers/write-lod.ts
@@ -290,7 +290,7 @@ type WriteLodSourceOptions = {
     filename: string;
     /**
      * The scene as a structural multi-LOD source: LOD `i` is output detail level
-     * `i`. lcc/lcc2 expose this intrinsically; multi-PLY `--tag-lod` inputs are stacked
+     * `i`. Streamed SOG/lcc/lcc2 expose this intrinsically; multi-PLY `--tag-lod` inputs are stacked
      * by tag via {@link stackLods}. No per-gaussian lod tag — LOD is structural.
      */
     mainSource: ChunkSource;

--- a/test/container-source.test.mjs
+++ b/test/container-source.test.mjs
@@ -1,5 +1,5 @@
 /**
- * Tests for the lazy multi-LOD container source (the LCC/LCC2 backend): segments
+ * Tests for the lazy multi-LOD container source (the Streamed SOG/LCC/LCC2 backend): segments
  * are decoded on demand, LRU-cached, and stitched per LOD via concatSource.
  */
 

--- a/test/write-lod.test.mjs
+++ b/test/write-lod.test.mjs
@@ -11,11 +11,15 @@ import { dirname, join } from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
-import { Column, DataTable, Transform, WebPCodec } from '../src/lib/index.js';
+import {
+    Column, DataTable, MemoryReadFileSystem, Transform, WebPCodec,
+    getInputFormat, readFile
+} from '../src/lib/index.js';
 import { dataTableToChunkSource, materializeToDataTable } from '../src/lib/compat/data-table.js';
 import { MemoryFileSystem } from '../src/lib/io/write/index.js';
 import { bakeTransform, mapSource, stackLods } from '../src/lib/ops/index.js';
 import { readPly } from '../src/lib/readers/read-ply.js';
+import { readLodEnvironmentSource } from '../src/lib/readers/read-lod.js';
 import { createChunkDataPool } from '../src/lib/chunk/index.js';
 import { positionsFromSlim, writeLodSource } from '../src/lib/writers/write-lod.js';
 import { version } from '../src/lib/version.js';
@@ -104,6 +108,12 @@ const writeScene = async (levelCounts, envRows) => {
     }, fs);
     const meta = JSON.parse(new TextDecoder().decode(fs.results.get('/scene/lod-meta.json')));
     return { fs, meta };
+};
+
+const asReadFileSystem = (writeFs) => {
+    const readFs = new MemoryReadFileSystem();
+    for (const [name, data] of writeFs.results) readFs.set(name, data);
+    return readFs;
 };
 
 describe('writeLodSource: lod-meta.json contract', function () {
@@ -238,6 +248,58 @@ describe('writeLodSource: lod-meta.json contract', function () {
             assert.ok(meta.tree.bound.min[axis] >= lo[axis] - 0.2, `root bound min[${name}] within splat extents of baked positions`);
             assert.ok(meta.tree.bound.max[axis] <= hi[axis] + 0.2, `root bound max[${name}] within splat extents of baked positions`);
         });
+    });
+});
+
+describe('readLodSource: streamed SOG input', function () {
+    it('detects lod-meta.json before a regular SOG meta.json', function () {
+        assert.strictEqual(getInputFormat('/scene/lod-meta.json'), 'lod');
+        assert.strictEqual(getInputFormat('/scene/meta.json'), 'sog');
+    });
+
+    it('reads all levels as a structural multi-LOD ChunkSource', async function () {
+        const { fs } = await writeScene([3, 2], 0);
+        const [source] = await readFile({
+            filename: '/scene/lod-meta.json',
+            inputFormat: 'lod',
+            options: { lodSelect: [] },
+            fileSystem: asReadFileSystem(fs)
+        });
+
+        assert.strictEqual(source.meta.numLods, 2);
+        assert.strictEqual(source.meta.numGaussians, 3);
+        assert.deepStrictEqual(source.meta.lodCounts, [3, 2]);
+        const table = await materializeToDataTable(source, createChunkDataPool());
+        assert.strictEqual(table.numRows, 5);
+        await source.close();
+    });
+
+    it('honors LOD selection', async function () {
+        const { fs } = await writeScene([3, 2], 0);
+        const [source] = await readFile({
+            filename: '/scene/lod-meta.json',
+            inputFormat: 'lod',
+            options: { lodSelect: [1] },
+            fileSystem: asReadFileSystem(fs)
+        });
+
+        assert.strictEqual(source.meta.numLods, 1);
+        assert.strictEqual(source.meta.numGaussians, 2);
+        assert.deepStrictEqual(source.meta.lodCounts, [2]);
+        await source.close();
+    });
+
+    it('opens the optional environment SOG', async function () {
+        const { fs } = await writeScene([3], 2);
+        const source = await readLodEnvironmentSource(
+            asReadFileSystem(fs),
+            '/scene/lod-meta.json',
+            createChunkDataPool()
+        );
+
+        assert.ok(source);
+        assert.strictEqual(source.meta.numGaussians, 2);
+        await source.close();
     });
 });
 

--- a/test/write-lod.test.mjs
+++ b/test/write-lod.test.mjs
@@ -19,7 +19,7 @@ import { dataTableToChunkSource, materializeToDataTable } from '../src/lib/compa
 import { MemoryFileSystem } from '../src/lib/io/write/index.js';
 import { bakeTransform, mapSource, stackLods } from '../src/lib/ops/index.js';
 import { readPly } from '../src/lib/readers/read-ply.js';
-import { readLodEnvironmentSource } from '../src/lib/readers/read-lod.js';
+import { collectFilesByLod, readLodEnvironmentSource } from '../src/lib/readers/read-lod.js';
 import { createChunkDataPool } from '../src/lib/chunk/index.js';
 import { positionsFromSlim, writeLodSource } from '../src/lib/writers/write-lod.js';
 import { version } from '../src/lib/version.js';
@@ -255,6 +255,16 @@ describe('readLodSource: streamed SOG input', function () {
     it('detects lod-meta.json before a regular SOG meta.json', function () {
         assert.strictEqual(getInputFormat('/scene/lod-meta.json'), 'lod');
         assert.strictEqual(getInputFormat('/scene/meta.json'), 'sog');
+    });
+
+    it('rejects malformed tree children with a controlled error', function () {
+        for (const child of [null, 1]) {
+            const meta = { lodLevels: 1, counts: [0], filenames: [], tree: { children: [child] } };
+            assert.throws(
+                () => collectFilesByLod(meta, '/scene/lod-meta.json'),
+                { message: 'Invalid lod-meta.json tree: /scene/lod-meta.json' }
+            );
+        }
     });
 
     it('reads all levels as a structural multi-LOD ChunkSource', async function () {


### PR DESCRIPTION
Add chunk-native loading for streamed SOG (lod-meta.json), including structural LOD selection, lazy SOG unit decoding, environment loading, CLI integration, documentation updates, and round-trip test coverage.