### PR TITLE
Drop gaussians with a zero-norm rotation quaternion in --filter-nan

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ Actions execute in the order specified and can be repeated. Any action may appea
 -r, --rotate           <x,y,z>          Rotate Gaussians by Euler angles (x, y, z), in degrees
 -s, --scale            <factor>         Uniformly scale Gaussians by factor
 -H, --filter-harmonics <0|1|2|3>        Remove spherical harmonic bands > n
--N, --filter-nan                        Remove Gaussians with NaN values and most Inf values;
+-N, --filter-nan                        Remove Gaussians with NaN values, most Inf values, or a
+                                          zero-norm (unrenderable) rotation quaternion;
                                           retains +Infinity in opacity and -Infinity in scale_*
 -B, --filter-box       <x,y,z,X,Y,Z>    Remove Gaussians outside box (min, max corners)
 -S, --filter-sphere    <x,y,z,radius>   Remove Gaussians outside sphere (center, radius)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -782,7 +782,7 @@ ACTIONS (executed in order; can be repeated)
     -r, --rotate           <x,y,z>          Rotate Gaussians by Euler angles, in degrees
     -s, --scale            <factor>         Uniformly scale Gaussians by factor
     -H, --filter-harmonics <0|1|2|3>        Remove spherical harmonic bands > n
-    -N, --filter-nan                        Remove Gaussians with NaN values and most Inf values
+    -N, --filter-nan                        Remove Gaussians with NaN values, most Inf values, or a zero-norm rotation
     -B, --filter-box       <x,y,z,X,Y,Z>    Remove Gaussians outside box (min, max corners)
     -S, --filter-sphere    <x,y,z,radius>   Remove Gaussians outside sphere
     -V, --filter-value     <name,cmp,value> Keep Gaussians where <name> <cmp> <value>;

