### PR TITLE
Fix GPU dilation hangs with Float64 block-mask keys

### DIFF
--- a/src/lib/gpu/gpu-dilation.ts
+++ b/src/lib/gpu/gpu-dilation.ts
@@ -284,7 +284,7 @@ class GpuDilation {
      */
     uploadSrc(src: SparseVoxelGrid): void {
         const types = src.types;
-        const keys = src.masks.keys;     // Int32Array; -1 sentinel reads as 0xFFFFFFFF when interpreted as u32
+        const keys = src.masks.keys;
         const lo = src.masks.lo;
         const hi = src.masks.hi;
 
@@ -296,7 +296,11 @@ class GpuDilation {
         }
         this.srcTypesBuffer.write(0, types, 0, types.length);
 
-        const masksBytes = keys.byteLength;
+        // BlockMaskMap stores keys as Float64 so it can represent the full u32
+        // block-index range. Pack values for the shader; converting -1 preserves
+        // the expected 0xFFFFFFFF empty-slot sentinel.
+        const keysU32 = Uint32Array.from(keys);
+        const masksBytes = keysU32.byteLength;
         if (this.srcKeysBuffer === null || this.srcMasksCapacity < masksBytes) {
             this.srcKeysBuffer?.destroy();
             this.srcLoBuffer?.destroy();
@@ -306,8 +310,6 @@ class GpuDilation {
             this.srcHiBuffer = new StorageBuffer(this.device, masksBytes, BUFFERUSAGE_COPY_DST);
             this.srcMasksCapacity = masksBytes;
         }
-        // Treat keys (Int32) as Uint32 — same byte pattern; -1 reads as 0xFFFFFFFF.
-        const keysU32 = new Uint32Array(keys.buffer, keys.byteOffset, keys.length);
         this.srcKeysBuffer.write(0, keysU32, 0, keys.length);
         this.srcLoBuffer.write(0, lo, 0, lo.length);
         this.srcHiBuffer.write(0, hi, 0, hi.length);

--- a/src/lib/gpu/shaders/dilation.ts
+++ b/src/lib/gpu/shaders/dilation.ts
@@ -91,6 +91,7 @@ fn main(@builtin(global_invocation_id) gid: vec3u) {
     } else {
         // BLOCK_MIXED → hash lookup. Same constant as CPU BlockMaskMap.
         var i = (blockIdx * FIBONACCI_HASH) & u.srcCapMinusOne;
+        var probes: u32 = 0u;
         loop {
             let k = srcKeys[i];
             if (k == blockIdx) {
@@ -98,9 +99,10 @@ fn main(@builtin(global_invocation_id) gid: vec3u) {
                 hi = srcHi[i];
                 break;
             }
-            if (k == 0xFFFFFFFFu) {
-                return;  // not found (shouldn't happen for MIXED)
+            if (k == 0xFFFFFFFFu || probes == u.srcCapMinusOne) {
+                return;  // not found or corrupt/full table
             }
+            probes = probes + 1u;
             i = (i + 1u) & u.srcCapMinusOne;
         }
     }

--- a/test/gpu-dilation.test.mjs
+++ b/test/gpu-dilation.test.mjs
@@ -1,0 +1,63 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { GpuDilation } from '../src/lib/gpu/gpu-dilation.js';
+import { extractWgsl } from '../src/lib/gpu/shaders/dilation.js';
+
+describe('GpuDilation', function () {
+    it('packs Float64 block-mask keys for the u32 shader table', function () {
+        let uploadedKeys;
+        const gpu = Object.create(GpuDilation.prototype);
+        gpu.srcTypesBuffer = { write() {} };
+        gpu.srcKeysBuffer = {
+            write(_offset, data, dataOffset, count) {
+                uploadedKeys = data.slice(dataOffset, dataOffset + count);
+            }
+        };
+        gpu.srcLoBuffer = { write() {} };
+        gpu.srcHiBuffer = { write() {} };
+        gpu.srcTypesCapacity = Number.MAX_SAFE_INTEGER;
+        gpu.srcMasksCapacity = Number.MAX_SAFE_INTEGER;
+
+        const keys = new Float64Array([
+            -1,
+            0,
+            0x7FFFFFFF,
+            0x80000000,
+            0xFFFFFFFE,
+            0xFFFFFFFF,
+            -1,
+            -1
+        ]);
+        gpu.uploadSrc({
+            types: new Uint32Array(1),
+            masks: {
+                keys,
+                lo: new Uint32Array(keys.length),
+                hi: new Uint32Array(keys.length)
+            },
+            nbx: 1,
+            nby: 1,
+            nbz: 1,
+            bStride: 1
+        });
+
+        assert.ok(uploadedKeys instanceof Uint32Array);
+        assert.deepStrictEqual([...uploadedKeys], [
+            0xFFFFFFFF,
+            0,
+            0x7FFFFFFF,
+            0x80000000,
+            0xFFFFFFFE,
+            0xFFFFFFFF,
+            0xFFFFFFFF,
+            0xFFFFFFFF
+        ]);
+    });
+
+    it('bounds shader hash probes to the uploaded table capacity', function () {
+        const shader = extractWgsl();
+        assert.match(shader, /var probes: u32 = 0u;/);
+        assert.match(shader, /probes == u\.srcCapMinusOne/);
+    });
+});


### PR DESCRIPTION
Pack Float64 block-mask keys into the Uint32 format expected by the GPU dilation shader and bound hash-table probing to prevent infinite GPU loops. Adds regression coverage and verifies the previously hanging production scene completes successfully.