### PR TITLE
Fix all-null SOG scales codebook on scenes containing flat (-Infinity scale) splats

### DIFF
--- a/src/lib/spatial/quantize-1d-core.ts
+++ b/src/lib/spatial/quantize-1d-core.ts
@@ -11,69 +11,11 @@ type QuantizedColumns = {
     labels: { name: string, data: Uint8Array }[];
 };
 
-/**
- * Optimal 1D quantization using dynamic programming on a histogram.
- *
- * Pools all columns into a single 1D dataset, sorts the values, bins them
- * using a blend of uniform and quantile positioning, then uses DP to find k
- * centroids that minimize weighted sum-of-squared-errors (SSE).
- *
- * Bin positions are an adaptive blend of uniform (value-space) and
- * quantile (rank-space) positioning. The blend ratio is computed from
- * the data's IQR-to-range ratio: extreme outlier distributions (small
- * IQR relative to range) use near-pure quantile to give the dense
- * center adequate bins, while moderate-tail distributions reduce
- * quantile bias (but keep at least 50% quantile weighting).
- *
- * Bin weights use sub-linear density weighting: weight = count^alpha.
- * With alpha < 1, sparse tail regions earn meaningful influence on
- * centroid placement.
- *
- * @param columns - Named columns pooled into 1D.
- * @param k - Number of codebook entries (default 256).
- * @param alpha - Density weight exponent. 0 = uniform (each bin equal),
- * 0.5 = sqrt (balanced), 1.0 = standard MSE (dense regions dominate).
- * Default 0.5.
- * @returns Object with `centroids` (k Float32 values, sorted ascending) and
- * `labels` (same column layout as input, each holding Uint8Array indices
- * into the codebook).
- */
-const quantize1dColumns = (columns: { name: string, data: TypedArray }[], k = 256, alpha = 0.5): QuantizedColumns => {
-    const numColumns = columns.length;
-    const numRows = numColumns > 0 ? columns[0].data.length : 0;
-
-    // pool all columns into a flat 1D array
-    const N = numRows * numColumns;
-
-    if (N === 0) {
-        return {
-            centroids: new Float32Array(k),
-            labels: columns.map(c => ({ name: c.name, data: new Uint8Array(numRows) }))
-        };
-    }
-
-    const data = new Float32Array(N);
-    for (let i = 0; i < numColumns; ++i) {
-        data.set(columns[i].data, i * numRows);
-    }
-
-    // sort a copy for histogram binning (keep original for label assignment)
-    const sortedData = new Float32Array(data);
-    sortedData.sort();
-
+// The histogram + DP core over sorted finite values: returns up to kTarget
+// centroids, sorted ascending.
+const quantizeFinite = (sortedData: Float32Array, N: number, kTarget: number, alpha: number): Float32Array => {
     const vMin = sortedData[0];
     const vMax = sortedData[N - 1];
-
-    // handle degenerate case where all values are identical
-    if (vMax - vMin < 1e-20) {
-        const centroids = new Float32Array(k);
-        centroids.fill(vMin);
-
-        return {
-            centroids,
-            labels: columns.map(c => ({ name: c.name, data: new Uint8Array(numRows) }))
-        };
-    }
 
     // build histogram using blended uniform/quantile bin positions
     const H = Math.min(1024, N);
@@ -135,7 +77,7 @@ const quantize1dColumns = (columns: { name: string, data: TypedArray }[], k = 25
     };
 
     const nonEmpty = counts.reduce((n, c) => n + (c > 0 ? 1 : 0), 0);
-    const effectiveK = Math.min(k, nonEmpty);
+    const effectiveK = Math.min(kTarget, nonEmpty);
 
     // DP: dp[m][j] = min weighted SSE of quantizing bins 0..j into m centroids
     // Use two rows to save memory (only need previous row)
@@ -193,11 +135,135 @@ const quantize1dColumns = (columns: { name: string, data: TypedArray }[], k = 25
     // sort centroids (should already be sorted, but ensure)
     centroidValues.sort();
 
-    // pad to k entries if effectiveK < k (duplicate last centroid)
+    return centroidValues;
+};
+
+/**
+ * Optimal 1D quantization using dynamic programming on a histogram.
+ *
+ * Pools all columns into a single 1D dataset, sorts the values, bins them
+ * using a blend of uniform and quantile positioning, then uses DP to find k
+ * centroids that minimize weighted sum-of-squared-errors (SSE).
+ *
+ * Bin positions are an adaptive blend of uniform (value-space) and
+ * quantile (rank-space) positioning. The blend ratio is computed from
+ * the data's IQR-to-range ratio: extreme outlier distributions (small
+ * IQR relative to range) use near-pure quantile to give the dense
+ * center adequate bins, while moderate-tail distributions reduce
+ * quantile bias (but keep at least 50% quantile weighting).
+ *
+ * Bin weights use sub-linear density weighting: weight = count^alpha.
+ * With alpha < 1, sparse tail regions earn meaningful influence on
+ * centroid placement.
+ *
+ * Non-finite values: `±Infinity` is a valid pipeline value (`scale_*` may be
+ * `-Infinity` for flat splats, `opacity` `+Infinity` — see `filterNaN`), but a
+ * single one pooled into the histogram poisons vMin/vRange and NaN-cascades
+ * into an all-NaN codebook (serialized as JSON nulls). So the histogram/DP
+ * runs over the finite values only, and each infinity present earns a
+ * dedicated end centroid at a finite sentinel 20 units outside the finite
+ * range — JSON-safe, and far enough that log-scale consumers decode
+ * exp(-20) ≈ 2e-9x the nearest finite value, i.e. effectively flat. NaN
+ * contributes nothing to the codebook and labels arbitrarily (in range).
+ *
+ * @param columns - Named columns pooled into 1D.
+ * @param k - Number of codebook entries (default 256).
+ * @param alpha - Density weight exponent. 0 = uniform (each bin equal),
+ * 0.5 = sqrt (balanced), 1.0 = standard MSE (dense regions dominate).
+ * Default 0.5.
+ * @returns Object with `centroids` (k Float32 values, sorted ascending) and
+ * `labels` (same column layout as input, each holding Uint8Array indices
+ * into the codebook).
+ */
+const quantize1dColumns = (columns: { name: string, data: TypedArray }[], k = 256, alpha = 0.5): QuantizedColumns => {
+    const numColumns = columns.length;
+    const numRows = numColumns > 0 ? columns[0].data.length : 0;
+
+    // pool all columns into a flat 1D array
+    const N = numRows * numColumns;
+
+    if (N === 0) {
+        return {
+            centroids: new Float32Array(k),
+            labels: columns.map(c => ({ name: c.name, data: new Uint8Array(numRows) }))
+        };
+    }
+
+    const data = new Float32Array(N);
+    for (let i = 0; i < numColumns; ++i) {
+        data.set(columns[i].data, i * numRows);
+    }
+
+    // gather the finite values for histogram binning (keep original for label
+    // assignment), noting any infinities for the reserved end slots
+    const sortedData = new Float32Array(N);
+    let numFinite = 0;
+    let hasNegInf = false;
+    let hasPosInf = false;
+    for (let i = 0; i < N; ++i) {
+        const v = data[i];
+        if (isFinite(v)) {
+            sortedData[numFinite++] = v;
+        } else if (v === -Infinity) {
+            hasNegInf = true;
+        } else if (v === Infinity) {
+            hasPosInf = true;
+        }
+    }
+    const finite = sortedData.subarray(0, numFinite);
+    finite.sort();
+
+    const INF_MARGIN = 20;
+    const loSlots = hasNegInf ? 1 : 0;
+    const hiSlots = hasPosInf ? 1 : 0;
+    const negInfCentroid = (numFinite > 0 ? finite[0] : 0) - INF_MARGIN;
+    const posInfCentroid = (numFinite > 0 ? finite[numFinite - 1] : 0) + INF_MARGIN;
+
+    const vMin = finite[0];
+    const vMax = finite[numFinite - 1];
+
+    // handle degenerate case where all values are identical
+    if (loSlots === 0 && hiSlots === 0 && vMax - vMin < 1e-20) {
+        const centroids = new Float32Array(k);
+        centroids.fill(vMin);
+
+        return {
+            centroids,
+            labels: columns.map(c => ({ name: c.name, data: new Uint8Array(numRows) }))
+        };
+    }
+
+    // centroid budget for the finite values (end slots reserved for infinities)
+    const kFinite = Math.max(0, k - loSlots - hiSlots);
+
+    let centroidValues: Float32Array;
+
+    if (numFinite === 0 || kFinite === 0) {
+        // no finite values at all (±Infinity/NaN-only input): sentinels only
+        centroidValues = new Float32Array(0);
+    } else if (vMax - vMin < 1e-20) {
+        // all finite values identical, with infinities alongside (the all-finite
+        // case returned above): a single centroid represents them
+        centroidValues = Float32Array.of(vMin);
+    } else {
+        centroidValues = quantizeFinite(finite, numFinite, kFinite, alpha);
+    }
+
+    const effectiveK = centroidValues.length;
+
+    // compose the final codebook, ascending: [-Inf sentinel][finite centroids,
+    // padded with the last][+Inf sentinel]
     const finalCentroids = new Float32Array(k);
-    finalCentroids.set(centroidValues);
-    for (let i = effectiveK; i < k; ++i) {
-        finalCentroids[i] = centroidValues[effectiveK - 1];
+    finalCentroids.set(centroidValues, loSlots);
+    const padValue = effectiveK > 0 ? centroidValues[effectiveK - 1] : (hasNegInf ? negInfCentroid : posInfCentroid);
+    for (let i = loSlots + effectiveK; i < k - hiSlots; ++i) {
+        finalCentroids[i] = padValue;
+    }
+    if (loSlots) {
+        finalCentroids[0] = negInfCentroid;
+    }
+    if (hiSlots) {
+        finalCentroids[k - 1] = posInfCentroid;
     }
 
     // assign each data point to nearest centroid via binary search

--- a/test/quantize-1d.test.mjs
+++ b/test/quantize-1d.test.mjs
@@ -1,0 +1,192 @@
+/**
+ * quantize1dColumns: the histogram/DP codebook quantizer.
+ *
+ * Focus: non-finite input robustness. `scale_* = -Infinity` (flat splats) and
+ * `opacity = +Infinity` are valid pipeline values (filterNaN deliberately
+ * keeps them), and a single one pooled into the histogram used to NaN-poison
+ * the entire codebook — serialized as JSON nulls, which SOG readers decode as
+ * log-scale 0 (unit-sized splats). Infinities must land on dedicated finite
+ * end centroids; finite values must quantize as before.
+ */
+
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { quantize1dColumns } from '../src/lib/spatial/quantize-1d-core.js';
+
+// deterministic rng for reproducible data
+const mulberry32 = (seed) => {
+    let a = seed >>> 0;
+    return () => {
+        a = (a + 0x6D2B79F5) >>> 0;
+        let t = a;
+        t = Math.imul(t ^ (t >>> 15), t | 1);
+        t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+};
+
+const assertAllFinite = (centroids) => {
+    for (let i = 0; i < centroids.length; i++) {
+        assert.ok(isFinite(centroids[i]), `centroid ${i} is ${centroids[i]}`);
+    }
+};
+
+const assertAscending = (centroids) => {
+    for (let i = 1; i < centroids.length; i++) {
+        assert.ok(centroids[i] >= centroids[i - 1], `centroids not ascending at ${i}`);
+    }
+};
+
+// decoded value of row i of column c
+const decode = (result, c, i) => result.centroids[result.labels[c].data[i]];
+
+describe('quantize1dColumns', () => {
+
+    it('quantizes finite columns accurately', () => {
+        const rand = mulberry32(1);
+        const n = 1000;
+        const cols = ['scale_0', 'scale_1', 'scale_2'].map(name => ({
+            name,
+            data: Float32Array.from({ length: n }, () => -12 + rand() * 11)
+        }));
+
+        const result = quantize1dColumns(cols);
+
+        assert.strictEqual(result.centroids.length, 256);
+        assertAllFinite(result.centroids);
+        assertAscending(result.centroids);
+        for (let c = 0; c < 3; c++) {
+            assert.strictEqual(result.labels[c].name, cols[c].name);
+            for (let i = 0; i < n; i++) {
+                assert.ok(Math.abs(decode(result, c, i) - cols[c].data[i]) < 11 / 64,
+                    `column ${c} row ${i} decodes too far from source`);
+            }
+        }
+    });
+
+    it('a single -Infinity does not poison the codebook', () => {
+        const rand = mulberry32(2);
+        const n = 1000;
+        const data = Float32Array.from({ length: n }, () => -12 + rand() * 11);
+        data[500] = -Infinity;
+
+        const result = quantize1dColumns([{ name: 'scale_0', data }]);
+
+        assertAllFinite(result.centroids);
+        assertAscending(result.centroids);
+        // the -Infinity row decodes to a sentinel below every finite value
+        assert.ok(decode(result, 0, 500) <= -12 - 10, 'flat sentinel not far below finite range');
+        // finite rows are unaffected
+        for (let i = 0; i < n; i++) {
+            if (i === 500) continue;
+            assert.ok(Math.abs(decode(result, 0, i) - data[i]) < 11 / 64);
+        }
+    });
+
+    it('flat splats (-Infinity scales pooled with other columns) keep a dedicated flat centroid', () => {
+        // the corrupt-publish shape: scale_2 mostly one constant with a band of
+        // -Infinity (flat) splats, scale_0/1 varied
+        const rand = mulberry32(3);
+        const n = 2000;
+        const s0 = Float32Array.from({ length: n }, () => -11.6 + rand() * 10.3);
+        const s1 = Float32Array.from({ length: n }, () => -13.5 + rand() * 12.1);
+        const s2 = new Float32Array(n).fill(-10.6);
+        for (let i = 0; i < n; i += 10) s2[i] = -Infinity;
+
+        const result = quantize1dColumns([
+            { name: 'scale_0', data: s0 }, { name: 'scale_1', data: s1 }, { name: 'scale_2', data: s2 }
+        ]);
+
+        assertAllFinite(result.centroids);
+        for (let i = 0; i < n; i++) {
+            const d = decode(result, 2, i);
+            if (i % 10 === 0) {
+                assert.ok(d <= -13.5 - 10, `flat splat ${i} decoded to ${d}`);
+            } else {
+                assert.ok(Math.abs(d - -10.6) < 0.1, `constant scale ${i} decoded to ${d}`);
+            }
+        }
+    });
+
+    it('+Infinity gets a dedicated top centroid', () => {
+        const rand = mulberry32(4);
+        const n = 1000;
+        const data = Float32Array.from({ length: n }, () => -5 + rand() * 11);
+        data[0] = Infinity;
+        data[999] = Infinity;
+
+        const result = quantize1dColumns([{ name: 'opacity', data }]);
+
+        assertAllFinite(result.centroids);
+        assertAscending(result.centroids);
+        assert.ok(decode(result, 0, 0) >= 6 + 10, 'top sentinel not far above finite range');
+        assert.ok(decode(result, 0, 999) >= 6 + 10);
+        for (let i = 1; i < 999; i++) {
+            assert.ok(Math.abs(decode(result, 0, i) - data[i]) < 11 / 64);
+        }
+    });
+
+    it('all -Infinity input yields a finite codebook', () => {
+        const data = new Float32Array(100).fill(-Infinity);
+
+        const result = quantize1dColumns([{ name: 'scale_0', data }]);
+
+        assertAllFinite(result.centroids);
+        for (let i = 0; i < 100; i++) {
+            assert.ok(decode(result, 0, i) <= -10);
+        }
+    });
+
+    it('NaN values do not poison the codebook', () => {
+        const rand = mulberry32(5);
+        const n = 1000;
+        const data = Float32Array.from({ length: n }, () => rand() * 4);
+        data[10] = NaN;
+        data[20] = NaN;
+
+        const result = quantize1dColumns([{ name: 'scale_0', data }]);
+
+        assertAllFinite(result.centroids);
+        for (let i = 0; i < n; i++) {
+            const label = result.labels[0].data[i];
+            assert.ok(label >= 0 && label < 256);
+            if (i !== 10 && i !== 20) {
+                assert.ok(Math.abs(decode(result, 0, i) - data[i]) < 4 / 64);
+            }
+        }
+    });
+
+    it('identical finite values keep the legacy all-zero labels', () => {
+        const data = new Float32Array(100).fill(-7.25);
+
+        const result = quantize1dColumns([{ name: 'scale_0', data }]);
+
+        for (let i = 0; i < 256; i++) {
+            assert.strictEqual(result.centroids[i], -7.25);
+        }
+        for (let i = 0; i < 100; i++) {
+            assert.strictEqual(result.labels[0].data[i], 0);
+        }
+    });
+
+    it('identical finite values alongside -Infinity keep both representable', () => {
+        const data = new Float32Array(100).fill(-10.6);
+        data[0] = -Infinity;
+
+        const result = quantize1dColumns([{ name: 'scale_2', data }]);
+
+        assertAllFinite(result.centroids);
+        assert.ok(decode(result, 0, 0) <= -10.6 - 10);
+        for (let i = 1; i < 100; i++) {
+            assert.strictEqual(decode(result, 0, i), Math.fround(-10.6));
+        }
+    });
+
+    it('empty input returns zeroed shapes', () => {
+        const result = quantize1dColumns([{ name: 'scale_0', data: new Float32Array(0) }]);
+
+        assert.strictEqual(result.centroids.length, 256);
+        assert.strictEqual(result.labels[0].data.length, 0);
+    });
+});

--- a/test/write-sog.test.mjs
+++ b/test/write-sog.test.mjs
@@ -18,6 +18,7 @@ import { fileURLToPath } from 'node:url';
 import { compareSummaries, computeStatsView } from './helpers/summary-compare.mjs';
 import { createTestDataTable, encodePlyBinary } from './helpers/test-utils.mjs';
 import { dataTableToChunkSource } from '../src/lib/compat/data-table.js';
+import { readFile as readRawFile } from '../src/lib/io/read/index.js';
 import {
     Transform, readSog,
     MemoryFileSystem, MemoryReadFileSystem, ZipReadFileSystem, WebPCodec
@@ -89,6 +90,50 @@ describe('writeSogSource: native SOG from a ChunkSource', () => {
 
         assert.strictEqual(decoded.numRows, dt.numRows);
         compareSummaries(await computeStatsView(decoded), expected, { tolerance: 0.5, allowExtraColumns: true });
+    });
+
+    it('flat splats (scale_2 = -Infinity, a valid filterNaN survivor) produce a finite codebook', async () => {
+        // Regression: one -Infinity pooled into the scales quantizer used to
+        // NaN-poison all 256 codebook entries (JSON nulls; readers decode
+        // log-scale 0 — unit-sized splats).
+        const dt = createTestDataTable(300);
+        dt.transform = Transform.PLY.clone();
+        const s2 = dt.getColumnByName('scale_2').data;
+        let numFlat = 0;
+        let finiteMin = Infinity;
+        for (let i = 0; i < s2.length; i++) {
+            if (i % 10 === 0) {
+                s2[i] = -Infinity;
+                numFlat++;
+            }
+        }
+        for (const name of ['scale_0', 'scale_1', 'scale_2']) {
+            for (const v of dt.getColumnByName(name).data) {
+                if (isFinite(v) && v < finiteMin) finiteMin = v;
+            }
+        }
+
+        const pool = createChunkDataPool();
+        const fs = new MemoryFileSystem();
+        await writeSogSource(dataTableToChunkSource(dt, pool.chunkSize), pool,
+            { filename: 'out.sog', bundle: true, iterations: 5, logging: 'silent' }, fs);
+
+        const rfs = new MemoryReadFileSystem();
+        rfs.set('out.sog', fs.results.get('out.sog'));
+        const zip = new ZipReadFileSystem(await rfs.createSource('out.sog'));
+        const meta = JSON.parse(new TextDecoder().decode(await readRawFile(zip, 'meta.json')));
+        assert.ok(meta.scales.codebook.every(v => typeof v === 'number' && isFinite(v)),
+            'scales codebook must contain only finite numbers');
+
+        // decode: exactly the flat splats come back below the finite range
+        const decoded = await readSog(zip, 'meta.json');
+        const out = decoded.getColumnByName('scale_2').data;
+        let decodedFlat = 0;
+        for (const v of out) {
+            assert.ok(isFinite(v), `decoded scale ${v} not finite`);
+            if (v <= finiteMin - 10) decodedFlat++;
+        }
+        assert.strictEqual(decodedFlat, numFlat);
     });
 });
 


### PR DESCRIPTION
## Problem

Writing SOG (or streamed SOG via the LOD writer) for a scene containing flat splats — gaussians with `scale_* = -Infinity`, e.g. 2DGS-style exports where one axis is collapsed to zero (log 0) — silently produces a corrupt file: all 256 entries of `meta.json`'s `scales.codebook` are `null` and `scales.webp` is a ~400-byte constant texture. These are valid pipeline values (`--filter-nan` deliberately keeps `-Infinity` scales and `+Infinity` opacity), so affected scenes pass filtering and publish corrupt. Readers coerce the JSON `null`s to 0, decoding every gaussian at log-scale 0 (unit scale), which renders as catastrophic overdraw and can effectively hang the viewer on multi-million-splat scenes.

## Cause

`quantize1dColumns` pools the scale columns and derives `vMin`/`vMax` from the raw data. A single `-Infinity` makes `vRange` infinite, so every histogram position computes to NaN, all bins stay empty, `effectiveK` collapses to 0, and the padding loop reads `centroidValues[-1]` — yielding 256 NaN centroids, serialized to JSON as `null`.

## Fix

- The histogram/DP core now runs over finite values only (moved unchanged into a `quantizeFinite` helper).
- When `-Infinity`/`+Infinity` values are present, each gets a dedicated end centroid at a finite sentinel 20 units outside the finite range — JSON-safe, and log-scale consumers decode `exp(min - 20)` ≈ 2e-9x the smallest real scale, i.e. effectively flat. The existing nearest-centroid binary search routes infinities to these slots without changes.
- NaN input no longer poisons the codebook either: excluded from binning, labels stay in range.
- All-finite input is byte-identical to the previous behavior (the legacy writer-parity test still passes).

## Testing

- New `test/quantize-1d.test.mjs`: finite accuracy, single/many/all `-Infinity`, `+Infinity`, NaN, degenerate constant inputs, and legacy label behavior for all-identical values.
- New write-sog round-trip test: flat splats produce an all-finite codebook, and exactly the flat splats decode below the finite range.
- Full suite passes (734 tests), lint clean.
- Verified on a real 8.9M-gaussian PLY containing ~940k flat splats: `scales.webp` goes from 424 B (corrupt) to 1.6 MB, codebook 256/256 finite, flat splats decode flat.