### PR TITLE
Fix pathological decimation slowness and a GPU buffer overflow on scenes with flyaway splats

### DIFF
--- a/src/lib/decimate/knn-blocks.ts
+++ b/src/lib/decimate/knn-blocks.ts
@@ -5,7 +5,8 @@ import { type BlockRange, type ResidentPositions } from './partition';
  * A block's local point set: owned gaussians first (in the block's sorted
  * owned order), then halo members from neighbouring blocks. `ids` maps local
  * index → global gaussian index; `positions` is interleaved xyz; `h` is the
- * halo radius the set was collected with.
+ * halo radius the set was collected with — `-Infinity` when no covering halo
+ * fits the cap (halo empty, every owned query takes the exact requery).
  */
 type BlockLocals = {
     ids: Uint32Array;
@@ -76,6 +77,8 @@ const collectBlock = (
     const nOwned = block.end - block.start;
     const maxHalo = Math.ceil(nOwned * haloCap);
 
+    // The shrink loop only asks whether the halo exceeds the cap — bail as
+    // soon as that is known rather than counting the whole scene.
     const countHalo = (h2: number): number => {
         let count = 0;
         for (let b2 = 0; b2 < blocks.length; b2++) {
@@ -84,7 +87,9 @@ const collectBlock = (
             if (aabbAabbDist2(block.aabb, other.aabb) > h2) continue;
             for (let i = other.start; i < other.end; i++) {
                 const g = order[i];
-                if (pointAabbDist2(pos.x[g], pos.y[g], pos.z[g], block.aabb) <= h2) count++;
+                if (pointAabbDist2(pos.x[g], pos.y[g], pos.z[g], block.aabb) <= h2) {
+                    if (++count > maxHalo) return count;
+                }
             }
         }
         return count;
@@ -96,10 +101,36 @@ const collectBlock = (
     // reduced h are then legitimately outside the covered region and boundary
     // queries fall through to the brute-force requery.
     let h = haloRadius(block, k, haloFactor);
+    let fits = false;
     for (let iter = 0; iter < 40 && h > 0; iter++) {
-        if (countHalo(h * h) <= maxHalo) break;
+        if (countHalo(h * h) <= maxHalo) {
+            fits = true;
+            break;
+        }
         h *= 0.7;
         if (h < 1e-12) h = 0;
+    }
+    if (!fits) {
+        if (countHalo(0) > maxHalo) {
+            // No h can fit the cap: other blocks' points sit INSIDE this
+            // block's AABB (e.g. an outlier-residual block enveloping the
+            // core), so the covering guarantee is unobtainable at any radius.
+            // Collect no halo and disable the guarantee (h = -Infinity):
+            // every owned query then takes the best-first requery, which is
+            // exact by construction.
+            const ids = new Uint32Array(nOwned);
+            const positions = new Float32Array(nOwned * 3);
+            for (let i = 0; i < nOwned; i++) {
+                const g = order[block.start + i];
+                ids[i] = g;
+                positions[i * 3] = pos.x[g];
+                positions[i * 3 + 1] = pos.y[g];
+                positions[i * 3 + 2] = pos.z[g];
+            }
+            return { ids, ownedCount: nOwned, positions, h: -Infinity };
+        }
+        // The shrink iterations ran out, but a zero-radius halo fits.
+        h = 0;
     }
     const h2 = h * h;
 
@@ -182,9 +213,10 @@ const kBestInsert = (bestIds: Uint32Array, bestD2: Float64Array, size: number, k
  * Exactness backstop for block KNN. A query's result is guaranteed correct
  * when its k-th neighbour distance fits inside the halo-covered region
  * (`d_k ≤ depth(q) + h`). Queries that fail — or that carry sentinel slots
- * despite the scene having ≥ k other points — are re-queried by brute force
- * against every block within the k-th distance, making the block KNN
- * globally exact.
+ * despite the scene having ≥ k other points — are re-queried best-first:
+ * blocks are visited in ascending point-to-AABB distance and the scan stops
+ * at the first block that can no longer improve on the k-th best so far.
+ * Same candidate set as a full scan, making the block KNN globally exact.
  *
  * Fixed entries are written into `nbGlobal`; the matching `nbLocal` slots
  * (when provided) are marked {@link KNN_FIXED} so callers resolve those
@@ -217,6 +249,8 @@ const verifyAndFixKnn = (
 
     const bestIds = new Uint32Array(k);
     const bestD2 = new Float64Array(k);
+    const blockD2 = new Float64Array(blocks.length);
+    const blockOrd = new Uint32Array(blocks.length);
 
     for (let qi = 0; qi < locals.ownedCount; qi++) {
         const g = locals.ids[qi];
@@ -245,13 +279,29 @@ const verifyAndFixKnn = (
         const needFix = (sentinels && N - 1 >= k) || Math.sqrt(dkSq) > depth + h;
         if (!needFix) continue;
 
-        // Brute re-query against every block within reach of the current
-        // k-th distance (everything, when sentinels made the bound unknown).
+        // Best-first re-query: blocks in ascending point-to-AABB distance
+        // (insertion sort — block counts are small), stopping at the first
+        // block beyond the unverified k-th distance (a valid upper bound on
+        // the true one; unknown when sentinels) or beyond the k-th best so
+        // far, which tightens as candidates land. Blocks the loop never
+        // reaches provably contain no improving candidate.
         const r2 = sentinels ? Infinity : dkSq;
-        let size = 0;
         for (let b2 = 0; b2 < blocks.length; b2++) {
+            const d2b = pointAabbDist2(qx, qy, qz, blocks[b2].aabb);
+            blockD2[b2] = d2b;
+            let at = b2;
+            while (at > 0 && blockD2[blockOrd[at - 1]] > d2b) {
+                blockOrd[at] = blockOrd[at - 1];
+                at--;
+            }
+            blockOrd[at] = b2;
+        }
+        let size = 0;
+        for (let t = 0; t < blocks.length; t++) {
+            const b2 = blockOrd[t];
+            const d2b = blockD2[b2];
+            if (d2b > r2 || (size === k && d2b >= bestD2[k - 1])) break;
             const other = blocks[b2];
-            if (r2 !== Infinity && pointAabbDist2(qx, qy, qz, other.aabb) > r2) continue;
             for (let i = other.start; i < other.end; i++) {
                 const cand = order[i];
                 if (cand === g) continue;

--- a/src/lib/decimate/partition.ts
+++ b/src/lib/decimate/partition.ts
@@ -34,7 +34,7 @@ const OUTLIER_SAMPLE_CAP = 1 << 20;
 // 0.1–99.9% half-spread. An axis with no spread stays unfenced (±Infinity).
 const outlierFence = (pos: ResidentPositions): { lo: number[]; hi: number[] } => {
     const n = pos.x.length;
-    const stride = Math.max(1, Math.floor(n / OUTLIER_SAMPLE_CAP));
+    const stride = Math.max(1, Math.ceil(n / OUTLIER_SAMPLE_CAP));
     const cols = [pos.x, pos.y, pos.z];
     const lo = [-Infinity, -Infinity, -Infinity];
     const hi = [Infinity, Infinity, Infinity];
@@ -60,9 +60,11 @@ const outlierFence = (pos: ResidentPositions): { lo: number[]; hi: number[] } =>
  * (quickselect, in place on one index array). Rare flyaway positions are set
  * aside into trailing residual block(s) first, so core blocks keep tight
  * AABBs — flyaways otherwise stretch AABBs scene-wide, which wrecks the
- * density-based halo estimate and AABB-distance pruning downstream. Blocks
- * are an IO pattern only — with globally exact KNN, block boundaries cannot
- * affect the decimation result.
+ * density-based halo estimate and AABB-distance pruning downstream. With
+ * globally exact KNN, block boundaries cannot change which merges are
+ * possible or their costs — but they do set output row order, and selection
+ * tie-breaks between quantized-equal costs can resolve differently under a
+ * different partition.
  *
  * @param pos - Resident positions.
  * @param blockSize - Maximum gaussians per block.

--- a/src/lib/decimate/partition.ts
+++ b/src/lib/decimate/partition.ts
@@ -21,12 +21,48 @@ type BlockRange = {
     aabb: Float32Array;
 };
 
+/** Outlier fence: expand the sampled per-axis quantile interval this much. */
+const OUTLIER_FENCE_FACTOR = 4;
+
+/** Treat out-of-fence points as flyaways only while they are rare. */
+const OUTLIER_MAX_FRACTION = 0.01;
+
+/** Position sample cap for the fence quantiles. */
+const OUTLIER_SAMPLE_CAP = 1 << 20;
+
+// Per-axis fence [lo, hi] from strided-sample quantiles: mid ± factor × the
+// 0.1–99.9% half-spread. An axis with no spread stays unfenced (±Infinity).
+const outlierFence = (pos: ResidentPositions): { lo: number[]; hi: number[] } => {
+    const n = pos.x.length;
+    const stride = Math.max(1, Math.floor(n / OUTLIER_SAMPLE_CAP));
+    const cols = [pos.x, pos.y, pos.z];
+    const lo = [-Infinity, -Infinity, -Infinity];
+    const hi = [Infinity, Infinity, Infinity];
+    const samp = new Float32Array(Math.ceil(n / stride) || 1);
+    for (let c = 0; c < 3; c++) {
+        let m = 0;
+        for (let i = 0; i < n; i += stride) samp[m++] = cols[c][i];
+        const s = samp.subarray(0, m).sort();
+        const qlo = s[Math.min(m - 1, Math.floor(0.001 * m))];
+        const qhi = s[Math.min(m - 1, Math.floor(0.999 * m))];
+        const half = (qhi - qlo) / 2;
+        if (!(half > 0)) continue;
+        const mid = (qlo + qhi) / 2;
+        lo[c] = mid - OUTLIER_FENCE_FACTOR * half;
+        hi[c] = mid + OUTLIER_FENCE_FACTOR * half;
+    }
+    return { lo, hi };
+};
+
 /**
  * KD-partition the resident positions into spatial blocks of at most
  * `blockSize` gaussians by recursive median splits on the largest AABB axis
- * (quickselect, in place on one index array). Blocks are an IO pattern only —
- * with globally exact KNN, block boundaries cannot affect the decimation
- * result.
+ * (quickselect, in place on one index array). Rare flyaway positions are set
+ * aside into trailing residual block(s) first, so core blocks keep tight
+ * AABBs — flyaways otherwise stretch AABBs scene-wide, which wrecks the
+ * density-based halo estimate and AABB-distance pruning downstream. Blocks
+ * are an IO pattern only — with globally exact KNN, block boundaries cannot
+ * affect the decimation result.
  *
  * @param pos - Resident positions.
  * @param blockSize - Maximum gaussians per block.
@@ -72,7 +108,32 @@ const kdPartition = (pos: ResidentPositions, blockSize: number): { order: Uint32
         recurse(start, mid);
         recurse(mid, end);
     };
-    if (n > 0) recurse(0, n);
+
+    // Residual split: fence classification must stay rare — a scene that is
+    // mostly "outliers" is just sparse, and splitting it would recreate the
+    // stretched-AABB problem inside the residual.
+    let coreEnd = n;
+    if (n > 0) {
+        const { lo, hi } = outlierFence(pos);
+        let out = 0;
+        for (let i = 0; i < n; i++) {
+            if (cols[0][i] < lo[0] || cols[0][i] > hi[0] ||
+                cols[1][i] < lo[1] || cols[1][i] > hi[1] ||
+                cols[2][i] < lo[2] || cols[2][i] > hi[2]) out++;
+        }
+        if (out > 0 && out <= n * OUTLIER_MAX_FRACTION) {
+            coreEnd = n - out;
+            let c = 0, o = coreEnd;
+            for (let i = 0; i < n; i++) {
+                if (cols[0][i] < lo[0] || cols[0][i] > hi[0] ||
+                    cols[1][i] < lo[1] || cols[1][i] > hi[1] ||
+                    cols[2][i] < lo[2] || cols[2][i] > hi[2]) order[o++] = i;
+                else order[c++] = i;
+            }
+        }
+    }
+    if (coreEnd > 0) recurse(0, coreEnd);
+    if (coreEnd < n) recurse(coreEnd, n);
     return { order, blocks };
 };
 

--- a/src/lib/decimate/priority.ts
+++ b/src/lib/decimate/priority.ts
@@ -231,6 +231,7 @@ const runPriorityPass = async (
 
     let gpuKnn: GpuKnn | undefined;
     let gpuCost: GpuEdgeCost | undefined;
+    let gpuCostCapacity = maxLocalN;
 
     // 1-deep prefetch: the next block's halo collection + tree build runs
     // while the current block computes. GpuKnn executions share one set of
@@ -287,6 +288,17 @@ const runPriorityPass = async (
             }
             const extraGlobals = Uint32Array.from(extRow.keys()).sort();
             for (let i = 0; i < extraGlobals.length; i++) extRow.set(extraGlobals[i], nOwned + i);
+
+            // Verification-fixed externals are not bounded by the halo cap, so
+            // a pathological block's view can exceed the preallocated cost
+            // buffers — grow them to the actual view size when that happens
+            // (rare; costs one reallocation).
+            const viewN = nOwned + extraGlobals.length;
+            if (gpuCost && viewN > gpuCostCapacity) {
+                gpuCost.destroy();
+                gpuCostCapacity = Math.ceil(viewN * 1.1);
+                gpuCost = new GpuEdgeCost(device!, gpuCostCapacity, maxOwned * k, colorDim);
+            }
 
             const { view } = await gatherBlockView(ctx, bi, extraGlobals);
 

--- a/test/decimate-knn.test.mjs
+++ b/test/decimate-knn.test.mjs
@@ -21,8 +21,16 @@ const mulberry = (seed) => {
 
 const scenes = {
     uniform: (n, r) => Float32Array.from({ length: n }, () => r() * 10),
-    clustered: (n, r) => Float32Array.from({ length: n }, (_, i) => (i % 7) + r() * 0.01)
+    clustered: (n, r) => Float32Array.from({ length: n }, (_, i) => (i % 7) + r() * 0.01),
+    // Bulk cluster + rare extreme flyaways: stretched block AABBs defeat the
+    // density-based halo estimate — the requery-heavy regime.
+    flyaway: (n, r) => Float32Array.from({ length: n }, () => (r() < 0.01 ? (r() - 0.5) * 5000 : r() * 10)),
+    // Integer-grid coordinates: many coincident points and exact distance ties.
+    coincident: (n, r) => Float32Array.from({ length: n }, () => Math.floor(r() * 12))
 };
+
+// Adversarial scenes are ALLOWED to requery heavily; the benign ones must not.
+const requeryCapped = new Set(['uniform', 'clustered']);
 
 describe('block KNN with halo + verification', () => {
     for (const [name, gen] of Object.entries(scenes)) {
@@ -34,6 +42,11 @@ describe('block KNN with halo + verification', () => {
             let totalFixed = 0;
             for (let bi = 0; bi < blocks.length; bi++) {
                 const locals = collectBlock(pos, order, blocks, bi, k, 2.5);
+                // Buffer-sizing contract: locals never exceed owned × (1 + haloCap).
+                assert.ok(
+                    locals.ids.length <= locals.ownedCount + Math.ceil(locals.ownedCount * 1),
+                    `${name} block ${bi}: halo exceeds the cap (${locals.ids.length} locals for ${locals.ownedCount} owned)`
+                );
                 const nbLocal = knnBlockCpu(locals, k);
                 const nbGlobal = toGlobalNeighbors(locals, nbLocal);
                 totalFixed += verifyAndFixKnn(pos, order, blocks, bi, locals, k, nbGlobal, nbLocal);
@@ -44,19 +57,85 @@ describe('block KNN with halo + verification', () => {
                         if (i !== g) dists.push(d2(g, i));
                     }
                     dists.sort((a, b) => a - b);
-                    const bruteMax = dists[k - 1];
+                    const got = [];
+                    const seen = new Set();
                     for (let s = 0; s < k; s++) {
                         const nb = nbGlobal[q * k + s];
                         assert.notStrictEqual(nb, 0xFFFFFFFF, `${name} block ${bi} q ${q} slot ${s} sentinel`);
                         assert.notStrictEqual(nb, g, 'self excluded');
-                        assert.ok(d2(g, nb) <= bruteMax + 1e-6, `${name} block ${bi} q ${q}: neighbor farther than true k-th`);
+                        assert.ok(!seen.has(nb), `${name} block ${bi} q ${q}: duplicate neighbour`);
+                        seen.add(nb);
+                        got.push(d2(g, nb));
                     }
+                    // Exact k-NN: the neighbour distance multiset must equal the
+                    // true k smallest (valid under ties, where ids may differ).
+                    got.sort((a, b) => a - b);
+                    assert.deepStrictEqual(got, dists.slice(0, k), `${name} block ${bi} q ${q}: not the exact k nearest`);
                 }
             }
             // sanity: verification exists but is not doing all the work
-            assert.ok(totalFixed < n * 0.5, `${name}: too many requeries (${totalFixed})`);
+            if (requeryCapped.has(name)) {
+                assert.ok(totalFixed < n * 0.5, `${name}: too many requeries (${totalFixed})`);
+            }
         });
     }
+
+    it('enveloping residual block (no covering halo) stays exact via forced requery', () => {
+        // Bulk grid + rare extreme flyaways: the residual block's AABB
+        // envelops the core, so no halo radius can satisfy the size cap —
+        // collectBlock must fall back to an empty halo (h = -Infinity) and
+        // verification must recover exactness for every residual query.
+        const k = 8;
+        const side = 22, nBulk = side * side * side; // 10648
+        const fly = [
+            [10000, 9000, -11000], [-12000, 10000, 9500], [11000, -9500, 12000], [-9000, -10000, -12000],
+            [15000, 14000, 13000], [-15000, 16000, -14000], [14000, -13000, 15000], [-16000, -15000, 14000]
+        ];
+        const n = nBulk + fly.length;
+        const pos = { x: new Float32Array(n), y: new Float32Array(n), z: new Float32Array(n) };
+        let i = 0;
+        for (let a = 0; a < side; a++) {
+            for (let b = 0; b < side; b++) {
+                for (let c = 0; c < side; c++, i++) {
+                    pos.x[i] = a; pos.y[i] = b; pos.z[i] = c;
+                }
+            }
+        }
+        fly.forEach(([fx, fy, fz], j) => {
+            pos.x[nBulk + j] = fx; pos.y[nBulk + j] = fy; pos.z[nBulk + j] = fz;
+        });
+        const { order, blocks } = kdPartition(pos, 1024);
+        const d2 = (a, b) => (pos.x[a] - pos.x[b]) ** 2 + (pos.y[a] - pos.y[b]) ** 2 + (pos.z[a] - pos.z[b]) ** 2;
+        let sawFallback = false;
+        for (let bi = 0; bi < blocks.length; bi++) {
+            const locals = collectBlock(pos, order, blocks, bi, k, 2.5);
+            assert.ok(
+                locals.ids.length <= locals.ownedCount + Math.ceil(locals.ownedCount * 1),
+                `block ${bi}: halo exceeds the cap`
+            );
+            if (locals.h === -Infinity) sawFallback = true;
+            const nbLocal = knnBlockCpu(locals, k);
+            const nbGlobal = toGlobalNeighbors(locals, nbLocal);
+            verifyAndFixKnn(pos, order, blocks, bi, locals, k, nbGlobal, nbLocal);
+            for (let q = 0; q < locals.ownedCount; q++) {
+                const g = locals.ids[q];
+                const dists = [];
+                for (let j = 0; j < n; j++) {
+                    if (j !== g) dists.push(d2(g, j));
+                }
+                dists.sort((a, b) => a - b);
+                const got = [];
+                for (let s = 0; s < k; s++) {
+                    const nb = nbGlobal[q * k + s];
+                    assert.notStrictEqual(nb, 0xFFFFFFFF, `block ${bi} q ${q} sentinel`);
+                    got.push(d2(g, nb));
+                }
+                got.sort((a, b) => a - b);
+                assert.deepStrictEqual(got, dists.slice(0, k), `block ${bi} q ${q}: not the exact k nearest`);
+            }
+        }
+        assert.ok(sawFallback, 'expected at least one no-covering-halo fallback block');
+    });
 
     it('tiny scene (n <= k) keeps sentinels', () => {
         const n = 4, k = 8;

--- a/test/decimate-partition.test.mjs
+++ b/test/decimate-partition.test.mjs
@@ -55,6 +55,64 @@ describe('kdPartition', () => {
         const { blocks } = kdPartition(pos, 512);
         assert.strictEqual(blocks.reduce((a, b) => a + (b.end - b.start), 0), n);
     });
+
+    it('rare flyaways land in residual blocks; core blocks stay tight', () => {
+        const g = grid(22); // 10648 bulk points in [0,21]^3
+        const nBulk = g.x.length;
+        const fly = [
+            [10000, 9000, -11000], [-12000, 10000, 9500], [11000, -9500, 12000], [-9000, -10000, -12000],
+            [15000, 14000, 13000], [-15000, 16000, -14000], [14000, -13000, 15000], [-16000, -15000, 14000]
+        ];
+        const n = nBulk + fly.length;
+        const pos = { x: new Float32Array(n), y: new Float32Array(n), z: new Float32Array(n) };
+        pos.x.set(g.x); pos.y.set(g.y); pos.z.set(g.z);
+        fly.forEach(([fx, fy, fz], i) => {
+            pos.x[nBulk + i] = fx; pos.y[nBulk + i] = fy; pos.z[nBulk + i] = fz;
+        });
+        const { order, blocks } = kdPartition(pos, 1024);
+        assert.strictEqual(blocks.reduce((a, b) => a + (b.end - b.start), 0), n);
+        for (const b of blocks) {
+            let hasBulk = false, hasFly = false;
+            for (let i = b.start; i < b.end; i++) {
+                if (order[i] < nBulk) hasBulk = true;
+                else hasFly = true;
+                if (i > b.start) assert.ok(order[i] > order[i - 1], 'owned range sorted ascending');
+            }
+            assert.ok(!(hasBulk && hasFly), 'flyaways segregated from the bulk');
+            if (hasBulk) {
+                const ext = Math.max(b.aabb[3] - b.aabb[0], b.aabb[4] - b.aabb[1], b.aabb[5] - b.aabb[2]);
+                assert.ok(ext <= 21 + 1e-6, `core block stretched by flyaways (extent ${ext})`);
+            }
+        }
+    });
+
+    it('a genuinely sparse scene (many out-of-fence points) is not split', () => {
+        // 4.6% "flyaways" exceed the rare-outlier fraction: the fence must
+        // stand down and partition the scene as-is (mixed blocks allowed).
+        const g = grid(16); // 4096 bulk points
+        const nBulk = g.x.length;
+        const nFly = 200;
+        const n = nBulk + nFly;
+        const pos = { x: new Float32Array(n), y: new Float32Array(n), z: new Float32Array(n) };
+        pos.x.set(g.x); pos.y.set(g.y); pos.z.set(g.z);
+        for (let i = 0; i < nFly; i++) {
+            const s = i % 2 === 0 ? 1 : -1;
+            pos.x[nBulk + i] = s * (10000 + i * 37);
+            pos.y[nBulk + i] = -s * (9000 + i * 53);
+            pos.z[nBulk + i] = s * (11000 + i * 71);
+        }
+        const { order, blocks } = kdPartition(pos, 300);
+        assert.strictEqual(blocks.reduce((a, b) => a + (b.end - b.start), 0), n);
+        const mixed = blocks.some((b) => {
+            let hasBulk = false, hasFly = false;
+            for (let i = b.start; i < b.end; i++) {
+                if (order[i] < nBulk) hasBulk = true;
+                else hasFly = true;
+            }
+            return hasBulk && hasFly;
+        });
+        assert.ok(mixed, 'fence should stand down above the rare-outlier fraction');
+    });
 });
 
 describe('coherenceRuns', () => {


### PR DESCRIPTION
## Problem

Decimating scenes that contain a few extreme "flyaway" gaussians is catastrophically slow. An 86M-gaussian aerial capture with ~2,100 flyaways (0.0025% of the scene, stretching the scene AABB to 162× the bulk extent on one axis) never completed its first 50% decimation pass: the priority pass alone ran 3+ hours without finishing, with instrumented blocks spending up to 33 minutes each inside `verifyAndFixKnn`. Past that point the run is doomed anyway by a latent GPU buffer overflow (below).

## Root cause

- kd median splits put the flyaway regions into trailing blocks whose (tight) AABBs still span the whole scene, so the AABB-volume Poisson halo estimate collapses under the halo cap and huge numbers of queries fail the `d_k ≤ depth + h` verification guarantee.
- Each failed query brute-re-queried every block within a static radius fixed at the unverified k-th distance — effectively the whole scene for sparse points — making verification O(failedQueries × N).
- Latent crash: the GPU edge-cost buffers are sized to `maxOwned × (1 + HALO_CAP)`, but verification-fixed external neighbours are not bounded by the halo cap; one block gathered 1.5M externals on top of 1.34M owned and threw `GpuEdgeCost: N=2841233 exceeds maxN=2682624`.
- Latent assumption: halo collection implicitly relies on kd-cell AABBs being pairwise disjoint; a block whose AABB contains other blocks' points swallows them all as halo.

## Changes

- `verifyAndFixKnn`: re-query blocks best-first (ascending point-to-AABB distance) with a tightening bound — the minimum of the initial k-th distance and the k-th best so far — stopping at the first block that provably cannot improve the result. Same candidate set as the full scan, so results stay exact.
- `kdPartition`: rare coordinate outliers (robust per-axis percentile fence; stands down above 1% of the scene) are set aside into trailing residual block(s) so core blocks keep tight AABBs. Blocks are an IO pattern only, so this cannot change which merges are possible.
- `collectBlock`: when no halo radius can satisfy the size cap (an enveloping-AABB block, e.g. the residual), collect no halo and route every owned query through the exact re-query instead of relying on the unobtainable covering guarantee; halo counting also bails out as soon as the cap is exceeded.
- `runPriorityPass`: grow the GPU edge-cost buffers when a block's gathered view exceeds the preallocated size instead of throwing.

No API or format changes.

## Results (M4 Max, GPU path)

- 86M-gaussian flyaway scene, 50% decimation: never completes → 4m16s end-to-end (priority pass 2m29s), 9.2 GB peak RSS; near-identical for training-ordered input (4m34s), so a `--morton-order` prepass is no longer required to make such scenes viable.
- 8.5M synthetic scene with 0.05% flyaways: 74s → 24s.
- Benign scenes: byte-identical output and neutral runtime, verified against the unpatched build at 200K and 8.5M multi-block scale.

## Verification

- New unit tests assert the exact k-NN distance multiset against global brute force on uniform, clustered, flyaway, coincident (exact-tie), and enveloping-residual scenes, plus the halo buffer-sizing contract and partition invariants (flyaway segregation, fence stand-down above the rare-outlier fraction).
- With the outlier fence disabled, this branch produces content-identical output to the unpatched build, isolating all behavioural difference to the partition itself.
- Where the fence fires, rows are emitted in the new block order, and quantized-cost ties in `selectMerges` (1024 linear buckets, index-order tie-break within a bucket) can resolve differently. That sensitivity is pre-existing rather than introduced here: the unpatched build already flips 0.78% of output records under a pure input row shuffle, while the fence measures 0.40% on the same scene. A follow-up could make selection tie-breaking content-based if reorder-invariant output is wanted.