### PR TITLE
Optimize voxel processing for large scenes

### DIFF
--- a/src/lib/voxel/block-cleanup.ts
+++ b/src/lib/voxel/block-cleanup.ts
@@ -1,5 +1,6 @@
 import { BlockMaskBuffer } from './block-mask-buffer';
 import { popcount } from './morton';
+import { sortKeyMaskPairs } from './sort-key-mask';
 import { logger } from '../utils';
 
 // ============================================================================
@@ -38,140 +39,168 @@ const SOLID_MASK = 0xFFFFFFFF >>> 0;
  *
  * Blocks that become empty or solid as a consequence are handled automatically.
  *
- * @param buffer - BlockMaskBuffer with voxelization results (linear-keyed).
+ * @param buffer - BlockMaskBuffer with voxelization results (linear-keyed). Entry order may be changed.
  * @param nbx - Grid block dimension X (used to decode block indices).
  * @param nby - Grid block dimension Y (used to decode block indices).
  * @param nbz - Grid block dimension Z (used for neighbor bounds checks).
+ * @param maxMixedBlocks - Optional output limit; filtering stops once exceeded.
  * @returns New BlockMaskBuffer with filtered/filled data.
  */
 function filterAndFillBlocks(
     buffer: BlockMaskBuffer,
     nbx: number,
     nby: number,
-    nbz: number
+    nbz: number,
+    maxMixedBlocks: number = Number.POSITIVE_INFINITY
 ): BlockMaskBuffer {
     const mixed = buffer.getMixedBlocks();
     const solid = buffer.getSolidBlocks();
     const masks = mixed.masks;
     const bStride = nbx * nby;
+    const totalBlocks = bStride * nbz;
 
-    // Build lookup structures from original (unmodified) data
-    const solidSet = new Set<number>();
-    for (let i = 0; i < solid.length; i++) {
-        solidSet.add(solid[i]);
-    }
-
-    const mixedMap = new Map<number, number>();
-    for (let i = 0; i < mixed.blockIdx.length; i++) {
-        mixedMap.set(mixed.blockIdx[i], i);
-    }
+    // Sort the source arrays in place. Cross-block neighbor queries below are
+    // resolved as monotonic merges over fixed-size mixed-block chunks, avoiding
+    // a full-scene hash table and its power-of-two capacity overhead.
+    solid.sort();
+    sortKeyMaskPairs(mixed.blockIdx, masks, mixed.blockIdx.length);
 
     // New masks array (snapshot: cross-block lookups always read the original masks)
     const newMasks = new Uint32Array(masks.length);
     let voxelsRemoved = 0;
     let voxelsFilled = 0;
+    let mixedBlocks = 0;
+    let promotedSolidBlocks = 0;
+    const CHUNK_SIZE = 1 << 20;
+    const work = new Uint32Array(Math.min(CHUNK_SIZE, mixed.blockIdx.length) * 12);
 
-    for (let i = 0; i < mixed.blockIdx.length; i++) {
-        const idx = mixed.blockIdx[i];
-        const origLo = masks[i * 2];
-        const origHi = masks[i * 2 + 1];
+    const lowerBound = (keys: Float64Array, target: number): number => {
+        let lo = 0;
+        let hi = keys.length;
+        while (lo < hi) {
+            const mid = (lo + hi) >>> 1;
+            if (keys[mid] < target) lo = mid + 1;
+            else hi = mid;
+        }
+        return lo;
+    };
 
-        const bx = idx % nbx;
-        const byBz = (idx / nbx) | 0;
-        const by = byBz % nby;
-        const bz = (byBz / nby) | 0;
+    for (let chunkStart = 0; chunkStart < mixed.blockIdx.length; chunkStart += CHUNK_SIZE) {
+        const chunkLength = Math.min(CHUNK_SIZE, mixed.blockIdx.length - chunkStart);
 
-        // --- In-block per-direction occupancy masks ---
+        for (let local = 0; local < chunkLength; local++) {
+            const i = chunkStart + local;
+            const origLo = masks[i * 2];
+            const origHi = masks[i * 2 + 1];
+            const w = local * 12;
+            work[w] = (origLo >>> 1) & ~FACE_X3;
+            work[w + 1] = (origHi >>> 1) & ~FACE_X3;
+            work[w + 2] = (origLo << 1) & ~FACE_X0;
+            work[w + 3] = (origHi << 1) & ~FACE_X0;
+            work[w + 4] = (origLo >>> 4) & ~FACE_Y3;
+            work[w + 5] = (origHi >>> 4) & ~FACE_Y3;
+            work[w + 6] = (origLo << 4) & ~FACE_Y0;
+            work[w + 7] = (origHi << 4) & ~FACE_Y0;
+            work[w + 8] = (origLo >>> 16) | (origHi << 16);
+            work[w + 9] = origHi >>> 16;
+            work[w + 10] = origLo << 16;
+            work[w + 11] = (origHi << 16) | (origLo >>> 16);
+        }
 
-        // +X: result[p] = mask[p+1], valid for lx < 3
-        let pxLo = (origLo >>> 1) & ~FACE_X3;
-        let pxHi = (origHi >>> 1) & ~FACE_X3;
+        for (let direction = 0; direction < 6; direction++) {
+            let solidPos = -1;
+            let mixedPos = -1;
+            for (let local = 0; local < chunkLength; local++) {
+                const i = chunkStart + local;
+                const idx = mixed.blockIdx[i];
+                const bx = idx % nbx;
+                const by = Math.floor(idx / nbx) % nby;
+                let target = -1;
+                if (direction === 0 && bx < nbx - 1) target = idx + 1;
+                else if (direction === 1 && bx > 0) target = idx - 1;
+                else if (direction === 2 && by < nby - 1) target = idx + nbx;
+                else if (direction === 3 && by > 0) target = idx - nbx;
+                else if (direction === 4 && idx + bStride < totalBlocks) target = idx + bStride;
+                else if (direction === 5 && idx >= bStride) target = idx - bStride;
+                if (target < 0) continue;
 
-        // -X: result[p] = mask[p-1], valid for lx > 0
-        let mxLo = (origLo << 1) & ~FACE_X0;
-        let mxHi = (origHi << 1) & ~FACE_X0;
+                if (solidPos < 0) {
+                    solidPos = lowerBound(solid, target);
+                    mixedPos = lowerBound(mixed.blockIdx, target);
+                } else {
+                    while (solidPos < solid.length && solid[solidPos] < target) solidPos++;
+                    while (mixedPos < mixed.blockIdx.length && mixed.blockIdx[mixedPos] < target) mixedPos++;
+                }
 
-        // +Y: result[p] = mask[p+4], valid for ly < 3
-        let pyLo = (origLo >>> 4) & ~FACE_Y3;
-        let pyHi = (origHi >>> 4) & ~FACE_Y3;
+                let adjLo = 0;
+                let adjHi = 0;
+                if (solidPos < solid.length && solid[solidPos] === target) {
+                    adjLo = SOLID_MASK;
+                    adjHi = SOLID_MASK;
+                } else if (mixedPos < mixed.blockIdx.length && mixed.blockIdx[mixedPos] === target) {
+                    adjLo = masks[mixedPos * 2];
+                    adjHi = masks[mixedPos * 2 + 1];
+                } else {
+                    continue;
+                }
 
-        // -Y: result[p] = mask[p-4], valid for ly > 0
-        let myLo = (origLo << 4) & ~FACE_Y0;
-        let myHi = (origHi << 4) & ~FACE_Y0;
+                const w = local * 12 + direction * 2;
+                if (direction === 0) {
+                    work[w] |= (adjLo & FACE_X0) << 3;
+                    work[w + 1] |= (adjHi & FACE_X0) << 3;
+                } else if (direction === 1) {
+                    work[w] |= (adjLo & FACE_X3) >>> 3;
+                    work[w + 1] |= (adjHi & FACE_X3) >>> 3;
+                } else if (direction === 2) {
+                    work[w] |= (adjLo & FACE_Y0) << 12;
+                    work[w + 1] |= (adjHi & FACE_Y0) << 12;
+                } else if (direction === 3) {
+                    work[w] |= (adjLo & FACE_Y3) >>> 12;
+                    work[w + 1] |= (adjHi & FACE_Y3) >>> 12;
+                } else if (direction === 4) {
+                    work[w + 1] |= (adjLo & FACE_Z0_LO) << 16;
+                } else {
+                    work[w] |= (adjHi & FACE_Z3_HI) >>> 16;
+                }
+            }
+        }
 
-        // +Z: result[p] = mask[p+16], crosses lo/hi at lz=1->lz=2
-        let pzLo = (origLo >>> 16) | (origHi << 16);
-        let pzHi = origHi >>> 16;
+        for (let local = 0; local < chunkLength; local++) {
+            const i = chunkStart + local;
+            const origLo = masks[i * 2];
+            const origHi = masks[i * 2 + 1];
+            const w = local * 12;
+            const pxLo = work[w], pxHi = work[w + 1];
+            const mxLo = work[w + 2], mxHi = work[w + 3];
+            const pyLo = work[w + 4], pyHi = work[w + 5];
+            const myLo = work[w + 6], myHi = work[w + 7];
+            const pzLo = work[w + 8], pzHi = work[w + 9];
+            const mzLo = work[w + 10], mzHi = work[w + 11];
+            const neighborLo = pxLo | mxLo | pyLo | myLo | pzLo | mzLo;
+            const neighborHi = pxHi | mxHi | pyHi | myHi | pzHi | mzHi;
+            let lo = origLo & neighborLo;
+            let hi = origHi & neighborHi;
+            lo |= ~lo & pxLo & mxLo & pyLo & myLo & pzLo & mzLo;
+            hi |= ~hi & pxHi & mxHi & pyHi & myHi & pzHi & mzHi;
 
-        // -Z: result[p] = mask[p-16], crosses lo/hi at lz=2->lz=1
-        let mzLo = origLo << 16;
-        let mzHi = (origHi << 16) | (origLo >>> 16);
+            voxelsRemoved += popcount(origLo & ~lo) + popcount(origHi & ~hi);
+            voxelsFilled += popcount(lo & ~origLo) + popcount(hi & ~origHi);
+            newMasks[i * 2] = lo;
+            newMasks[i * 2 + 1] = hi;
 
-        // --- Cross-block contributions ---
-
-        // +X: our lx=3 face <- adjacent's lx=0 face (shifted left by 3)
-        addCrossFace(bx + 1, by, bz, nbx, nby, nbz, bStride, solidSet, mixedMap, masks,
-            FACE_X3, FACE_X0, 3, true, pxLo, pxHi,
-            (lo, hi) => {
-                pxLo = lo; pxHi = hi;
-            });
-
-        // -X: our lx=0 face <- adjacent's lx=3 face (shifted right by 3)
-        addCrossFace(bx - 1, by, bz, nbx, nby, nbz, bStride, solidSet, mixedMap, masks,
-            FACE_X0, FACE_X3, 3, false, mxLo, mxHi,
-            (lo, hi) => {
-                mxLo = lo; mxHi = hi;
-            });
-
-        // +Y: our ly=3 face <- adjacent's ly=0 face (shifted left by 12)
-        addCrossFace(bx, by + 1, bz, nbx, nby, nbz, bStride, solidSet, mixedMap, masks,
-            FACE_Y3, FACE_Y0, 12, true, pyLo, pyHi,
-            (lo, hi) => {
-                pyLo = lo; pyHi = hi;
-            });
-
-        // -Y: our ly=0 face <- adjacent's ly=3 face (shifted right by 12)
-        addCrossFace(bx, by - 1, bz, nbx, nby, nbz, bStride, solidSet, mixedMap, masks,
-            FACE_Y0, FACE_Y3, 12, false, myLo, myHi,
-            (lo, hi) => {
-                myLo = lo; myHi = hi;
-            });
-
-        // +Z: our lz=3 face (hi bits 16-31) <- adjacent's lz=0 face (lo bits 0-15)
-        addCrossFaceZ(bx, by, bz + 1, nbx, nby, nbz, bStride, solidSet, mixedMap, masks, true, pzLo, pzHi,
-            (lo, hi) => {
-                pzLo = lo; pzHi = hi;
-            });
-
-        // -Z: our lz=0 face (lo bits 0-15) <- adjacent's lz=3 face (hi bits 16-31)
-        addCrossFaceZ(bx, by, bz - 1, nbx, nby, nbz, bStride, solidSet, mixedMap, masks, false, mzLo, mzHi,
-            (lo, hi) => {
-                mzLo = lo; mzHi = hi;
-            });
-
-        // --- Apply operations ---
-
-        // Remove isolated voxels: keep only those with at least one occupied neighbor
-        const neighborLo = pxLo | mxLo | pyLo | myLo | pzLo | mzLo;
-        const neighborHi = pxHi | mxHi | pyHi | myHi | pzHi | mzHi;
-        let lo = origLo & neighborLo;
-        let hi = origHi & neighborHi;
-
-        // Fill isolated empties: fill where all 6 neighbors are occupied
-        const fillLo = ~lo & pxLo & mxLo & pyLo & myLo & pzLo & mzLo;
-        const fillHi = ~hi & pxHi & mxHi & pyHi & myHi & pzHi & mzHi;
-        lo |= fillLo;
-        hi |= fillHi;
-
-        voxelsRemoved += popcount(origLo & ~lo) + popcount(origHi & ~hi);
-        voxelsFilled += popcount(lo & ~origLo) + popcount(hi & ~origHi);
-
-        newMasks[i * 2] = lo;
-        newMasks[i * 2 + 1] = hi;
+            if ((lo >>> 0) === SOLID_MASK && (hi >>> 0) === SOLID_MASK) {
+                promotedSolidBlocks++;
+            } else if (lo !== 0 || hi !== 0) {
+                mixedBlocks++;
+                if (mixedBlocks > maxMixedBlocks) {
+                    throw new Error(`Voxel output has more than ${maxMixedBlocks} mixed blocks. Use a coarser voxel resolution.`);
+                }
+            }
+        }
     }
 
     // Rebuild buffer with state transitions (mixed->empty, mixed->solid)
-    const result = new BlockMaskBuffer();
+    const result = new BlockMaskBuffer(solid.length + promotedSolidBlocks, mixedBlocks);
 
     for (let i = 0; i < mixed.blockIdx.length; i++) {
         const lo = newMasks[i * 2];
@@ -186,93 +215,6 @@ function filterAndFillBlocks(
     logger.debug(`block cleanup: ${voxelsRemoved} voxels removed, ${voxelsFilled} voxels filled`);
 
     return result;
-}
-
-// ============================================================================
-// Cross-block face helpers
-// ============================================================================
-
-function addCrossFace(
-    nx: number, ny: number, nz: number,
-    nbx: number, nby: number, nbz: number, bStride: number,
-    solidSet: Set<number>,
-    mixedMap: Map<number, number>,
-    masks: Uint32Array,
-    ourFaceMask: number,
-    adjFaceMask: number,
-    shiftAmount: number,
-    shiftLeft: boolean,
-    curLo: number, curHi: number,
-    write: (lo: number, hi: number) => void
-): void {
-    if (nx < 0 || ny < 0 || nz < 0 || nx >= nbx || ny >= nby || nz >= nbz) {
-        write(curLo, curHi);
-        return;
-    }
-    const adjIdx = nx + ny * nbx + nz * bStride;
-
-    if (solidSet.has(adjIdx)) {
-        write(curLo | ourFaceMask, curHi | ourFaceMask);
-        return;
-    }
-
-    const mIdx = mixedMap.get(adjIdx);
-    if (mIdx === undefined) {
-        write(curLo, curHi);
-        return;
-    }
-
-    const adjLo = masks[mIdx * 2];
-    const adjHi = masks[mIdx * 2 + 1];
-    const faceLo = adjLo & adjFaceMask;
-    const faceHi = adjHi & adjFaceMask;
-
-    if (shiftLeft) {
-        write(curLo | (faceLo << shiftAmount), curHi | (faceHi << shiftAmount));
-    } else {
-        write(curLo | (faceLo >>> shiftAmount), curHi | (faceHi >>> shiftAmount));
-    }
-}
-
-function addCrossFaceZ(
-    nx: number, ny: number, nz: number,
-    nbx: number, nby: number, nbz: number, bStride: number,
-    solidSet: Set<number>,
-    mixedMap: Map<number, number>,
-    masks: Uint32Array,
-    plusZ: boolean,
-    curLo: number, curHi: number,
-    write: (lo: number, hi: number) => void
-): void {
-    if (nx < 0 || ny < 0 || nz < 0 || nx >= nbx || ny >= nby || nz >= nbz) {
-        write(curLo, curHi);
-        return;
-    }
-    const adjIdx = nx + ny * nbx + nz * bStride;
-
-    if (solidSet.has(adjIdx)) {
-        if (plusZ) {
-            write(curLo, curHi | FACE_Z3_HI);
-        } else {
-            write(curLo | FACE_Z0_LO, curHi);
-        }
-        return;
-    }
-
-    const mIdx = mixedMap.get(adjIdx);
-    if (mIdx === undefined) {
-        write(curLo, curHi);
-        return;
-    }
-
-    const adjLo = masks[mIdx * 2];
-    const adjHi = masks[mIdx * 2 + 1];
-
-    if (plusZ) {
-        write(curLo, curHi | ((adjLo & FACE_Z0_LO) << 16));
-    } else {
-        write(curLo | ((adjHi & FACE_Z3_HI) >>> 16), curHi);
-    }
 }
 
 export { filterAndFillBlocks };

--- a/src/lib/voxel/block-index-map.ts
+++ b/src/lib/voxel/block-index-map.ts
@@ -1,0 +1,77 @@
+const EMPTY_KEY = -1;
+
+/** Returned by `get` for a block index that was never inserted (empty block). */
+const ABSENT = -1;
+
+/** Stored/returned value marking a fully-solid block. */
+const SOLID = -2;
+
+/**
+ * Build-once, query-many open-addressing hash from a linear block index to a
+ * small state value, backed by typed arrays. Unlike a JS `Map`/`Set` it has no
+ * 2^24-entry ceiling. Capacity is limited to the largest power-of-two table
+ * whose slots can still be addressed by the 32-bit hash arithmetic.
+ *
+ * Values encode block state for the voxel cleanup / query passes:
+ *   - `SOLID` (-2): the block is fully solid.
+ *   - `>= 0`: the block is mixed; the value is its index into the caller's
+ *     parallel masks array (mask pair at `masks[v * 2]`, `masks[v * 2 + 1]`).
+ * `get` returns `ABSENT` (-1) for indices that were never inserted.
+ *
+ * Keys are held in a `Float64Array` so block indices beyond 2^32 (very large
+ * grids) are stored and compared exactly; the hash mixes both 32-bit halves.
+ * The table is sized once from a capacity hint and never resizes, so callers
+ * must not insert more than the hinted number of entries.
+ */
+class BlockIndexMap {
+    private keys: Float64Array;
+    private vals: Int32Array;
+    private mask: number;
+
+    /**
+     * @param capacityHint - Exact (or upper-bound) number of entries that will
+     * be inserted. The table is sized to the next power of two above
+     * `capacityHint / 0.7` so the load factor stays <= 0.7 and it never resizes.
+     */
+    constructor(capacityHint: number) {
+        const need = Math.max(16, Math.ceil(capacityHint / 0.7));
+        const cap = 2 ** Math.ceil(Math.log2(need));
+        if (!Number.isSafeInteger(capacityHint) || capacityHint < 0 || cap > 0x80000000) {
+            throw new Error(`BlockIndexMap capacity ${capacityHint} exceeds the typed hash-table limit`);
+        }
+        this.mask = cap - 1;
+        this.keys = new Float64Array(cap).fill(EMPTY_KEY);
+        this.vals = new Int32Array(cap);
+    }
+
+    set(key: number, val: number): void {
+        const keys = this.keys;
+        const mask = this.mask;
+        let i = ((Math.imul(key >>> 0, 0x9E3779B9) ^ Math.imul((key / 4294967296) >>> 0, 0x85EBCA77)) >>> 0) & mask;
+        while (keys[i] !== EMPTY_KEY && keys[i] !== key) {
+            i = (i + 1) & mask;
+        }
+        keys[i] = key;
+        this.vals[i] = val;
+    }
+
+    get(key: number): number {
+        const keys = this.keys;
+        const mask = this.mask;
+        let i = ((Math.imul(key >>> 0, 0x9E3779B9) ^ Math.imul((key / 4294967296) >>> 0, 0x85EBCA77)) >>> 0) & mask;
+        while (true) {
+            const k = keys[i];
+            if (k === key) return this.vals[i];
+            if (k === EMPTY_KEY) return ABSENT;
+            i = (i + 1) & mask;
+        }
+    }
+
+    releaseStorage(): void {
+        this.keys = new Float64Array(0);
+        this.vals = new Int32Array(0);
+        this.mask = 0;
+    }
+}
+
+export { BlockIndexMap, ABSENT, SOLID };

--- a/src/lib/voxel/block-mask-buffer.ts
+++ b/src/lib/voxel/block-mask-buffer.ts
@@ -41,6 +41,18 @@ class BlockMaskBuffer {
     /** Interleaved voxel masks for mixed blocks: [lo0, hi0, lo1, hi1, ...] */
     private _mixedMasks: Uint32Array = new Uint32Array(0);
 
+    constructor(solidCapacity = 0, mixedCapacity = 0) {
+        if (solidCapacity > 0) {
+            this._solidCap = solidCapacity;
+            this._solidIdx = new Float64Array(solidCapacity);
+        }
+        if (mixedCapacity > 0) {
+            this._mixedCap = mixedCapacity;
+            this._mixedIdx = new Float64Array(mixedCapacity);
+            this._mixedMasks = new Uint32Array(mixedCapacity * 2);
+        }
+    }
+
     /**
      * Add a non-empty block to the buffer.
      * Automatically classifies as solid or mixed based on mask values.

--- a/src/lib/voxel/block-mask-map.ts
+++ b/src/lib/voxel/block-mask-map.ts
@@ -9,7 +9,7 @@ const EMPTY = -1;
  * Uses Fibonacci hashing with linear probing and backward-shift deletion.
  */
 class BlockMaskMap {
-    keys: Int32Array;
+    keys: Float64Array;
     lo: Uint32Array;
     hi: Uint32Array;
     private _size: number;
@@ -17,11 +17,14 @@ class BlockMaskMap {
     private _mask: number;
 
     constructor(initialCapacity = 4096) {
-        const cap = 1 << (32 - Math.clz32(Math.max(15, initialCapacity - 1)));
+        const cap = 2 ** Math.ceil(Math.log2(Math.max(16, initialCapacity)));
+        if (!Number.isSafeInteger(initialCapacity) || initialCapacity < 0 || cap > 0x80000000) {
+            throw new Error(`BlockMaskMap capacity ${initialCapacity} exceeds the typed hash-table limit`);
+        }
         this._capacity = cap;
         this._mask = cap - 1;
         this._size = 0;
-        this.keys = new Int32Array(cap).fill(EMPTY);
+        this.keys = new Float64Array(cap).fill(EMPTY);
         this.lo = new Uint32Array(cap);
         this.hi = new Uint32Array(cap);
     }
@@ -39,7 +42,7 @@ class BlockMaskMap {
      */
     slot(key: number): number {
         const mask = this._mask;
-        let i = (Math.imul(key, 0x9E3779B9) >>> 0) & mask;
+        let i = this._hash(key) & mask;
         while (true) {
             const k = this.keys[i];
             if (k === key || k === EMPTY) return i;
@@ -65,7 +68,7 @@ class BlockMaskMap {
         this.lo[slot] = loVal;
         this.hi[slot] = hiVal;
         this._size++;
-        if (this._size > ((this._capacity * 0.7) | 0)) {
+        if (this._size > Math.floor(this._capacity * 0.7)) {
             this._grow();
         }
     }
@@ -82,7 +85,7 @@ class BlockMaskMap {
         if (this.keys[s] === EMPTY) {
             this.keys[s] = key;
             this._size++;
-            if (this._size > ((this._capacity * 0.7) | 0)) {
+            if (this._size > Math.floor(this._capacity * 0.7)) {
                 this._grow();
                 s = this.slot(key);
             }
@@ -105,7 +108,7 @@ class BlockMaskMap {
         while (true) {
             j = (j + 1) & mask;
             if (this.keys[j] === EMPTY) break;
-            const k = ((Math.imul(this.keys[j], 0x9E3779B9) >>> 0) & mask);
+            const k = this._hash(this.keys[j]) & mask;
             if ((i < j) ? (k <= i || k > j) : (k <= i && k > j)) {
                 this.keys[i] = this.keys[j];
                 this.lo[i] = this.lo[j];
@@ -133,7 +136,7 @@ class BlockMaskMap {
      * replacing it with a new instance.
      */
     releaseStorage(): void {
-        this.keys = new Int32Array(0);
+        this.keys = new Float64Array(0);
         this.lo = new Uint32Array(0);
         this.hi = new Uint32Array(0);
         this._size = 0;
@@ -167,8 +170,11 @@ class BlockMaskMap {
         const oldCap = this._capacity;
 
         this._capacity *= 2;
+        if (this._capacity > 0x80000000) {
+            throw new Error('BlockMaskMap exceeded the typed hash-table capacity limit');
+        }
         this._mask = this._capacity - 1;
-        this.keys = new Int32Array(this._capacity).fill(EMPTY);
+        this.keys = new Float64Array(this._capacity).fill(EMPTY);
         this.lo = new Uint32Array(this._capacity);
         this.hi = new Uint32Array(this._capacity);
         this._size = 0;
@@ -182,6 +188,12 @@ class BlockMaskMap {
                 this._size++;
             }
         }
+    }
+
+    private _hash(key: number): number {
+        const lo = key >>> 0;
+        const hi = Math.floor(key / 0x100000000) >>> 0;
+        return (Math.imul(lo, 0x9E3779B9) ^ Math.imul(hi, 0x85EBCA77)) >>> 0;
     }
 }
 

--- a/src/lib/voxel/filter-cluster.ts
+++ b/src/lib/voxel/filter-cluster.ts
@@ -78,9 +78,9 @@ const buildInvertedGrid = (
 
 /**
  * Find the connected component of occupied voxels reachable from a seed
- * position via 6-connected voxel-level flood fill. Returns the set of block
- * linear indices that contain at least one reachable voxel, the visited grid,
- * and the resolved seed position.
+ * position via 6-connected voxel-level flood fill. Returns the count of blocks
+ * that contain at least one reachable voxel, the visited grid, and the resolved
+ * seed position.
  *
  * If the seed voxel is not occupied, finds the nearest occupied voxel first.
  *
@@ -91,13 +91,13 @@ const buildInvertedGrid = (
  * @param seedIx - Seed voxel X coordinate.
  * @param seedIy - Seed voxel Y coordinate.
  * @param seedIz - Seed voxel Z coordinate.
- * @returns Object with ccSet, visited grid, and the resolved seed, or null if no occupied voxel found.
+ * @returns Object with ccCount, visited grid, and the resolved seed, or null if no occupied voxel found.
  */
 const findClusterVoxelFlood = (
     buffer: BlockMaskBuffer,
     nx: number, ny: number, nz: number,
     seedIx: number, seedIy: number, seedIz: number
-): { ccSet: Set<number>; visited: SparseVoxelGrid; resolvedSeed: { ix: number; iy: number; iz: number } } | null => {
+): { ccCount: number; visited: SparseVoxelGrid; resolvedSeed: { ix: number; iy: number; iz: number } } | null => {
     const blocked = buildInvertedGrid(buffer, nx, ny, nz);
     const nbx = nx >> 2;
     const bStride = nbx * (ny >> 2);
@@ -120,7 +120,7 @@ const findClusterVoxelFlood = (
 
     const visited = twoLevelBFS(blocked, blockSeeds, voxelSeeds, nx, ny, nz);
 
-    const ccSet = new Set<number>();
+    let ccCount = 0;
     const totalBlocks = nbx * (ny >> 2) * (nz >> 2);
     const visitedTypes = visited.types;
     for (let w = 0; w < visitedTypes.length; w++) {
@@ -132,13 +132,13 @@ const findClusterVoxelFlood = (
             const bp = 31 - Math.clz32(nonEmpty & -nonEmpty);
             const blockIdx = baseIdx + (bp >>> 1);
             if (blockIdx < totalBlocks) {
-                ccSet.add(blockIdx);
+                ccCount++;
             }
             nonEmpty &= nonEmpty - 1;
         }
     }
 
-    return { ccSet, visited, resolvedSeed: { ix: seedIx, iy: seedIy, iz: seedIz } };
+    return { ccCount, visited, resolvedSeed: { ix: seedIx, iy: seedIy, iz: seedIz } };
 };
 
 /**
@@ -257,7 +257,7 @@ const filterCluster = async (
             return finish(dataTable.clone({ rows: [] }));
         }
 
-        const { ccSet, visited: visitedGrid, resolvedSeed } = floodResult;
+        const { ccCount, visited: visitedGrid, resolvedSeed } = floodResult;
         if (resolvedSeed.ix !== seedIx || resolvedSeed.iy !== seedIy || resolvedSeed.iz !== seedIz) {
             const worldX = gridBounds.min.x + (resolvedSeed.ix + 0.5) * clampedResolution;
             const worldY = gridBounds.min.y + (resolvedSeed.iy + 0.5) * clampedResolution;
@@ -265,7 +265,7 @@ const filterCluster = async (
             logger.warn(`seed (${seed.x.toFixed(2)}, ${seed.y.toFixed(2)}, ${seed.z.toFixed(2)}) unoccupied; resolved to nearest at (${worldX.toFixed(2)}, ${worldY.toFixed(2)}, ${worldZ.toFixed(2)})`);
         }
 
-        logger.info(`cluster is ${fmtCount(ccSet.size)} of ${fmtCount(buffer.count)} blocks`);
+        logger.info(`cluster is ${fmtCount(ccCount)} of ${fmtCount(buffer.count)} blocks`);
 
         // Build lookup from visited voxels only (not all original voxels in ccSet blocks).
         // Every visited voxel is originally-occupied (the BFS only traverses through them),
@@ -273,7 +273,8 @@ const filterCluster = async (
         const visitedBuffer = visitedGrid.toBuffer(0, 0, 0, nbx, nby, nbz);
         const lookup = buildBlockLookup(visitedBuffer);
 
-        if (ccSet.size === buffer.count) {
+        if (ccCount === buffer.count) {
+            lookup.blocks.releaseStorage();
             logger.info('all blocks in one cluster, no filtering needed');
             return finish(dataTable);
         }
@@ -314,6 +315,7 @@ const filterCluster = async (
             }
         }
 
+        lookup.blocks.releaseStorage();
         if (keepIndices.length === numRows) {
             return finish(dataTable);
         }

--- a/src/lib/voxel/filter-floaters.ts
+++ b/src/lib/voxel/filter-floaters.ts
@@ -93,7 +93,7 @@ const filterFloaters = async (
 
         const lookup = buildBlockLookup(buffer);
 
-        logger.info(`occupied blocks: ${fmtCount(lookup.solidSet.size + lookup.mixedMap.size)} (${fmtCount(lookup.solidSet.size)} solid, ${fmtCount(lookup.mixedMap.size)} mixed)`);
+        logger.info(`occupied blocks: ${fmtCount(lookup.solidCount + lookup.mixedCount)} (${fmtCount(lookup.solidCount)} solid, ${fmtCount(lookup.mixedCount)} mixed)`);
 
         const gaussianCols = buildGaussianColumns(ctx);
         const keepIndices: number[] = [];
@@ -113,6 +113,7 @@ const filterFloaters = async (
             }
         }
 
+        lookup.blocks.releaseStorage();
         if (keepIndices.length === numRows) {
             return finish(dataTable);
         }

--- a/src/lib/voxel/sort-key-mask.ts
+++ b/src/lib/voxel/sort-key-mask.ts
@@ -1,0 +1,87 @@
+/**
+ * Sort Float64 keys in place while applying the same permutation to paired
+ * interleaved Uint32 values. Uses an iterative quicksort so it does not route
+ * through V8's regular-array compare-function path.
+ *
+ * @param keys - Sort keys.
+ * @param values - Interleaved value pairs associated with each key.
+ * @param length - Number of key/value entries to sort.
+ */
+function sortKeyMaskPairs(keys: Float64Array, values: Uint32Array, length: number): void {
+    if (length < 2) return;
+
+    const swap = (a: number, b: number): void => {
+        const key = keys[a]; keys[a] = keys[b]; keys[b] = key;
+        const a2 = a * 2, b2 = b * 2;
+        const lo = values[a2]; values[a2] = values[b2]; values[b2] = lo;
+        const hi = values[a2 + 1]; values[a2 + 1] = values[b2 + 1]; values[b2 + 1] = hi;
+    };
+
+    const stack = new Int32Array(64);
+    let sp = 0;
+    stack[sp++] = 0;
+    stack[sp++] = length - 1;
+
+    while (sp > 0) {
+        const hi = stack[--sp];
+        const lo = stack[--sp];
+
+        if (hi - lo < 16) {
+            for (let i = lo + 1; i <= hi; i++) {
+                const key = keys[i];
+                const valueLo = values[i * 2];
+                const valueHi = values[i * 2 + 1];
+                let j = i - 1;
+                while (j >= lo && keys[j] > key) {
+                    keys[j + 1] = keys[j];
+                    values[(j + 1) * 2] = values[j * 2];
+                    values[(j + 1) * 2 + 1] = values[j * 2 + 1];
+                    j--;
+                }
+                keys[j + 1] = key;
+                values[(j + 1) * 2] = valueLo;
+                values[(j + 1) * 2 + 1] = valueHi;
+            }
+            continue;
+        }
+
+        const mid = (lo + hi) >>> 1;
+        if (keys[lo] > keys[mid]) swap(lo, mid);
+        if (keys[lo] > keys[hi]) swap(lo, hi);
+        if (keys[mid] > keys[hi]) swap(mid, hi);
+        swap(mid, hi - 1);
+        const pivot = keys[hi - 1];
+
+        let i = lo;
+        let j = hi - 1;
+        while (true) {
+            while (keys[++i] < pivot) { /* sentinel at hi */ }
+            while (keys[--j] > pivot) { /* sentinel at lo */ }
+            if (i >= j) break;
+            swap(i, j);
+        }
+        swap(i, hi - 1);
+
+        const leftSize = i - 1 - lo;
+        const rightSize = hi - (i + 1);
+        if (leftSize > rightSize) {
+            stack[sp++] = lo;
+            stack[sp++] = i - 1;
+            if (rightSize > 0) {
+                stack[sp++] = i + 1;
+                stack[sp++] = hi;
+            }
+        } else {
+            if (rightSize > 0) {
+                stack[sp++] = i + 1;
+                stack[sp++] = hi;
+            }
+            if (leftSize > 0) {
+                stack[sp++] = lo;
+                stack[sp++] = i - 1;
+            }
+        }
+    }
+}
+
+export { sortKeyMaskPairs };

--- a/src/lib/voxel/sparse-voxel-grid.ts
+++ b/src/lib/voxel/sparse-voxel-grid.ts
@@ -114,12 +114,15 @@ class SparseVoxelGrid {
         this.nx = nx;
         this.ny = ny;
         this.nz = nz;
-        this.nbx = nx >> 2;
-        this.nby = ny >> 2;
-        this.nbz = nz >> 2;
+        this.nbx = Math.floor(nx / 4);
+        this.nby = Math.floor(ny / 4);
+        this.nbz = Math.floor(nz / 4);
         this.bStride = this.nbx * this.nby;
         const totalBlocks = this.nbx * this.nby * this.nbz;
-        this.types = new Uint32Array((totalBlocks + BLOCKS_PER_WORD - 1) >>> 4);
+        if (!Number.isSafeInteger(totalBlocks) || totalBlocks > 0x100000000) {
+            throw new Error(`SparseVoxelGrid cannot address ${totalBlocks} blocks; the limit is 2^32`);
+        }
+        this.types = new Uint32Array(Math.ceil(totalBlocks / BLOCKS_PER_WORD));
         this.masks = new BlockMaskMap();
     }
 
@@ -224,9 +227,10 @@ class SparseVoxelGrid {
         nx: number, ny: number, nz: number,
         onProgress?: (done: number, total: number) => void
     ): SparseVoxelGrid {
-        const g = new SparseVoxelGrid(nx, ny, nz);
         const solidIdx = acc.getSolidBlocks();
         const mixed = acc.getMixedBlocks();
+        const g = new SparseVoxelGrid(nx, ny, nz);
+        g.masks = new BlockMaskMap(Math.ceil(mixed.blockIdx.length / 0.7));
         const total = solidIdx.length + mixed.blockIdx.length;
         const PROGRESS_INTERVAL = 1 << 16;
         let nextTick = PROGRESS_INTERVAL;

--- a/src/lib/voxel/voxel-query.ts
+++ b/src/lib/voxel/voxel-query.ts
@@ -1,3 +1,4 @@
+import { ABSENT, BlockIndexMap, SOLID } from './block-index-map';
 import { BlockMaskBuffer } from './block-mask-buffer';
 import {
     computeGaussianInverse,
@@ -9,9 +10,11 @@ import {
  * Pre-computed lookup structures for efficient voxel block queries.
  */
 interface BlockLookup {
-    solidSet: Set<number>;
-    mixedMap: Map<number, number>;
+    /** Block index -> state: `SOLID`, a mixed-array slot (`>= 0`), or `ABSENT`. */
+    blocks: BlockIndexMap;
     masks: Uint32Array;
+    solidCount: number;
+    mixedCount: number;
 }
 
 /**
@@ -33,25 +36,24 @@ interface BlockGridParams {
 /**
  * Build block lookup structures from the buffer's linear block indices.
  * The buffer's keys are already linear block indices, so this is a direct
- * copy into a Set / Map for O(1) random access.
+ * copy into a typed-array hash for O(1) random access (no V8 Set/Map cap).
  *
  * @param buffer - Block mask buffer containing voxelized blocks.
- * @returns Solid block set, mixed block map (linear index to masks array index), and masks.
+ * @returns Block-state lookup, masks array, and solid/mixed counts.
  */
 const buildBlockLookup = (
     buffer: BlockMaskBuffer
 ): BlockLookup => {
-    const solidSet = new Set<number>();
     const solidIdx = buffer.getSolidBlocks();
-    for (let i = 0; i < solidIdx.length; i++) {
-        solidSet.add(solidIdx[i]);
-    }
     const mixed = buffer.getMixedBlocks();
-    const mixedMap = new Map<number, number>();
-    for (let i = 0; i < mixed.blockIdx.length; i++) {
-        mixedMap.set(mixed.blockIdx[i], i);
+    const blocks = new BlockIndexMap(solidIdx.length + mixed.blockIdx.length);
+    for (let i = 0; i < solidIdx.length; i++) {
+        blocks.set(solidIdx[i], SOLID);
     }
-    return { solidSet, mixedMap, masks: mixed.masks };
+    for (let i = 0; i < mixed.blockIdx.length; i++) {
+        blocks.set(mixed.blockIdx[i], i);
+    }
+    return { blocks, masks: mixed.masks, solidCount: solidIdx.length, mixedCount: mixed.blockIdx.length };
 };
 
 /**
@@ -86,12 +88,13 @@ const isCenterInOccupiedVoxel = (
         return false;
     }
 
-    if (lookup.solidSet.has(centerBlockIdx)) {
+    const centerState = lookup.blocks.get(centerBlockIdx);
+    if (centerState === SOLID) {
         return true;
     }
 
-    const centerMixedIdx = lookup.mixedMap.get(centerBlockIdx);
-    if (centerMixedIdx !== undefined) {
+    if (centerState !== ABSENT) {
+        const centerMixedIdx = centerState;
         const lx = Math.floor((px - grid.gridMinX - centerBx * grid.blockSize) / grid.voxelResolution);
         const ly = Math.floor((py - grid.gridMinY - centerBy * grid.blockSize) / grid.voxelResolution);
         const lz = Math.floor((pz - grid.gridMinZ - centerBz * grid.blockSize) / grid.voxelResolution);
@@ -163,16 +166,16 @@ const gaussianContributesToVoxels = (
             for (let bbx = aabbMinBx; bbx <= aabbMaxBx; bbx++) {
                 const blockIdx = bbx + yzOff;
                 if (blockFilter && !blockFilter.has(blockIdx)) continue;
-                const isSolid = lookup.solidSet.has(blockIdx);
-                const mixedIdx = isSolid ? -1 : lookup.mixedMap.get(blockIdx);
-                if (!isSolid && mixedIdx === undefined) continue;
+                const state = lookup.blocks.get(blockIdx);
+                if (state === ABSENT) continue;
+                const isSolid = state === SOLID;
 
                 const blockOriginX = grid.gridMinX + bbx * grid.blockSize;
                 const blockOriginY = grid.gridMinY + bby * grid.blockSize;
                 const blockOriginZ = grid.gridMinZ + bbz * grid.blockSize;
 
-                const lo = isSolid ? 0xFFFFFFFF : lookup.masks[mixedIdx * 2];
-                const hi = isSolid ? 0xFFFFFFFF : lookup.masks[mixedIdx * 2 + 1];
+                const lo = isSolid ? 0xFFFFFFFF : lookup.masks[state * 2];
+                const hi = isSolid ? 0xFFFFFFFF : lookup.masks[state * 2 + 1];
 
                 for (let lz = 0; lz < 4; lz++) {
                     const vz = blockOriginZ + (lz + 0.5) * grid.voxelResolution;

--- a/src/lib/writers/sparse-octree.ts
+++ b/src/lib/writers/sparse-octree.ts
@@ -699,6 +699,12 @@ function buildSparseOctreeFromBuffer(
     }
     const sourceStride = sourceNbx * sourceNby;
     const totalBlocks = sourceStride * sourceNbz;
+    if (!Number.isSafeInteger(totalBlocks)) {
+        throw new Error(
+            `Voxel source grid ${sourceNbx}x${sourceNby}x${sourceNbz} exceeds the safe-integer block-index limit. ` +
+            'Use a coarser voxel resolution.'
+        );
+    }
 
     const convertToMorton = (stream: Float64Array): void => {
         for (let i = 0; i < stream.length; i++) {

--- a/src/lib/writers/sparse-octree.ts
+++ b/src/lib/writers/sparse-octree.ts
@@ -2,7 +2,9 @@ import { Vec3 } from 'playcanvas';
 
 import type { Bounds } from '../data-table';
 import { logger } from '../utils';
+import { BlockMaskBuffer } from '../voxel/block-mask-buffer';
 import { popcount, xyzToMorton } from '../voxel/morton';
+import { sortKeyMaskPairs } from '../voxel/sort-key-mask';
 import {
     BLOCK_EMPTY,
     BLOCK_MIXED,
@@ -31,6 +33,7 @@ const SOLID_LEAF_MARKER = 0xFF000000 >>> 0;
  * `SOLID_LEAF_MARKER`, so the practical interior cap is 16,777,215.)
  */
 const MAX_24BIT_OFFSET = 0x00FFFFFF;
+const MAX_V1_MIXED_LEAVES = MAX_24BIT_OFFSET + 1;
 
 const DENSE_SOLID_STREAM_THRESHOLD = 8_000_000;
 
@@ -98,11 +101,11 @@ const enum BlockType {
  */
 interface LevelData {
     /** Sorted Morton codes for nodes at this level */
-    mortons: number[];
+    mortons: Float64Array;
     /** Block type for each node (Solid or Mixed) */
-    types: number[];
+    types: Uint8Array;
     /** 8-bit child presence mask for each node */
-    childMasks: number[];
+    childMasks: Uint8Array;
 }
 
 /**
@@ -111,7 +114,7 @@ interface LevelData {
  */
 interface InteriorWave {
     pos: Uint32Array;
-    li: Uint32Array;
+    li: Int32Array;
     ii: Uint32Array;
     length: number;
 }
@@ -145,88 +148,6 @@ interface DenseLevel {
  * @param masks - Interleaved [lo, hi] mask pairs (length = 2 * n).
  * @param n - Number of mixed entries to sort.
  */
-function sortMixedByMorton(
-    mortons: Float64Array,
-    masks: Uint32Array,
-    n: number
-): void {
-    if (n < 2) return;
-
-    const swap = (a: number, b: number): void => {
-        const tm = mortons[a]; mortons[a] = mortons[b]; mortons[b] = tm;
-        const a2 = a * 2, b2 = b * 2;
-        const tlo = masks[a2]; masks[a2] = masks[b2]; masks[b2] = tlo;
-        const thi = masks[a2 + 1]; masks[a2 + 1] = masks[b2 + 1]; masks[b2 + 1] = thi;
-    };
-
-    const stack = new Int32Array(64);
-    let sp = 0;
-    stack[sp++] = 0;
-    stack[sp++] = n - 1;
-
-    while (sp > 0) {
-        const hi = stack[--sp];
-        const lo = stack[--sp];
-
-        if (hi - lo < 16) {
-            // Insertion sort
-            for (let i = lo + 1; i <= hi; i++) {
-                const km = mortons[i];
-                const kl = masks[i * 2];
-                const kh = masks[i * 2 + 1];
-                let j = i - 1;
-                while (j >= lo && mortons[j] > km) {
-                    mortons[j + 1] = mortons[j];
-                    masks[(j + 1) * 2] = masks[j * 2];
-                    masks[(j + 1) * 2 + 1] = masks[j * 2 + 1];
-                    j--;
-                }
-                mortons[j + 1] = km;
-                masks[(j + 1) * 2] = kl;
-                masks[(j + 1) * 2 + 1] = kh;
-            }
-            continue;
-        }
-
-        const mid = (lo + hi) >>> 1;
-        if (mortons[lo] > mortons[mid]) swap(lo, mid);
-        if (mortons[lo] > mortons[hi]) swap(lo, hi);
-        if (mortons[mid] > mortons[hi]) swap(mid, hi);
-        swap(mid, hi - 1);
-        const pivot = mortons[hi - 1];
-
-        let i = lo;
-        let j = hi - 1;
-        while (true) {
-            while (mortons[++i] < pivot) { /* sentinel at hi */ }
-            while (mortons[--j] > pivot) { /* sentinel at lo */ }
-            if (i >= j) break;
-            swap(i, j);
-        }
-        swap(i, hi - 1);
-
-        const leftSize = i - 1 - lo;
-        const rightSize = hi - (i + 1);
-        if (leftSize > rightSize) {
-            stack[sp++] = lo;
-            stack[sp++] = i - 1;
-            if (rightSize > 0) {
-                stack[sp++] = i + 1;
-                stack[sp++] = hi;
-            }
-        } else {
-            if (rightSize > 0) {
-                stack[sp++] = i + 1;
-                stack[sp++] = hi;
-            }
-            if (leftSize > 0) {
-                stack[sp++] = lo;
-                stack[sp++] = i - 1;
-            }
-        }
-    }
-}
-
 /**
  * Binary-search lowest index i in `arr[0..n)` such that `arr[i] >= target`.
  * Returns `n` if all entries are less than `target`.
@@ -257,7 +178,7 @@ function createInteriorWave(initialCapacity: number): InteriorWave {
     const cap = Math.max(16, initialCapacity);
     return {
         pos: new Uint32Array(cap),
-        li: new Uint32Array(cap),
+        li: new Int32Array(cap),
         ii: new Uint32Array(cap),
         length: 0
     };
@@ -280,7 +201,7 @@ function pushInteriorWave(
     if (wave.length === wave.pos.length) {
         const cap = wave.pos.length * 2;
         const grownPos = new Uint32Array(cap);
-        const grownLi = new Uint32Array(cap);
+        const grownLi = new Int32Array(cap);
         const grownIi = new Uint32Array(cap);
         grownPos.set(wave.pos);
         grownLi.set(wave.li);
@@ -421,6 +342,13 @@ function flattenDenseLevels(
     sceneBounds: Bounds,
     voxelResolution: number
 ): SparseOctree {
+    if (grid.masks.size > MAX_V1_MIXED_LEAVES) {
+        throw new Error(
+            `Sparse octree mixed-leaf count (${grid.masks.size}) exceeds the ` +
+            `Laine-Karras 24-bit baseOffset limit (${MAX_V1_MIXED_LEAVES}). ` +
+            'Use a coarser voxel resolution.'
+        );
+    }
     const treeDepth = Math.max(1, levels.length - 1);
     const rootLi = levels.length - 1;
     const rootLevel = levels[rootLi]!;
@@ -448,8 +376,15 @@ function flattenDenseLevels(
     let numMixedLeaves = 0;
 
     const appendNode = (value: number): number => {
+        if (nodeLen >= MAX_24BIT_OFFSET + 1) {
+            throw new Error(
+                `Sparse octree node count (${nodeLen + 1}) exceeds the ` +
+                `Laine-Karras 24-bit baseOffset limit (${MAX_24BIT_OFFSET + 1}). ` +
+                'Use a coarser voxel resolution.'
+            );
+        }
         if (nodeLen === nodes.length) {
-            const grown = new Uint32Array(nodes.length * 2);
+            const grown = new Uint32Array(Math.min(MAX_24BIT_OFFSET + 1, nodes.length * 2));
             grown.set(nodes);
             nodes = grown;
         }
@@ -463,7 +398,7 @@ function flattenDenseLevels(
             throw new Error(
                 `Sparse octree mixed-leaf count (${leafDataIndex + 1}) exceeds the ` +
                 `Laine-Karras 24-bit baseOffset limit (${MAX_24BIT_OFFSET + 1}). ` +
-                'Reduce the grid size or split the scene.'
+                'Use a coarser voxel resolution.'
             );
         }
         if (leafDataLen + 2 > leafData.length) {
@@ -519,7 +454,7 @@ function flattenDenseLevels(
                 throw new Error(
                     `Sparse octree node count (${childStart + 1}) exceeds the ` +
                     `Laine-Karras 24-bit baseOffset limit (${MAX_24BIT_OFFSET + 1}). ` +
-                    'Reduce the grid size or split the scene.'
+                    'Use a coarser voxel resolution.'
                 );
             }
 
@@ -639,7 +574,7 @@ function buildSparseOctree(
     // pointer compression) and throws past it. Instead:
     //   - Native `Float64Array.sort()` (no comparefn) on the solid stream,
     //     avoiding V8's FixedArray comparefn path.
-    //   - Custom `sortMixedByMorton` for the mixed stream: iterative
+    //   - Custom `sortKeyMaskPairs` for the mixed stream: iterative
     //     quicksort tailored to the (Float64 morton, Uint32×2 mask) layout.
 
     const { nbx, nby, nbz, types: gridTypes, masks: gridMasks } = grid;
@@ -691,9 +626,9 @@ function buildSparseOctree(
             const blockIdx = baseIdx + lane;
             if (blockIdx >= totalBlocks) break;
             const bx = blockIdx % nbx;
-            const byBz = (blockIdx / nbx) | 0;
+            const byBz = Math.floor(blockIdx / nbx);
             const by = byBz % nby;
-            const bz = (byBz / nby) | 0;
+            const bz = Math.floor(byBz / nby);
             const morton = xyzToMorton(bx, by, bz);
             const bt = (word >>> (lane << 1)) & TYPE_MASK;
             if (bt === BLOCK_SOLID) {
@@ -713,13 +648,128 @@ function buildSparseOctree(
     }
 
     if (nSolid > 1) solidStream.sort();
-    if (nMixed > 1) sortMixedByMorton(mixedStream, mixedMasks, nMixed);
+    if (nMixed > 1) sortKeyMaskPairs(mixedStream, mixedMasks, nMixed);
+
+    return buildSparseOctreeFromStreams(
+        solidStream, mixedStream, mixedMasks,
+        gridBounds, sceneBounds, voxelResolution, treeDepth
+    );
+}
+
+interface BlockBufferRegion {
+    minBx: number;
+    minBy: number;
+    minBz: number;
+}
+
+/**
+ * Build a sparse octree directly from a voxelization buffer. The block-index
+ * arrays are converted to Morton codes and sorted in place, so the buffer is
+ * consumed and must not be reused after this call.
+ *
+ * @param buffer - Filtered voxelization output.
+ * @param sourceNbx - X block count used to linearize buffer indices.
+ * @param sourceNby - Y block count used to linearize buffer indices.
+ * @param sourceNbz - Z block count used to linearize buffer indices.
+ * @param gridBounds - Output bounds, optionally cropped to `region`.
+ * @param sceneBounds - Original scene bounds.
+ * @param voxelResolution - Size of each voxel in world units.
+ * @param region - Source block origin corresponding to `gridBounds`.
+ * @returns Sparse octree structure.
+ */
+function buildSparseOctreeFromBuffer(
+    buffer: BlockMaskBuffer,
+    sourceNbx: number,
+    sourceNby: number,
+    sourceNbz: number,
+    gridBounds: Bounds,
+    sceneBounds: Bounds,
+    voxelResolution: number,
+    region: BlockBufferRegion = { minBx: 0, minBy: 0, minBz: 0 }
+): SparseOctree {
+    const solidStream = buffer.getSolidBlocks();
+    const mixed = buffer.getMixedBlocks();
+    const mixedStream = mixed.blockIdx;
+    if (mixedStream.length > MAX_V1_MIXED_LEAVES) {
+        throw new Error(
+            `Sparse octree mixed-leaf count (${mixedStream.length}) exceeds the ` +
+            `Laine-Karras 24-bit baseOffset limit (${MAX_V1_MIXED_LEAVES}). ` +
+            'Use a coarser voxel resolution.'
+        );
+    }
+    const sourceStride = sourceNbx * sourceNby;
+    const totalBlocks = sourceStride * sourceNbz;
+
+    const convertToMorton = (stream: Float64Array): void => {
+        for (let i = 0; i < stream.length; i++) {
+            const blockIdx = stream[i];
+            if (!Number.isSafeInteger(blockIdx) || blockIdx < 0 || blockIdx >= totalBlocks) {
+                throw new Error(`Voxel block index ${blockIdx} is outside the ${sourceNbx}x${sourceNby}x${sourceNbz} grid`);
+            }
+            const bx = blockIdx % sourceNbx;
+            const byBz = Math.floor(blockIdx / sourceNbx);
+            const by = byBz % sourceNby;
+            const bz = Math.floor(byBz / sourceNby);
+            const x = bx - region.minBx;
+            const y = by - region.minBy;
+            const z = bz - region.minBz;
+            if (x < 0 || y < 0 || z < 0) {
+                throw new Error(`Voxel block index ${blockIdx} lies outside the cropped output region`);
+            }
+            stream[i] = xyzToMorton(x, y, z);
+        }
+    };
+
+    convertToMorton(solidStream);
+    convertToMorton(mixedStream);
+    if (solidStream.length > 1) solidStream.sort();
+    if (mixedStream.length > 1) sortKeyMaskPairs(mixedStream, mixed.masks, mixedStream.length);
+
+    const treeDepth = calculateTreeDepth(gridBounds, voxelResolution);
+    return buildSparseOctreeFromStreams(
+        solidStream, mixedStream, mixed.masks,
+        gridBounds, sceneBounds, voxelResolution, treeDepth
+    );
+}
+
+/**
+ * Build and flatten an octree from sorted leaf streams.
+ *
+ * @param solidStream - Solid leaf Morton codes.
+ * @param mixedStream - Mixed leaf Morton codes.
+ * @param mixedMasks - Interleaved masks paired with `mixedStream`.
+ * @param gridBounds - Grid bounds aligned to block boundaries.
+ * @param sceneBounds - Original scene bounds.
+ * @param voxelResolution - Size of each voxel in world units.
+ * @param treeDepth - Tree depth in block levels.
+ * @returns Sparse octree structure.
+ */
+function buildSparseOctreeFromStreams(
+    solidStream: Float64Array,
+    mixedStream: Float64Array,
+    mixedMasks: Uint32Array,
+    gridBounds: Bounds,
+    sceneBounds: Bounds,
+    voxelResolution: number,
+    treeDepth: number
+): SparseOctree {
+    const nSolid = solidStream.length;
+    const nMixed = mixedStream.length;
+    if (treeDepth > 17) {
+        throw new Error(`Sparse octree depth ${treeDepth} exceeds the 17-level Morton encoding limit. Use a coarser voxel resolution.`);
+    }
+    if (nMixed > MAX_V1_MIXED_LEAVES) {
+        throw new Error(
+            `Sparse octree mixed-leaf count (${nMixed}) exceeds the ` +
+            `Laine-Karras 24-bit baseOffset limit (${MAX_V1_MIXED_LEAVES}). ` +
+            'Use a coarser voxel resolution.'
+        );
+    }
 
     // --- Phase 2: Build tree bottom-up level by level using linear scan ---
     // Level 0 lives in `solidStream` + `mixedStream` (dual streams, sorted).
     // We build level 1 by a two-pointer merge of these streams; subsequent
-    // levels (2, 3, ...) are built from JS-array level data via the same
-    // single-array linear scan as before.
+    // levels (2, 3, ...) use exactly-sized typed arrays.
     //
     // `interiorLevels[]` holds INTERIOR levels only (no level 0).
     // `interiorLevels[0]` is the first interior level (= original "level 1");
@@ -736,13 +786,28 @@ function buildSparseOctree(
     // child to process. Group children with the same `floor(morton/8)` parent.
     // childMask records which octants are present; allSolid tracks whether we
     // can collapse this parent into a SOLID leaf at level 1.
-    let curMortons: number[] = [];
-    let curTypes: number[] = [];
-    let curChildMasks: number[] = [];
+    let parentCount = 0;
+    {
+        let sI = 0;
+        let mI = 0;
+        while (sI < nSolid || mI < nMixed) {
+            const sM0 = sI < nSolid ? solidStream[sI] : Number.POSITIVE_INFINITY;
+            const mM0 = mI < nMixed ? mixedStream[mI] : Number.POSITIVE_INFINITY;
+            const parentMorton = Math.floor(Math.min(sM0, mM0) / 8);
+            parentCount++;
+            while (sI < nSolid && Math.floor(solidStream[sI] / 8) === parentMorton) sI++;
+            while (mI < nMixed && Math.floor(mixedStream[mI] / 8) === parentMorton) mI++;
+        }
+    }
+
+    let curMortons = new Float64Array(parentCount);
+    let curTypes = new Uint8Array(parentCount);
+    let curChildMasks = new Uint8Array(parentCount);
 
     {
         let sI = 0;
         let mI = 0;
+        let writeIdx = 0;
         while (sI < nSolid || mI < nMixed) {
             const sM0 = sI < nSolid ? solidStream[sI] : Number.POSITIVE_INFINITY;
             const mM0 = mI < nMixed ? mixedStream[mI] : Number.POSITIVE_INFINITY;
@@ -767,14 +832,14 @@ function buildSparseOctree(
                 }
             }
 
-            curMortons.push(parentMorton);
+            curMortons[writeIdx] = parentMorton;
             if (allSolid && childCount === 8) {
-                curTypes.push(BlockType.Solid);
-                curChildMasks.push(0);
+                curTypes[writeIdx] = BlockType.Solid;
             } else {
-                curTypes.push(BlockType.Mixed);
-                curChildMasks.push(childMask);
+                curTypes[writeIdx] = BlockType.Mixed;
+                curChildMasks[writeIdx] = childMask;
             }
+            writeIdx++;
         }
     }
 
@@ -816,11 +881,20 @@ function buildSparseOctree(
 
             // Build next level using linear scan on sorted data.
             const n = curMortons.length;
-            const nextMortons: number[] = [];
-            const nextTypes: number[] = [];
-            const nextChildMasks: number[] = [];
+            let nextCount = 0;
+            for (let i = 0; i < n;) {
+                const parentMorton = Math.floor(curMortons[i] / 8);
+                nextCount++;
+                do {
+                    i++;
+                } while (i < n && Math.floor(curMortons[i] / 8) === parentMorton);
+            }
+            const nextMortons = new Float64Array(nextCount);
+            const nextTypes = new Uint8Array(nextCount);
+            const nextChildMasks = new Uint8Array(nextCount);
 
             let i = 0;
+            let writeIdx = 0;
             while (i < n) {
                 const parentMorton = Math.floor(curMortons[i] / 8);
                 let childMask = 0;
@@ -837,14 +911,14 @@ function buildSparseOctree(
                     i++;
                 }
 
-                nextMortons.push(parentMorton);
+                nextMortons[writeIdx] = parentMorton;
                 if (allSolid && childCount === 8) {
-                    nextTypes.push(BlockType.Solid);
-                    nextChildMasks.push(0);
+                    nextTypes[writeIdx] = BlockType.Solid;
                 } else {
-                    nextTypes.push(BlockType.Mixed);
-                    nextChildMasks.push(childMask);
+                    nextTypes[writeIdx] = BlockType.Mixed;
+                    nextChildMasks[writeIdx] = childMask;
                 }
+                writeIdx++;
             }
 
             curMortons = nextMortons;
@@ -949,7 +1023,7 @@ function flattenTreeFromLevels(
         maxNodes += interiorLevels[l].mortons.length;
     }
 
-    const nodes = new Uint32Array(maxNodes);
+    const nodes = new Uint32Array(Math.min(maxNodes, MAX_24BIT_OFFSET + 1));
     // Pre-size leafData to its upper bound (2 entries per mixed leaf).
     const leafData = new Uint32Array(nMixed * 2);
     let leafDataLen = 0;
@@ -957,33 +1031,20 @@ function flattenTreeFromLevels(
     let numMixedLeaves = 0;
     let emitPos = 0;
 
-    // BFS wave as parallel arrays (avoids object allocation per queue entry)
-    let waveLi: number[] = [];
-    let waveIi: number[] = [];
-
-    // Initialize wave with root level entries.
+    // BFS waves use typed parallel arrays. `li === -1` identifies leaf entries.
     const rootLi = interiorLevels.length - 1;
+    let wave = createInteriorWave(rootLevel.mortons.length);
     for (let i = 0; i < rootLevel.mortons.length; i++) {
-        waveLi.push(rootLi);
-        waveIi.push(i);
+        pushInteriorWave(wave, 0, rootLi, i);
     }
 
-    // Reusable arrays for tracking interior nodes within each wave
-    const intPos: number[] = [];
-    const intLi: number[] = [];
-    const intIi: number[] = [];
-    const intMask: number[] = [];
-
-    while (waveLi.length > 0) {
-        intPos.length = 0;
-        intLi.length = 0;
-        intIi.length = 0;
-        intMask.length = 0;
+    while (wave.length > 0) {
+        const interiors = createInteriorWave(wave.length);
 
         // --- Emit all nodes in this wave ---
-        for (let w = 0; w < waveLi.length; w++) {
-            const li = waveLi[w];
-            const ii = waveIi[w];
+        for (let w = 0; w < wave.length; w++) {
+            const li = wave.li[w];
+            const ii = wave.ii[w];
 
             if (li === -1) {
                 // Level-0 leaf via dual-stream encoding.
@@ -994,7 +1055,7 @@ function flattenTreeFromLevels(
                         throw new Error(
                             `Sparse octree mixed-leaf count (${leafDataIndex + 1}) exceeds the ` +
                             `Laine-Karras 24-bit baseOffset limit (${MAX_24BIT_OFFSET + 1}). ` +
-                            'Reduce the grid size or split the scene.'
+                            'Use a coarser voxel resolution.'
                         );
                     }
                     leafData[leafDataLen++] = mixedMasks[ii * 2];
@@ -1020,10 +1081,7 @@ function flattenTreeFromLevels(
                 nodes[emitPos] = SOLID_LEAF_MARKER;
             } else {
                 // Interior node — record position for backfill after wave
-                intPos.push(emitPos);
-                intLi.push(li);
-                intIi.push(ii);
-                intMask.push(level.childMasks[ii]);
+                pushInteriorWave(interiors, emitPos, li, ii);
                 numInteriorNodes++;
                 nodes[emitPos] = 0;
             }
@@ -1031,25 +1089,29 @@ function flattenTreeFromLevels(
         }
 
         // --- Build next wave from children of interior nodes ---
-        const nextWaveLi: number[] = [];
-        const nextWaveIi: number[] = [];
+        let nextLength = 0;
+        for (let j = 0; j < interiors.length; j++) {
+            nextLength += popcount(interiorLevels[interiors.li[j]].childMasks[interiors.ii[j]]);
+        }
+        if (emitPos + nextLength > MAX_24BIT_OFFSET + 1) {
+            throw new Error(
+                `Sparse octree node count (${emitPos + nextLength}) exceeds the ` +
+                `Laine-Karras 24-bit baseOffset limit (${MAX_24BIT_OFFSET + 1}). ` +
+                'Use a coarser voxel resolution.'
+            );
+        }
+        const nextWave = createInteriorWave(nextLength);
         let nextChildStart = emitPos;
 
-        for (let j = 0; j < intPos.length; j++) {
-            const childMask = intMask[j];
+        for (let j = 0; j < interiors.length; j++) {
+            const myLi = interiors.li[j];
+            const myIi = interiors.ii[j];
+            const childMask = interiorLevels[myLi].childMasks[myIi];
             const childCount = popcount(childMask);
 
-            if (nextChildStart > MAX_24BIT_OFFSET) {
-                throw new Error(
-                    `Sparse octree node count (${nextChildStart + 1}) exceeds the ` +
-                    `Laine-Karras 24-bit baseOffset limit (${MAX_24BIT_OFFSET + 1}). ` +
-                    'Reduce the grid size or split the scene.'
-                );
-            }
-            nodes[intPos[j]] = ((childMask & 0xFF) << 24) | nextChildStart;
+            nodes[interiors.pos[j]] = ((childMask & 0xFF) << 24) | nextChildStart;
 
-            const myLi = intLi[j];
-            const myMorton = interiorLevels[myLi].mortons[intIi[j]];
+            const myMorton = interiorLevels[myLi].mortons[myIi];
             const childMortonBase = myMorton * 8;
             const childMortonEnd = childMortonBase + 8;
 
@@ -1068,12 +1130,10 @@ function flattenTreeFromLevels(
                         mixedStream[mIdx] : Number.POSITIVE_INFINITY;
                     if (!isFinite(sM) && !isFinite(mM)) break;
                     if (sM < mM) {
-                        nextWaveLi.push(-1);
-                        nextWaveIi.push(nMixed + sIdx);
+                        pushInteriorWave(nextWave, 0, -1, nMixed + sIdx);
                         sIdx++;
                     } else {
-                        nextWaveLi.push(-1);
-                        nextWaveIi.push(mIdx);
+                        pushInteriorWave(nextWave, 0, -1, mIdx);
                         mIdx++;
                     }
                 }
@@ -1092,8 +1152,7 @@ function flattenTreeFromLevels(
                 }
 
                 while (lo < childMortons.length && childMortons[lo] < childMortonEnd) {
-                    nextWaveLi.push(childLi);
-                    nextWaveIi.push(lo);
+                    pushInteriorWave(nextWave, 0, childLi, lo);
                     lo++;
                 }
             }
@@ -1101,8 +1160,7 @@ function flattenTreeFromLevels(
             nextChildStart += childCount;
         }
 
-        waveLi = nextWaveLi;
-        waveIi = nextWaveIi;
+        wave = nextWave;
     }
 
     return {
@@ -1120,6 +1178,8 @@ function flattenTreeFromLevels(
 
 export {
     buildSparseOctree,
+    buildSparseOctreeFromBuffer,
+    MAX_V1_MIXED_LEAVES,
     SOLID_LEAF_MARKER
 };
 

--- a/src/lib/writers/write-voxel.ts
+++ b/src/lib/writers/write-voxel.ts
@@ -10,7 +10,7 @@ import { GaussianBVH } from '../spatial';
 import type { CollisionMeshShape, DeviceCreator } from '../types';
 import { fmtCount, logger, Transform } from '../utils';
 import { version } from '../version';
-import { buildSparseOctree, type SparseOctree } from './sparse-octree';
+import { buildSparseOctree, buildSparseOctreeFromBuffer, MAX_V1_MIXED_LEAVES, type SparseOctree } from './sparse-octree';
 import {
     filterAndFillBlocks,
     alignGridBounds,
@@ -20,7 +20,106 @@ import {
     type NavSeed,
     voxelizeToBuffer
 } from '../voxel';
+import type { BlockMaskBuffer } from '../voxel/block-mask-buffer';
 import { SparseVoxelGrid } from '../voxel/sparse-voxel-grid';
+
+const MAX_MUTABLE_GRID_PEAK_BYTES = 1024 * 1024 * 1024;
+
+interface OccupiedBlockBounds {
+    minBx: number;
+    minBy: number;
+    minBz: number;
+    maxBx: number;
+    maxBy: number;
+    maxBz: number;
+}
+
+const getBufferOccupiedBounds = (
+    buffer: BlockMaskBuffer,
+    nbx: number,
+    nby: number,
+    nbz: number
+): OccupiedBlockBounds | null => {
+    let minBx = nbx, minBy = nby, minBz = nbz;
+    let maxBx = -1, maxBy = -1, maxBz = -1;
+
+    const scan = (indices: Float64Array): void => {
+        for (let i = 0; i < indices.length; i++) {
+            const blockIdx = indices[i];
+            const bx = blockIdx % nbx;
+            const byBz = Math.floor(blockIdx / nbx);
+            const by = byBz % nby;
+            const bz = Math.floor(byBz / nby);
+            if (bx < minBx) minBx = bx;
+            if (by < minBy) minBy = by;
+            if (bz < minBz) minBz = bz;
+            if (bx > maxBx) maxBx = bx;
+            if (by > maxBy) maxBy = by;
+            if (bz > maxBz) maxBz = bz;
+        }
+    };
+
+    scan(buffer.getSolidBlocks());
+    scan(buffer.getMixedBlocks().blockIdx);
+    return maxBx < 0 ? null : { minBx, minBy, minBz, maxBx, maxBy, maxBz };
+};
+
+const cropBufferBounds = (
+    buffer: BlockMaskBuffer,
+    nbx: number,
+    nby: number,
+    nbz: number,
+    gridBounds: Bounds,
+    voxelResolution: number
+): { gridBounds: Bounds; region: { minBx: number; minBy: number; minBz: number } } => {
+    const occupied = getBufferOccupiedBounds(buffer, nbx, nby, nbz);
+    if (!occupied) {
+        return { gridBounds, region: { minBx: 0, minBy: 0, minBz: 0 } };
+    }
+
+    const blockSize = 4 * voxelResolution;
+    const min = new Vec3(
+        gridBounds.min.x + occupied.minBx * blockSize,
+        gridBounds.min.y + occupied.minBy * blockSize,
+        gridBounds.min.z + occupied.minBz * blockSize
+    );
+    return {
+        gridBounds: {
+            min,
+            max: new Vec3(
+                min.x + (occupied.maxBx - occupied.minBx + 1) * blockSize,
+                min.y + (occupied.maxBy - occupied.minBy + 1) * blockSize,
+                min.z + (occupied.maxBz - occupied.minBz + 1) * blockSize
+            )
+        },
+        region: { minBx: occupied.minBx, minBy: occupied.minBy, minBz: occupied.minBz }
+    };
+};
+
+const assertMutableGridFits = (
+    buffer: BlockMaskBuffer,
+    nbx: number,
+    nby: number,
+    nbz: number,
+    simultaneousGrids: number
+): void => {
+    const totalBlocks = nbx * nby * nbz;
+    if (!Number.isSafeInteger(totalBlocks) || totalBlocks > 0x100000000) {
+        throw new Error(`Voxel mutation requires ${fmtCount(totalBlocks)} blocks, exceeding the 32-bit mutable-grid limit. Use a coarser voxel resolution or disable navigation, fill, and collision output.`);
+    }
+
+    const typeBytes = Math.ceil(totalBlocks / 16) * 4;
+    const mixedCapacity = 2 ** Math.ceil(Math.log2(Math.max(16, Math.ceil(buffer.mixedCount / 0.7))));
+    const maskBytes = mixedCapacity * 16;
+    const estimatedPeak = typeBytes * simultaneousGrids + maskBytes;
+    if (estimatedPeak > MAX_MUTABLE_GRID_PEAK_BYTES) {
+        throw new Error(
+            `Voxel mutation would require approximately ${fmtCount(Math.ceil(estimatedPeak / (1024 * 1024)))} MiB ` +
+            `of mutable-grid storage, exceeding the ${MAX_MUTABLE_GRID_PEAK_BYTES / (1024 * 1024)} MiB safety limit. ` +
+            'Use a coarser voxel resolution or disable navigation, fill, and collision output.'
+        );
+    }
+};
 
 /**
  * Options for writing a voxel octree file.
@@ -428,88 +527,112 @@ const writeVoxel = async (options: WriteVoxelOptions, fs: FileSystem): Promise<v
         const nbxInit = Math.round((gridBounds.max.x - gridBounds.min.x) / (4 * voxelResolution));
         const nbyInit = Math.round((gridBounds.max.y - gridBounds.min.y) / (4 * voxelResolution));
         const nbzInit = Math.round((gridBounds.max.z - gridBounds.min.z) / (4 * voxelResolution));
-        const filteredBuffer = filterAndFillBlocks(buffer, nbxInit, nbyInit, nbzInit);
+        const filteredBuffer = filterAndFillBlocks(
+            buffer, nbxInit, nbyInit, nbzInit, MAX_V1_MIXED_LEAVES
+        );
         buffer.clear();
         filterSub.end();
 
-        // Buffer → grid: the single conversion in the pipeline. Every phase
-        // beyond this point operates on SparseVoxelGrid directly.
-        const loadSub = logger.group('Loading grid');
-        const nxInit = nbxInit << 2;
-        const nyInit = nbyInit << 2;
-        const nzInit = nbzInit << 2;
-        const loadBar = logger.bar('Loading grid', Math.max(1, filteredBuffer.count));
-        let grid = SparseVoxelGrid.fromBuffer(
-            filteredBuffer, nxInit, nyInit, nzInit,
-            (done, total) => loadBar.update(Math.min(done, total))
-        );
-        loadBar.end();
-        filteredBuffer.clear();
-        loadSub.end();
+        const needsMutableGrid = hasFillExterior || hasFloorFill || hasNav || collisionMeshShape !== null;
+        let glbBytes: Uint8Array | null = null;
+        let octree: SparseOctree;
 
-        // Reuse the same device for GPU dilation across exterior, floor, carve.
-        const needsGpuDilation = hasFillExterior || hasNav || (hasFloorFill && floorFillDilation > 0);
-        if (needsGpuDilation) {
-            gpuDilation = new GpuDilation(device);
-        }
-
-        if (hasFillExterior) {
-            const sub = logger.group('Fill exterior');
-            const fillResult = await fillExterior(
-                grid, gridBounds, voxelResolution,
-                navExteriorRadius!, navSeed!,
-                gpuDilation!
+        if (!needsMutableGrid) {
+            const cropSub = logger.group('Cropping');
+            const cropped = cropBufferBounds(
+                filteredBuffer, nbxInit, nbyInit, nbzInit, gridBounds, voxelResolution
             );
-            grid = fillResult.grid;
-            gridBounds = fillResult.gridBounds;
-            sub.end();
-        }
+            gridBounds = cropped.gridBounds;
+            cropSub.end();
 
-        if (hasFloorFill) {
-            const sub = logger.group('Fill floor');
-            const floorResult = await fillFloor(
-                grid, gridBounds, voxelResolution, floorFillDilation, gpuDilation
+            octree = buildSparseOctreeFromBuffer(
+                filteredBuffer,
+                nbxInit, nbyInit, nbzInit,
+                gridBounds, bounds, voxelResolution,
+                cropped.region
             );
-            grid = floorResult.grid;
-            gridBounds = floorResult.gridBounds;
-            sub.end();
-        }
+            filteredBuffer.clear();
+        } else {
+            const simultaneousGrids = hasFillExterior || hasFloorFill || hasNav ? 4 : 2;
+            assertMutableGridFits(filteredBuffer, nbxInit, nbyInit, nbzInit, simultaneousGrids);
 
-        if (hasNav) {
-            const sub = logger.group('Carve');
-            const navResult = await carve(
-                grid, gridBounds, voxelResolution,
-                navCapsule!.height, navCapsule!.radius,
-                navSeed!,
-                gpuDilation!
+            const loadSub = logger.group('Loading grid');
+            const nxInit = nbxInit * 4;
+            const nyInit = nbyInit * 4;
+            const nzInit = nbzInit * 4;
+            const loadBar = logger.bar('Loading grid', Math.max(1, filteredBuffer.count));
+            let grid = SparseVoxelGrid.fromBuffer(
+                filteredBuffer, nxInit, nyInit, nzInit,
+                (done, total) => loadBar.update(Math.min(done, total))
             );
-            grid = navResult.grid;
-            gridBounds = navResult.gridBounds;
-            sub.end();
+            loadBar.end();
+            filteredBuffer.clear();
+            loadSub.end();
+
+            // Reuse the same device for GPU dilation across exterior, floor, carve.
+            const needsGpuDilation = hasFillExterior || hasNav || (hasFloorFill && floorFillDilation > 0);
+            if (needsGpuDilation) {
+                gpuDilation = new GpuDilation(device);
+            }
+
+            if (hasFillExterior) {
+                const sub = logger.group('Fill exterior');
+                const fillResult = await fillExterior(
+                    grid, gridBounds, voxelResolution,
+                    navExteriorRadius!, navSeed!,
+                    gpuDilation!
+                );
+                grid = fillResult.grid;
+                gridBounds = fillResult.gridBounds;
+                sub.end();
+            }
+
+            if (hasFloorFill) {
+                const sub = logger.group('Fill floor');
+                const floorResult = await fillFloor(
+                    grid, gridBounds, voxelResolution, floorFillDilation, gpuDilation
+                );
+                grid = floorResult.grid;
+                gridBounds = floorResult.gridBounds;
+                sub.end();
+            }
+
+            if (hasNav) {
+                const sub = logger.group('Carve');
+                const navResult = await carve(
+                    grid, gridBounds, voxelResolution,
+                    navCapsule!.height, navCapsule!.radius,
+                    navSeed!,
+                    gpuDilation!
+                );
+                grid = navResult.grid;
+                gridBounds = navResult.gridBounds;
+                sub.end();
+            }
+
+            const cropSub = logger.group('Cropping');
+            const finalCrop = hasFillExterior || hasFloorFill ?
+                cropToNavigable(grid, gridBounds, voxelResolution) :
+                cropToOccupied(grid, gridBounds, voxelResolution);
+            grid = finalCrop.grid;
+            gridBounds = finalCrop.gridBounds;
+            cropSub.end();
+
+            gpuDilation?.destroy();
+            gpuDilation = null;
+
+            glbBytes = collisionMeshShape ?
+                buildCollisionMesh(grid, gridBounds, voxelResolution, collisionMeshShape) :
+                null;
+
+            octree = buildSparseOctree(
+                grid,
+                gridBounds,
+                bounds,
+                voxelResolution,
+                { consumeGrid: true }
+            );
         }
-
-        const cropSub = logger.group('Cropping');
-        const finalCrop = hasFillExterior || hasFloorFill ?
-            cropToNavigable(grid, gridBounds, voxelResolution) :
-            cropToOccupied(grid, gridBounds, voxelResolution);
-        grid = finalCrop.grid;
-        gridBounds = finalCrop.gridBounds;
-        cropSub.end();
-
-        gpuDilation?.destroy();
-        gpuDilation = null;
-
-        const glbBytes = collisionMeshShape ?
-            buildCollisionMesh(grid, gridBounds, voxelResolution, collisionMeshShape) :
-            null;
-
-        const octree = buildSparseOctree(
-            grid,
-            gridBounds,
-            bounds,
-            voxelResolution,
-            { consumeGrid: true }
-        );
 
         logger.info(`octree depth: ${octree.treeDepth}`);
         logger.info(`interior nodes: ${fmtCount(octree.numInteriorNodes)}`);

--- a/test/flood-fill-cluster.test.mjs
+++ b/test/flood-fill-cluster.test.mjs
@@ -64,6 +64,22 @@ function bufferFromMixedBlocks(entries, nbx, nby) {
     return buffer;
 }
 
+// findClusterVoxelFlood now returns a block count (`ccCount`), not a Set. The
+// `visited` grid is the source of truth for cluster membership; these helpers
+// recover per-block membership from it for assertions (test grids are tiny).
+function clusterHas(visited, bi) {
+    return visited.getBlockType(bi) !== BLOCK_EMPTY;
+}
+
+function clusterBlocks(visited) {
+    const set = new Set();
+    const total = visited.nbx * visited.nby * visited.nbz;
+    for (let bi = 0; bi < total; bi++) {
+        if (visited.getBlockType(bi) !== BLOCK_EMPTY) set.add(bi);
+    }
+    return set;
+}
+
 /**
  * Block-level BFS from seed through face-adjacent ccSet members.
  * Returns array of ccSet blocks NOT reachable from the seed.
@@ -294,8 +310,8 @@ describe('findClusterVoxelFlood', () => {
         const buffer = bufferFromSolidBlocks([[0, 0, 0]], nbx, nby);
         const result = findClusterVoxelFlood(buffer, nx, ny, nz, 1, 1, 1);
         assert.ok(result);
-        assert.strictEqual(result.ccSet.size, 1);
-        assert.ok(result.ccSet.has(0));
+        assert.strictEqual(result.ccCount, 1);
+        assert.ok(clusterHas(result.visited,0));
     });
 
     it('two solid cubes separated by gap -- should only reach seeded cluster', () => {
@@ -315,18 +331,18 @@ describe('findClusterVoxelFlood', () => {
 
         const result = findClusterVoxelFlood(buffer, nx, ny, nz, 1, 1, 1);
         assert.ok(result);
-        assert.strictEqual(result.ccSet.size, 8);
+        assert.strictEqual(result.ccCount, 8);
 
         for (const [bx, by, bz] of coordsA) {
-            assert.ok(result.ccSet.has(blockIdx(bx, by, bz, nbx, nby)),
+            assert.ok(clusterHas(result.visited,blockIdx(bx, by, bz, nbx, nby)),
                 `cluster A block (${bx},${by},${bz}) should be in ccSet`);
         }
         for (const [bx, by, bz] of coordsB) {
-            assert.ok(!result.ccSet.has(blockIdx(bx, by, bz, nbx, nby)),
+            assert.ok(!clusterHas(result.visited,blockIdx(bx, by, bz, nbx, nby)),
                 `cluster B block (${bx},${by},${bz}) should NOT be in ccSet`);
         }
 
-        const unreachable = verifyCcSetConnectivity(result.ccSet,
+        const unreachable = verifyCcSetConnectivity(clusterBlocks(result.visited),
             blockIdx(0, 0, 0, nbx, nby), nbx, nby, nz >> 2);
         assert.strictEqual(unreachable.length, 0, 'ccSet should be fully connected');
     });
@@ -353,14 +369,14 @@ describe('findClusterVoxelFlood', () => {
         for (let bz = 0; bz < 2; bz++) {
             for (let by = 0; by < 2; by++) {
                 for (let bx = 4; bx < 6; bx++) {
-                    assert.ok(!result.ccSet.has(blockIdx(bx, by, bz, nbx, nby)),
+                    assert.ok(!clusterHas(result.visited,blockIdx(bx, by, bz, nbx, nby)),
                         `cluster B block (${bx},${by},${bz}) should NOT be in ccSet`);
                 }
             }
         }
 
         const seedBi = blockIdx(0, 0, 0, nbx, nby);
-        const unreachable = verifyCcSetConnectivity(result.ccSet, seedBi, nbx, nby, nz >> 2);
+        const unreachable = verifyCcSetConnectivity(clusterBlocks(result.visited), seedBi, nbx, nby, nz >> 2);
         assert.strictEqual(unreachable.length, 0, 'ccSet should be fully connected');
     });
 
@@ -374,10 +390,10 @@ describe('findClusterVoxelFlood', () => {
 
         const result = findClusterVoxelFlood(buffer, nx, ny, nz, 1, 1, 1);
         assert.ok(result);
-        assert.strictEqual(result.ccSet.size, coords.length);
+        assert.strictEqual(result.ccCount, coords.length);
 
         for (const [bx, by, bz] of coords) {
-            assert.ok(result.ccSet.has(blockIdx(bx, by, bz, nbx, nby)),
+            assert.ok(clusterHas(result.visited,blockIdx(bx, by, bz, nbx, nby)),
                 `block (${bx},${by},${bz}) should be in ccSet`);
         }
     });
@@ -401,10 +417,10 @@ describe('findClusterVoxelFlood', () => {
         const result = findClusterVoxelFlood(buffer, nx, ny, nz, 1, 1, 1);
         assert.ok(result);
         const allCoords = [...coordsA, ...bridge, ...coordsB];
-        assert.strictEqual(result.ccSet.size, allCoords.length);
+        assert.strictEqual(result.ccCount, allCoords.length);
 
         for (const [bx, by, bz] of allCoords) {
-            assert.ok(result.ccSet.has(blockIdx(bx, by, bz, nbx, nby)),
+            assert.ok(clusterHas(result.visited,blockIdx(bx, by, bz, nbx, nby)),
                 `block (${bx},${by},${bz}) should be in ccSet`);
         }
     });
@@ -428,9 +444,9 @@ describe('findClusterVoxelFlood', () => {
         assert.ok(result);
 
         const allBlocks = [...coordsA, [2, 0, 0], ...coordsB];
-        assert.strictEqual(result.ccSet.size, allBlocks.length);
+        assert.strictEqual(result.ccCount, allBlocks.length);
         for (const [bx, by, bz] of allBlocks) {
-            assert.ok(result.ccSet.has(blockIdx(bx, by, bz, nbx, nby)),
+            assert.ok(clusterHas(result.visited,blockIdx(bx, by, bz, nbx, nby)),
                 `block (${bx},${by},${bz}) should be in ccSet`);
         }
     });
@@ -452,11 +468,11 @@ describe('findClusterVoxelFlood', () => {
         const result = findClusterVoxelFlood(buffer, nx, ny, nz, 1, 1, 1);
         assert.ok(result);
 
-        assert.ok(result.ccSet.has(blockIdx(0, 0, 0, nbx, nby)));
-        assert.ok(result.ccSet.has(blockIdx(1, 0, 0, nbx, nby)));
-        assert.ok(!result.ccSet.has(blockIdx(3, 0, 0, nbx, nby)),
+        assert.ok(clusterHas(result.visited,blockIdx(0, 0, 0, nbx, nby)));
+        assert.ok(clusterHas(result.visited,blockIdx(1, 0, 0, nbx, nby)));
+        assert.ok(!clusterHas(result.visited,blockIdx(3, 0, 0, nbx, nby)),
             'cluster B should not be reached through interior-only bridge');
-        assert.ok(!result.ccSet.has(blockIdx(4, 0, 0, nbx, nby)),
+        assert.ok(!clusterHas(result.visited,blockIdx(4, 0, 0, nbx, nby)),
             'cluster B should not be reached through interior-only bridge');
     });
 
@@ -467,8 +483,8 @@ describe('findClusterVoxelFlood', () => {
 
         const result = findClusterVoxelFlood(buffer, nx, ny, nz, 0, 0, 0);
         assert.ok(result);
-        assert.strictEqual(result.ccSet.size, 1);
-        assert.ok(result.ccSet.has(blockIdx(2, 2, 2, nbx, nby)));
+        assert.strictEqual(result.ccCount, 1);
+        assert.ok(clusterHas(result.visited,blockIdx(2, 2, 2, nbx, nby)));
     });
 });
 
@@ -494,20 +510,20 @@ describe('findClusterVoxelFlood grid dimension sweep', () => {
 
                     const result = findClusterVoxelFlood(buffer, nx, ny, nz, 1, 1, 1);
                     assert.ok(result, 'should find a cluster');
-                    assert.strictEqual(result.ccSet.size, 2,
-                        `should only have 2 blocks from cluster A, got ${result.ccSet.size}`);
+                    assert.strictEqual(result.ccCount, 2,
+                        `should only have 2 blocks from cluster A, got ${result.ccCount}`);
 
                     for (const [bx, by, bz] of coordsA) {
-                        assert.ok(result.ccSet.has(blockIdx(bx, by, bz, nbx, nby)),
+                        assert.ok(clusterHas(result.visited,blockIdx(bx, by, bz, nbx, nby)),
                             `cluster A block (${bx},${by},${bz}) should be in ccSet`);
                     }
                     for (const [bx, by, bz] of coordsB) {
-                        assert.ok(!result.ccSet.has(blockIdx(bx, by, bz, nbx, nby)),
+                        assert.ok(!clusterHas(result.visited,blockIdx(bx, by, bz, nbx, nby)),
                             `cluster B block (${bx},${by},${bz}) should NOT be in ccSet`);
                     }
 
                     const seedBi = blockIdx(0, 0, 0, nbx, nby);
-                    const unreachable = verifyCcSetConnectivity(result.ccSet, seedBi, nbx, nby, nbz);
+                    const unreachable = verifyCcSetConnectivity(clusterBlocks(result.visited), seedBi, nbx, nby, nbz);
                     assert.strictEqual(unreachable.length, 0, 'ccSet should be fully connected');
                 });
             }
@@ -584,12 +600,12 @@ describe('findClusterVoxelFlood randomized layouts', () => {
 
             for (const [bx, by, bz] of coordsB) {
                 const bi = blockIdx(bx, by, bz, nbx, nby);
-                assert.ok(!result.ccSet.has(bi),
+                assert.ok(!clusterHas(result.visited,bi),
                     `cluster B block (${bx},${by},${bz}) should NOT be in ccSet`);
             }
 
             const seedBi = blockIdx(seedCoord[0], seedCoord[1], seedCoord[2], nbx, nby);
-            const unreachable = verifyCcSetConnectivity(result.ccSet, seedBi, nbx, nby, nbz);
+            const unreachable = verifyCcSetConnectivity(clusterBlocks(result.visited), seedBi, nbx, nby, nbz);
             assert.strictEqual(unreachable.length, 0,
                 `ccSet should be fully connected, but ${unreachable.length} blocks are disconnected`);
         });
@@ -649,14 +665,14 @@ describe('findClusterVoxelFlood randomized mixed blocks', () => {
                 for (let by = 0; by < 2; by++) {
                     for (let bx = 0; bx < 2; bx++) {
                         const bi = blockIdx(farX + bx, farY + by, farZ, nbx, nby);
-                        assert.ok(!result.ccSet.has(bi),
+                        assert.ok(!clusterHas(result.visited,bi),
                             `cluster B block (${farX + bx},${farY + by},${farZ}) should NOT be in ccSet`);
                     }
                 }
             }
 
             const seedBi = blockIdx(0, 0, 0, nbx, nby);
-            const unreachable = verifyCcSetConnectivity(result.ccSet, seedBi, nbx, nby, nbz);
+            const unreachable = verifyCcSetConnectivity(clusterBlocks(result.visited), seedBi, nbx, nby, nbz);
             assert.strictEqual(unreachable.length, 0,
                 `ccSet should be fully connected, but ${unreachable.length} blocks are disconnected`);
         });
@@ -698,8 +714,8 @@ describe('buildInvertedGrid + BFS consistency', () => {
 
         const result = findClusterVoxelFlood(buffer, nx, ny, nz, 1, 1, 1);
         assert.ok(result);
-        assert.strictEqual(result.ccSet.size, 1, 'should only reach 1 block');
-        assert.ok(result.ccSet.has(0), 'should reach block at (0,0,0)');
+        assert.strictEqual(result.ccCount, 1, 'should only reach 1 block');
+        assert.ok(clusterHas(result.visited,0), 'should reach block at (0,0,0)');
     });
 });
 
@@ -756,7 +772,7 @@ describe('verifyVisitedVoxelConnectivity', () => {
         assert.strictEqual(check.totalReachable, check.totalVisited,
             `all visited voxels should be reachable, but ${check.totalVisited - check.totalReachable} are not`);
 
-        assert.ok(!result.ccSet.has(blockIdx(2, 0, 0, nbx, nby)),
+        assert.ok(!clusterHas(result.visited,blockIdx(2, 0, 0, nbx, nby)),
             'block (2,0,0) should not be reachable through lx=0-only bridge');
     });
 

--- a/test/sparse-octree.test.mjs
+++ b/test/sparse-octree.test.mjs
@@ -33,6 +33,7 @@ function mortonToXYZ(m) {
 }
 import {
     buildSparseOctree,
+    buildSparseOctreeFromBuffer,
     SOLID_LEAF_MARKER
 } from '../src/lib/writers/sparse-octree.js';
 import { alignGridBounds } from '../src/lib/voxel/voxelize.js';
@@ -374,6 +375,35 @@ describe('BlockMaskBuffer', function () {
 // ============================================================================
 
 describe('buildSparseOctree', function () {
+    it('builds directly from block indices above 2^32', function () {
+        const sourceNbx = 65536;
+        const sourceNby = 65536;
+        const sourceNbz = 2;
+        const region = { minBx: 10, minBy: 20, minBz: 1 };
+        const acc = new BlockMaskBuffer();
+        acc.addBlock(linearBlockIdx(10, 20, 1, sourceNbx, sourceNby), 0xFFFFFFFF, 0xFFFFFFFF);
+        acc.addBlock(linearBlockIdx(11, 20, 1, sourceNbx, sourceNby), 0x12345678, 0x9ABCDEF0);
+
+        const gridBounds = {
+            min: new Vec3(0, 0, 0),
+            max: new Vec3(2, 1, 1)
+        };
+        const octree = buildSparseOctreeFromBuffer(
+            acc,
+            sourceNbx, sourceNby, sourceNbz,
+            gridBounds, gridBounds, 0.25,
+            region
+        );
+
+        assert.strictEqual(octree.numMixedLeaves, 1);
+        assert.strictEqual(octree.leafData[0], 0x12345678);
+        assert.strictEqual(octree.leafData[1], 0x9ABCDEF0);
+        assert.strictEqual(
+            Array.from(octree.nodes).filter(node => node === SOLID_LEAF_MARKER).length,
+            1
+        );
+    });
+
     describe('empty octree', function () {
         it('should handle empty buffer', function () {
             const acc = new BlockMaskBuffer();

--- a/test/sparse-octree.test.mjs
+++ b/test/sparse-octree.test.mjs
@@ -375,6 +375,19 @@ describe('BlockMaskBuffer', function () {
 // ============================================================================
 
 describe('buildSparseOctree', function () {
+    it('rejects source grids beyond the safe-integer block-index limit', function () {
+        const acc = new BlockMaskBuffer();
+        const gridBounds = {
+            min: new Vec3(0, 0, 0),
+            max: new Vec3(1, 1, 1)
+        };
+
+        assert.throws(
+            () => buildSparseOctreeFromBuffer(acc, 2 ** 27, 2 ** 27, 1, gridBounds, gridBounds, 0.25),
+            /exceeds the safe-integer block-index limit.*Use a coarser voxel resolution/
+        );
+    });
+
     it('builds directly from block indices above 2^32', function () {
         const sourceNbx = 65536;
         const sourceNby = 65536;

--- a/test/voxel-block-maps.test.mjs
+++ b/test/voxel-block-maps.test.mjs
@@ -1,0 +1,65 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { ABSENT, BlockIndexMap, SOLID } from '../src/lib/voxel/block-index-map.js';
+import { BlockMaskMap } from '../src/lib/voxel/block-mask-map.js';
+import { SparseVoxelGrid } from '../src/lib/voxel/sparse-voxel-grid.js';
+
+const LARGE_KEYS = [
+    0x7FFFFFFF,
+    0x80000000,
+    0xFFFFFFFF,
+    0x100000000,
+    0x100000001,
+    0x10000000000 + 17
+];
+
+describe('large voxel block maps', function () {
+    it('stores block states across the 2^31 and 2^32 boundaries', function () {
+        const map = new BlockIndexMap(LARGE_KEYS.length);
+        for (let i = 0; i < LARGE_KEYS.length; i++) {
+            map.set(LARGE_KEYS[i], i === 0 ? SOLID : i);
+        }
+
+        assert.strictEqual(map.get(LARGE_KEYS[0]), SOLID);
+        for (let i = 1; i < LARGE_KEYS.length; i++) {
+            assert.strictEqual(map.get(LARGE_KEYS[i]), i);
+        }
+        assert.strictEqual(map.get(0x200000000), ABSENT);
+    });
+
+    it('stores, updates, and deletes masks across the 2^31 and 2^32 boundaries', function () {
+        const map = new BlockMaskMap(4);
+        for (let i = 0; i < LARGE_KEYS.length; i++) {
+            map.set(LARGE_KEYS[i], 0x1000 + i, 0x2000 + i);
+        }
+
+        for (let i = 0; i < LARGE_KEYS.length; i++) {
+            const slot = map.slot(LARGE_KEYS[i]);
+            assert.strictEqual(map.keys[slot], LARGE_KEYS[i]);
+            assert.strictEqual(map.lo[slot], 0x1000 + i);
+            assert.strictEqual(map.hi[slot], 0x2000 + i);
+        }
+
+        map.set(0x100000000, 0xAAAA, 0xBBBB);
+        let slot = map.slot(0x100000000);
+        assert.strictEqual(map.lo[slot], 0xAAAA);
+        assert.strictEqual(map.hi[slot], 0xBBBB);
+
+        map.delete(0xFFFFFFFF);
+        assert.strictEqual(map.has(0xFFFFFFFF), false);
+        for (const key of LARGE_KEYS.filter(key => key !== 0xFFFFFFFF)) {
+            assert.strictEqual(map.has(key), true);
+        }
+
+        slot = map.slot(0x100000000);
+        assert.strictEqual(map.keys[slot], 0x100000000);
+    });
+
+    it('rejects mutable grids above the 32-bit block-index range', function () {
+        assert.throws(
+            () => new SparseVoxelGrid(65536 * 4, 65536 * 4, 8),
+            /limit is 2\^32/
+        );
+    });
+});

--- a/test/voxel-filter.test.mjs
+++ b/test/voxel-filter.test.mjs
@@ -295,6 +295,36 @@ describe('filterAndFillBlocks', function () {
             assert.strictEqual(result.mixedCount, 1,
                 'Mixed voxel adjacent to solid block should be preserved');
         });
+
+        it('should preserve adjacency for block indices above 2^32', function () {
+            const nbx = 65536;
+            const nby = 65536;
+            const buffer = new BlockMaskBuffer();
+            const block0 = 7 + 9 * nbx + nbx * nby;
+            const block1 = block0 + 1;
+            const [lo0, hi0] = voxelBit(3, 1, 1);
+            const [lo1, hi1] = voxelBit(0, 1, 1);
+            buffer.addBlock(block0, lo0, hi0);
+            buffer.addBlock(block1, lo1, hi1);
+
+            const result = filterAndFillBlocks(buffer, nbx, nby, 2);
+
+            assert.strictEqual(result.count, 2);
+            assert.deepStrictEqual(Array.from(result.getMixedBlocks().blockIdx), [block0, block1]);
+        });
+
+        it('should stop when the mixed-block output limit is exceeded', function () {
+            const buffer = new BlockMaskBuffer();
+            const [lo0, hi0] = voxelBit(3, 1, 1);
+            const [lo1, hi1] = voxelBit(0, 1, 1);
+            buffer.addBlock(0, lo0, hi0);
+            buffer.addBlock(1, lo1, hi1);
+
+            assert.throws(
+                () => filterAndFillBlocks(buffer, 2, 1, 1, 1),
+                /more than 1 mixed blocks/
+            );
+        });
     });
 
     // ============================================================================

--- a/test/voxel-query.test.mjs
+++ b/test/voxel-query.test.mjs
@@ -6,6 +6,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { BlockMaskBuffer } from '../src/lib/voxel/block-mask-buffer.js';
+import { SOLID } from '../src/lib/voxel/block-index-map.js';
 import {
     buildBlockLookup,
     isCenterInOccupiedVoxel,
@@ -85,10 +86,10 @@ describe('voxel-query', function () {
             const strideZ = 4 * 4;
             const lookup = buildBlockLookup(buffer);
 
-            assert.strictEqual(lookup.solidSet.size, 2);
-            assert.ok(lookup.solidSet.has(0 + 0 * strideY + 0 * strideZ));
-            assert.ok(lookup.solidSet.has(2 + 1 * strideY + 0 * strideZ));
-            assert.strictEqual(lookup.mixedMap.size, 0);
+            assert.strictEqual(lookup.solidCount, 2);
+            assert.strictEqual(lookup.blocks.get(0 + 0 * strideY + 0 * strideZ), SOLID);
+            assert.strictEqual(lookup.blocks.get(2 + 1 * strideY + 0 * strideZ), SOLID);
+            assert.strictEqual(lookup.mixedCount, 0);
         });
 
         it('should index mixed blocks correctly', function () {
@@ -102,11 +103,11 @@ describe('voxel-query', function () {
             const strideZ = 16;
             const lookup = buildBlockLookup(buffer);
 
-            assert.strictEqual(lookup.solidSet.size, 0);
-            assert.strictEqual(lookup.mixedMap.size, 1);
+            assert.strictEqual(lookup.solidCount, 0);
+            assert.strictEqual(lookup.mixedCount, 1);
             const blockIdx = 1 + 1 * strideY + 1 * strideZ;
-            assert.ok(lookup.mixedMap.has(blockIdx));
-            const maskIdx = lookup.mixedMap.get(blockIdx);
+            const maskIdx = lookup.blocks.get(blockIdx);
+            assert.ok(maskIdx >= 0);
             assert.strictEqual(lookup.masks[maskIdx * 2], lo);
             assert.strictEqual(lookup.masks[maskIdx * 2 + 1], hi);
         });
@@ -115,8 +116,8 @@ describe('voxel-query', function () {
             const buffer = new BlockMaskBuffer();
             const lookup = buildBlockLookup(buffer);
 
-            assert.strictEqual(lookup.solidSet.size, 0);
-            assert.strictEqual(lookup.mixedMap.size, 0);
+            assert.strictEqual(lookup.solidCount, 0);
+            assert.strictEqual(lookup.mixedCount, 0);
         });
     });
 


### PR DESCRIPTION
Improve large-scene voxel processing by replacing JavaScript collections with typed block maps, sorted chunked cleanup buffers, and typed octree waves; add a direct voxel-buffer-to-octree path when mutable grid operations are unnecessary; enforce memory and format limits with actionable errors; and expand test coverage for large indices, filtering, queries, and sparse-octree output.