--- a/src/lib/ops/filter-mask.ts
+++ b/src/lib/ops/filter-mask.ts
@@ -94,7 +94,11 @@ const selectRows = async (
 /**
  * Remove gaussians containing NaN or Infinity. Mirrors `processDataTable`'s
  * `filterNaN`: any non-finite value drops the row, except `opacity` may be
- * `+Infinity` and `scale_*` may be `-Infinity`.
+ * `+Infinity` and `scale_*` may be `-Infinity`. Rows whose rotation quaternion
+ * is all-zero are also dropped: a zero-norm quaternion cannot be normalized,
+ * so the gaussian is unrenderable (seen in zero-padded exporter output, where
+ * whole rows of zeros otherwise survive as visible alpha-0.5 splats at the
+ * origin).
  * @param src - The source to filter (LOD 0).
  * @param pool - Pool for the temporary read buffers.
  * @returns Ascending indices of the surviving gaussians.
@@ -121,6 +125,9 @@ const filterNaNRows = (src: ChunkSource, pool: ChunkDataPool): Promise<Uint32Arr
                 const o = r * 8;
                 if (!isFinite(geoF[o]) || !isFinite(geoF[o + 1]) || !isFinite(geoF[o + 2]) || !isFinite(geoF[o + 3])) {
                     return false; // rotation
+                }
+                if (geoF[o] === 0 && geoF[o + 1] === 0 && geoF[o + 2] === 0 && geoF[o + 3] === 0) {
+                    return false; // zero-norm rotation: unnormalizable, unrenderable
                 }
                 for (let e = 4; e <= 6; e++) {
                     const v = geoF[o + e];

--- a/src/lib/process.ts
+++ b/src/lib/process.ts
@@ -220,7 +220,7 @@ type ProcessOptions = {
  * - `translate` - Move splats by a Vec3 offset
  * - `rotate` - Rotate splats by Euler angles (degrees)
  * - `scale` - Uniformly scale splats
- * - `filterNaN` - Remove splats with NaN/Inf values
+ * - `filterNaN` - Remove splats with NaN/Inf values or a zero-norm rotation
  * - `filterByValue` - Keep splats matching a column condition
  * - `filterBands` - Remove spherical harmonic bands above a threshold
  * - `filterBox` - Keep splats within a bounding box
@@ -318,8 +318,15 @@ const processDataTable = async (dataTable: DataTable, processActions: ProcessAct
                 const infOk = new Set(['opacity']);
                 const negInfOk = new Set(['scale_0', 'scale_1', 'scale_2']);
                 const columnNames = result.columnNames;
+                const hasRotation = ['rot_0', 'rot_1', 'rot_2', 'rot_3'].every(c => columnNames.includes(c));
 
                 const predicate = (row: any) => {
+                    // a zero-norm rotation quaternion cannot be normalized, so the
+                    // gaussian is unrenderable (zero-padded exporter rows otherwise
+                    // survive as visible alpha-0.5 splats at the origin)
+                    if (hasRotation && row.rot_0 === 0 && row.rot_1 === 0 && row.rot_2 === 0 && row.rot_3 === 0) {
+                        return false;
+                    }
                     for (const key of columnNames) {
                         const value = row[key];
                         if (!isFinite(value)) {

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -185,3 +185,29 @@ describe('CLI decimate (terminal PLY restriction)', () => {
         assert.strictEqual(written, Math.round(inputCount / 2), `50% of ${inputCount}`);
     });
 });
+
+describe('CLI filter-nan (zero-norm rotation)', () => {
+    it('drops all-zero rotation rows through the source path', async () => {
+        const { mkdtemp, readFile: readFileFs, rm, writeFile } = await import('node:fs/promises');
+        const { tmpdir } = await import('node:os');
+        const { join } = await import('node:path');
+        const { createTestDataTable, encodePlyBinary } = await import('./helpers/test-utils.mjs');
+
+        const dataTable = createTestDataTable(4);
+        // createTestDataTable writes identity quaternions; zeroing rot_0 makes
+        // row 2 all-zero (rot_1..3 are already 0) -- the zero-padded-PLY shape
+        dataTable.getColumnByName('rot_0').data[2] = 0;
+
+        const dir = await mkdtemp(join(tmpdir(), 'st-filter-nan-cli-'));
+        const inPath = join(dir, 'in.ply');
+        const outPath = join(dir, 'out.ply');
+        await writeFile(inPath, encodePlyBinary(dataTable));
+
+        const result = await runCli([inPath, '--filter-nan', outPath]);
+        assert.strictEqual(result.code, 0, `CLI failed:\n${result.stderr}\n${result.stdout}`);
+
+        const header = (await readFileFs(outPath)).subarray(0, 512).toString('latin1');
+        await rm(dir, { recursive: true, force: true });
+        assert.match(header, /element vertex 3\n/, 'zero-norm rotation row should be dropped');
+    });
+});

--- a/test/process.test.mjs
+++ b/test/process.test.mjs
@@ -44,6 +44,16 @@ describe('processDataTable', function () {
             const result = await processDataTable(dataTable, [{ kind: 'filterNaN' }]);
             assert.strictEqual(result.numRows, 2, 'Should remove NaN row');
         });
+
+        it('should remove rows with a zero-norm rotation quaternion', async function () {
+            const dataTable = createTestDataTable(4);
+            // createTestDataTable writes identity quaternions; zeroing rot_0
+            // makes row 2 all-zero (rot_1..3 are already 0)
+            dataTable.getColumnByName('rot_0').data[2] = 0;
+
+            const result = await processDataTable(dataTable, [{ kind: 'filterNaN' }]);
+            assert.strictEqual(result.numRows, 3, 'Zero-norm rotation row should be removed');
+        });
     });
 
     describe('filterByValue', function () {


### PR DESCRIPTION
A real-world Postshot v1.1.0 PLY export declared 889,537 vertices but contained real data in only the first row — the remaining 889,536 rows were entirely zero-filled. Those rows sail through the existing filters: every value is finite, so `--filter-nan` keeps them, and opacity filters compare in linear space, so a raw (logit) opacity of 0 reads as a perfectly visible alpha of 0.5. The result published "successfully" as hundreds of thousands of identical gaussians stacked at the origin (alpha 0.5, scale e⁰ = 1), rendering as giant blobs with pathological overdraw — the downstream thumbnail render ground for over an hour on it.

The tell that these rows are garbage rather than unusual-but-valid content is the rotation: a quaternion of (0, 0, 0, 0) has zero norm and cannot be normalized, so the gaussian has no defined orientation and is unrenderable. No exporter produces it legitimately, and every packed rotation format decodes to a nonzero component, so an exact all-zero test cannot drop valid data.

`--filter-nan` (the validity filter) now also drops rows whose rotation quaternion is exactly zero, in both filter implementations, kept in sync per the existing contract:

- `filterNaNRows` (chunk-source path) rejects all-zero rotation in the geometric layer
- `processDataTable`'s `filterNaN` does the same, guarded on the rot_0..3 columns being present
- README, CLI help, and lib docs updated to state the extended contract

Tests: a `processDataTable` unit test and an end-to-end CLI test (zero-quat row in a binary PLY → output header count excludes it) covering the source path. Full suite passes (736/736). Against the original 210MB export, the CLI now reports `1 gaussians` and writes a consistent count/bounds/texture set for the single real splat.