### PR TITLE
Fall back when range response size is unavailable

### DIFF
--- a/src/lib/io/read/url-file-system.ts
+++ b/src/lib/io/read/url-file-system.ts
@@ -277,21 +277,16 @@ class UrlReadFileSystem implements ReadFileSystem {
         // Probe to check if Range requests are supported
         const { rangeSupported, size: probeSize } = await probeRangeSupport(url);
 
-        if (!rangeSupported) {
-            // Fall back to downloading the entire file into memory
+        if (!rangeSupported || probeSize === undefined) {
+            // Range reads require the resource's decoded byte size for seeking.
+            // If Content-Range is unavailable (commonly because CORS does not
+            // expose it), a HEAD Content-Length may describe a compressed
+            // representation and cannot be used safely.
             return await this.createMemorySource(url, progress);
         }
 
         // Range is supported - use streaming approach
-        // If we got size from probe, use it; otherwise try HEAD request
-        let size = probeSize;
-        if (size === undefined) {
-            const headResponse = await fetch(url, { method: 'HEAD' });
-            if (headResponse.ok) {
-                const contentLength = headResponse.headers.get('Content-Length');
-                size = contentLength ? parseInt(contentLength, 10) : undefined;
-            }
-        }
+        const size = probeSize;
 
         // Report initial progress
         if (progress) {

--- a/test/url-file-system.test.mjs
+++ b/test/url-file-system.test.mjs
@@ -60,14 +60,17 @@ WebPCodec.wasmUrl = join(__dirname, '..', 'lib', 'webp.wasm');
  *
  * @param {Record<string, Uint8Array>} routes - map of pathname (e.g. `/minimal.splat`) to body
  * @param {boolean} supportRange - if true, respect Range headers (206); else always 200
- * @returns {Promise<{ url: string, requests: string[], close: () => Promise<void> }>}
+ * @param {boolean} exposeRangeSize - if false, omit Content-Range from 206 responses
+ * @returns {Promise<{ url: string, requests: string[], requestMethods: string[], close: () => Promise<void> }>}
  */
-const startServer = (routes, supportRange) => {
+const startServer = (routes, supportRange, exposeRangeSize = true) => {
     return new Promise((resolve) => {
         const requests = [];
+        const requestMethods = [];
         const server = http.createServer((req, res) => {
             // Track the full request line so tests can assert on querystrings too.
             requests.push(req.url);
+            requestMethods.push(req.method);
 
             // Match on pathname only; querystring/fragment are ignored for routing
             // (but the server records them via `requests` for assertions).
@@ -86,12 +89,15 @@ const startServer = (routes, supportRange) => {
                     const start = parseInt(match[1], 10);
                     const end = match[2] ? parseInt(match[2], 10) : body.length - 1;
                     const slice = body.subarray(start, end + 1);
-                    res.writeHead(206, {
+                    const headers = {
                         'Content-Type': 'application/octet-stream',
                         'Content-Length': String(slice.length),
-                        'Content-Range': `bytes ${start}-${end}/${body.length}`,
                         'Accept-Ranges': 'bytes'
-                    });
+                    };
+                    if (exposeRangeSize) {
+                        headers['Content-Range'] = `bytes ${start}-${end}/${body.length}`;
+                    }
+                    res.writeHead(206, headers);
                     res.end(slice);
                     return;
                 }
@@ -109,6 +115,7 @@ const startServer = (routes, supportRange) => {
             resolve({
                 url: `http://127.0.0.1:${port}`,
                 requests,
+                requestMethods,
                 close: () => new Promise(r => server.close(() => r()))
             });
         });
@@ -157,6 +164,23 @@ describe('UrlReadFileSystem (CLI integration)', () => {
             });
             assert.strictEqual(tables.length, 1);
             assert.strictEqual(tables[0].numRows, 4);
+        } finally {
+            await server.close();
+        }
+    });
+
+    it('falls back to memory when the range response size is unavailable', async () => {
+        const server = await startServer({ '/minimal.splat': splatBody }, true, false);
+        try {
+            const fileSystem = new UrlReadFileSystem();
+            const source = await fileSystem.createSource(`${server.url}/minimal.splat`);
+            try {
+                const bytes = await source.read().readAll();
+                assert.deepStrictEqual(Array.from(bytes), Array.from(splatBody));
+                assert.ok(!server.requestMethods.includes('HEAD'), 'must not use a potentially encoded HEAD Content-Length');
+            } finally {
+                source.close();
+            }
         } finally {
             await server.close();
         }


### PR DESCRIPTION
## Summary
- Fall back to downloading files into memory when `Content-Range` is unavailable.
- Avoid using potentially compressed `HEAD Content-Length` values for byte-range seeking.
- Add regression coverage for cross-origin range responses without an exposed size.

## Testing
- `npm run lint`
- `npm test`