### PR TITLE
Load pre-v1 lod-meta.json; report input format and extra columns in --info/--stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Actions execute in the order specified and can be repeated. Any action may appea
 -p, --params           <key=val,...>    Pass parameters to .mjs generator script
 -l, --tag-lod          <n>              Tag the Gaussians with LOD level n (n >= 0, or -1 for environment)
     --stats            [text|json]      Print file info, per-column statistics and the fill/overdraw ratio to stdout. Default: text
-    --info             [text|json]      Print structural metadata (per-LOD counts, columns) to stdout. Default: text
+    --info             [text|json]      Print structural metadata (format, per-LOD counts, extra columns) to stdout. Default: text
 -m, --morton-order                      Reorder Gaussians by Morton code (Z-order curve)
 ```
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -796,7 +796,7 @@ ACTIONS (executed in order; can be repeated)
     -p, --params           <key=val,...>    Pass parameters to .mjs generator script
     -l, --tag-lod          <n>              Tag the Gaussians with LOD level n (n >= 0, or -1 for environment)
         --stats            [text|json]      Print file info, per-column statistics and the fill/overdraw ratio to stdout. Default: text
-        --info             [text|json]      Print structural metadata (per-LOD counts, columns) to stdout. Default: text
+        --info             [text|json]      Print structural metadata (format, per-LOD counts, extra columns) to stdout. Default: text
     -m, --morton-order                      Reorder Gaussians by Morton code (Z-order curve)
 
 GENERAL
@@ -1107,7 +1107,11 @@ const main = async () => {
             return cachedDevice;
         };
 
-        const processOptions = deviceCreator ? { createDevice: deviceCreator } : undefined;
+        // A single input has an unambiguous format for --info/--stats to report;
+        // with multiple (combined) inputs the format is omitted.
+        const soleInputFormat = inputArgs.length === 1 ?
+            getInputFormat(resolveInput(inputArgs[0].filename).classifyName) : undefined;
+        const processOptions = { createDevice: deviceCreator, sourceFormat: soleInputFormat };
 
         // declare phase total: one Read phase per input + one Write phase
         const phaseTotal = inputArgs.length + (isNullOutput ? 0 : 1);

--- a/src/lib/process-source.ts
+++ b/src/lib/process-source.ts
@@ -43,12 +43,14 @@ const SOURCE_ACTION_KINDS: ReadonlySet<ProcessAction['kind']> = new Set([
  * @param source - The input source.
  * @param actions - Actions to apply in order.
  * @param pool - Pool for the filter passes' temporary read buffers.
+ * @param options - Process options; `sourceFormat` is reported by `info`/`stats`.
  * @returns The processed source (a view chain over `source`).
  */
 const processSource = async (
     source: ChunkSource,
     actions: ProcessAction[],
-    pool: ChunkDataPool
+    pool: ChunkDataPool,
+    options?: ProcessOptions
 ): Promise<ChunkSource> => {
     let src = source;
 
@@ -96,12 +98,12 @@ const processSource = async (
                 // source's current, unbaked values — matching processDataTable
                 // for every ordering except a transform-baking filterByValue
                 // immediately followed by stats (a rare case).
-                logger.output(formatSourceStats(src.meta, await computeSourceStats(src, pool), action.format));
+                logger.output(formatSourceStats(src.meta, await computeSourceStats(src, pool), action.format, options?.sourceFormat));
                 break;
             case 'info':
                 // Structural metadata only (meta-level) — no materialization; the
                 // source passes through unchanged.
-                logger.output(formatSourceInfo(src.meta, action.format));
+                logger.output(formatSourceInfo(src.meta, action.format, options?.sourceFormat));
                 break;
             case 'param':
                 break; // generator params: no-op here, as in processDataTable
@@ -145,7 +147,7 @@ const processSourceBridged = async (
         }
         const run = actions.slice(i, j);
         if (chunkNative) {
-            src = await processSource(src, run, pool);
+            src = await processSource(src, run, pool, options);
         } else {
             // DataTable island: materialize the current (streaming) source, apply
             // the run on the table, and re-bridge back to a source to keep going.

--- a/src/lib/process.ts
+++ b/src/lib/process.ts
@@ -5,6 +5,7 @@ import { dataTableToChunkSource, materializeToDataTable } from './compat/data-ta
 import { Column, DataTable, sortMortonOrder, convertToSpace, getSHBands } from './data-table';
 import { decimateSource } from './decimate';
 import { computeSourceStats } from './ops';
+import { type InputFormat } from './read';
 import { formatSourceInfo, formatSourceStats } from './source-info';
 import type { DeviceCreator } from './types';
 import { fmtCount, type Group, logger, Transform } from './utils';
@@ -211,6 +212,8 @@ type FilterCluster = {
 type ProcessOptions = {
     /** Function to create a GPU device (required for filterFloaters, filterCluster). */
     createDevice?: DeviceCreator;
+    /** Input format reported by the `info`/`stats` actions; omitted when unset. */
+    sourceFormat?: InputFormat;
 };
 
 /**
@@ -488,13 +491,13 @@ const processDataTable = async (dataTable: DataTable, processActions: ProcessAct
                 // stats pass; raw/unbaked values, exactly as the table holds them.
                 const src = dataTableToChunkSource(result);
                 const stats = await computeSourceStats(src, createChunkDataPool());
-                logger.output(formatSourceStats(src.meta, stats, processAction.format));
+                logger.output(formatSourceStats(src.meta, stats, processAction.format, options?.sourceFormat));
                 await src.close();
                 break;
             }
             case 'info': {
                 const src = dataTableToChunkSource(result);
-                logger.output(formatSourceInfo(src.meta, processAction.format));
+                logger.output(formatSourceInfo(src.meta, processAction.format, options?.sourceFormat));
                 await src.close();
                 break;
             }

--- a/src/lib/read.ts
+++ b/src/lib/read.ts
@@ -1,5 +1,5 @@
-import { type ChunkLayer, type ChunkSource, type ChunkSourceMetadata, type SHBands, createChunkDataPool, hasGaussianLayers, orderedLayers } from './chunk';
-import { columnNamesFromMeta, dataTableToChunkSource } from './compat/data-table';
+import { type ChunkLayer, type ChunkSource, type ChunkSourceMetadata, type ExtraColumn, type SHBands, createChunkDataPool, hasGaussianLayers, orderedLayers } from './chunk';
+import { dataTableToChunkSource } from './compat/data-table';
 import { ReadFileSystem, ZipReadFileSystem } from './io/read';
 import { readKsplat, readMjs, readPly, readSogSource, readSplat, readSpz, statSogSource } from './readers';
 import { readLccSource } from './readers/read-lcc';
@@ -212,8 +212,12 @@ type FileInfo = {
     shBands: SHBands;
     /** Layers the file exposes, in canonical order. */
     layers: ChunkLayer[];
-    /** Canonical column names the file exposes. */
-    columns: string[];
+    /**
+     * Extra (non-standard `other`-layer) columns, with their storage type. The
+     * standard columns are fully implied by `layers` + `shBands`; only these
+     * carry additional information.
+     */
+    extraColumns: ExtraColumn[];
 };
 
 // The subset of ChunkSourceMetadata a FileInfo is built from — satisfied by a
@@ -229,7 +233,7 @@ const buildFileInfo = (format: InputFormat, meta: MetaSummary): FileInfo => ({
     lodCounts: [...meta.lodCounts],
     shBands: meta.shBands,
     layers: orderedLayers(meta.availableLayers),
-    columns: columnNamesFromMeta(meta)
+    extraColumns: [...meta.extraColumns]
 });
 
 /**

--- a/src/lib/readers/read-lod.ts
+++ b/src/lib/readers/read-lod.ts
@@ -16,9 +16,9 @@ type LodNode = {
 };
 
 type LodMeta = {
-    version: number;
-    count: number;
-    counts: number[];
+    version?: number;
+    count?: number;
+    counts?: number[];
     lodLevels: number;
     environment?: string;
     filenames: string[];
@@ -34,14 +34,18 @@ const parseLodMeta = (text: string, filename: string): LodMeta => {
         throw new Error(`Failed to parse lod-meta.json: ${filename}: ${reason}`);
     }
 
-    if (meta.version !== 1) {
+    // Accept pre-versioning manifests (no `version`) alongside v1: the LOD
+    // writer only began stamping `version`/`count`/`counts` in #261, so older
+    // published assets omit them (mirrors read-sog's legacy V1 fallback).
+    if (meta.version !== undefined && meta.version !== 1) {
         throw new Error(`Unsupported lod-meta.json version: ${meta.version}`);
     }
     if (!Number.isInteger(meta.lodLevels) || meta.lodLevels <= 0) {
         throw new Error(`Invalid lod-meta.json lodLevels: ${filename}`);
     }
-    if (!Array.isArray(meta.counts) || meta.counts.length !== meta.lodLevels ||
-        meta.counts.some(count => !Number.isInteger(count) || count < 0)) {
+    if (meta.counts !== undefined &&
+        (!Array.isArray(meta.counts) || meta.counts.length !== meta.lodLevels ||
+        meta.counts.some(count => !Number.isInteger(count) || count < 0))) {
         throw new Error(`Invalid lod-meta.json counts: ${filename}`);
     }
     if (!Array.isArray(meta.filenames) || meta.filenames.some(name => typeof name !== 'string')) {
@@ -80,12 +84,16 @@ const collectFilesByLod = (meta: LodMeta, filename: string): Map<number, Map<num
     };
     traverse(meta.tree);
 
-    for (let lod = 0; lod < meta.lodLevels; lod++) {
-        const count = [...(result.get(lod)?.values() ?? [])].reduce((sum, value) => sum + value, 0);
-        if (count !== meta.counts[lod]) {
-            throw new Error(
-                `lod-meta.json LOD ${lod} count mismatch: expected ${meta.counts[lod]}, found ${count}`
-            );
+    // Pre-v1 manifests omit `counts`; the per-LOD totals are then taken from the
+    // tree alone (and each SOG unit's real count is still checked at decode time).
+    if (meta.counts !== undefined) {
+        for (let lod = 0; lod < meta.lodLevels; lod++) {
+            const count = [...(result.get(lod)?.values() ?? [])].reduce((sum, value) => sum + value, 0);
+            if (count !== meta.counts[lod]) {
+                throw new Error(
+                    `lod-meta.json LOD ${lod} count mismatch: expected ${meta.counts[lod]}, found ${count}`
+                );
+            }
         }
     }
 

--- a/src/lib/source-info.ts
+++ b/src/lib/source-info.ts
@@ -56,15 +56,16 @@ const sourceInfoLines = (meta: ChunkSourceMetadata, format?: InputFormat): strin
         `lod counts: ${meta.lodCounts.join(', ')}`,
         `sh bands: ${meta.shBands}`,
         `layers: ${orderedLayers(meta.availableLayers).join(', ')}`,
-        `extra columns: ${meta.extraColumns.map(e => `${e.name} (${e.type})`).join(', ')}`
+        `extra columns: ${meta.extraColumns.length > 0 ? meta.extraColumns.map(e => `${e.name} (${e.type})`).join(', ') : '(none)'}`
     ];
 };
 
 /**
- * Render a source's structural metadata for the `info` action — the gaussian
- * verdict ({@link hasGaussianLayers}: `false` for e.g. a plain point-cloud PLY),
- * per-LOD counts, SH bands, available layers, and the canonical column list,
- * all from `meta` (no data read).
+ * Render a source's structural metadata for the `info` action — the detected
+ * input format (when known), the gaussian verdict ({@link hasGaussianLayers}:
+ * `false` for e.g. a plain point-cloud PLY), per-LOD counts, SH bands, available
+ * layers, and the extra (non-standard `other`-layer) columns, all from `meta`
+ * (no data read).
  * @param meta - The source metadata.
  * @param format - Output format. Default: 'text'
  * @param sourceFormat - Detected input format; reported when provided.

--- a/src/lib/source-info.ts
+++ b/src/lib/source-info.ts
@@ -1,6 +1,6 @@
 import { type ChunkSourceMetadata, hasGaussianLayers, orderedLayers } from './chunk';
-import { columnNamesFromMeta } from './compat/data-table';
 import { type LodStats, type SourceStats } from './ops';
+import { type InputFormat } from './read';
 import { forwardTransforms } from './value-transforms';
 
 /**
@@ -22,35 +22,41 @@ const stringifyCompact = (value: unknown): string => {
 
 /**
  * Build the info object — the JSON form of a source's structural metadata and
- * the shared head of the stats JSON output.
+ * the shared head of the stats JSON output. `extraColumns` lists only the
+ * non-standard (`other`-layer) columns; the standard columns are fully implied
+ * by `layers` + `shBands`.
  * @param meta - The source metadata.
+ * @param format - Detected input format; included only when provided.
  * @returns The info fields.
  */
-const buildSourceInfo = (meta: ChunkSourceMetadata) => ({
+const buildSourceInfo = (meta: ChunkSourceMetadata, format?: InputFormat) => ({
+    ...(format ? { format } : {}),
     gaussian: hasGaussianLayers(meta.availableLayers),
     numGaussians: meta.numGaussians,
     numLods: meta.numLods,
     lodCounts: [...meta.lodCounts],
     shBands: meta.shBands,
     layers: orderedLayers(meta.availableLayers),
-    columns: columnNamesFromMeta(meta)
+    extraColumns: meta.extraColumns.map(e => ({ name: e.name, type: e.type }))
 });
 
 /**
  * The info text lines — the text form of {@link buildSourceInfo}, mirroring
  * its fields one-to-one with exact (unabbreviated) counts.
  * @param meta - The source metadata.
+ * @param format - Detected input format; emitted only when provided.
  * @returns One `key: value` line per field.
  */
-const sourceInfoLines = (meta: ChunkSourceMetadata): string[] => {
+const sourceInfoLines = (meta: ChunkSourceMetadata, format?: InputFormat): string[] => {
     return [
+        ...(format ? [`format: ${format}`] : []),
         `gaussian: ${hasGaussianLayers(meta.availableLayers) ? 'yes' : 'no'}`,
         `gaussians: ${meta.numGaussians}`,
         `lods: ${meta.numLods}`,
         `lod counts: ${meta.lodCounts.join(', ')}`,
         `sh bands: ${meta.shBands}`,
         `layers: ${orderedLayers(meta.availableLayers).join(', ')}`,
-        `columns: ${columnNamesFromMeta(meta).join(', ')}`
+        `extra columns: ${meta.extraColumns.map(e => `${e.name} (${e.type})`).join(', ')}`
     ];
 };
 
@@ -61,13 +67,14 @@ const sourceInfoLines = (meta: ChunkSourceMetadata): string[] => {
  * all from `meta` (no data read).
  * @param meta - The source metadata.
  * @param format - Output format. Default: 'text'
+ * @param sourceFormat - Detected input format; reported when provided.
  * @returns A text or JSON block for `logger.output`.
  */
-const formatSourceInfo = (meta: ChunkSourceMetadata, format: OutputFormat = 'text'): string => {
+const formatSourceInfo = (meta: ChunkSourceMetadata, format: OutputFormat = 'text', sourceFormat?: InputFormat): string => {
     if (format === 'json') {
-        return stringifyCompact(buildSourceInfo(meta));
+        return stringifyCompact(buildSourceInfo(meta, sourceFormat));
     }
-    return sourceInfoLines(meta).join('\n');
+    return sourceInfoLines(meta, sourceFormat).join('\n');
 };
 
 // Display transform: raw values map to user-friendly space for output
@@ -144,17 +151,18 @@ const statsTable = (lod: LodStats): string[] => {
  * @param meta - The source metadata.
  * @param stats - The computed per-LOD statistics.
  * @param format - Output format. Default: 'text'
+ * @param sourceFormat - Detected input format; reported when provided.
  * @returns A text or JSON block for `logger.output`.
  */
-const formatSourceStats = (meta: ChunkSourceMetadata, stats: SourceStats, format: OutputFormat = 'text'): string => {
+const formatSourceStats = (meta: ChunkSourceMetadata, stats: SourceStats, format: OutputFormat = 'text', sourceFormat?: InputFormat): string => {
     if (format === 'json') {
         return stringifyCompact({
-            ...buildSourceInfo(meta),
+            ...buildSourceInfo(meta, sourceFormat),
             stats: stats.lods.map(displayLodStats)
         });
     }
 
-    const lines = sourceInfoLines(meta);
+    const lines = sourceInfoLines(meta, sourceFormat);
     for (const lod of stats.lods) {
         lines.push('');
         if (stats.lods.length > 1) {

--- a/test/file-info.test.mjs
+++ b/test/file-info.test.mjs
@@ -181,6 +181,7 @@ describe('info process action', () => {
         assert.match(outputs[0], /gaussians: 20/);
         assert.match(outputs[0], /sh bands: 1/);
         assert.match(outputs[0], /layers: position, geometric, color/);
+        assert.match(outputs[0], /\nextra columns: \(none\)$/); // sentinel when there are no extras
     });
 
     it('emits exact counts, never abbreviated', async () => {

--- a/test/file-info.test.mjs
+++ b/test/file-info.test.mjs
@@ -4,8 +4,8 @@
  *
  *  - columnNamesFromMeta reproduces materializeToDataTable's canonical column
  *    order from `meta` alone (per SH-band count, extras, and partial layer sets).
- *  - readFileInfo reports counts/columns/shBands without decoding gaussian data;
- *    a truncated file is rejected by the reader's size guard (throws).
+ *  - readFileInfo reports format/counts/layers/extra-columns/shBands without
+ *    decoding gaussian data; a truncated file is rejected by the size guard.
  *  - the `info` action passes the source through unchanged (meta-only).
  */
 
@@ -92,8 +92,7 @@ describe('readFileInfo', () => {
         assert.deepStrictEqual(info.lodCounts, [50]);
         assert.strictEqual(info.shBands, 1);
         assert.deepStrictEqual(info.layers, ['position', 'geometric', 'color']);
-        assert.deepStrictEqual(info.columns.slice(0, STANDARD.length), STANDARD);
-        assert.strictEqual(info.columns.length, STANDARD.length + 9); // + 9 f_rest for 1 band
+        assert.deepStrictEqual(info.extraColumns, []); // all standard columns, nothing extra
     });
 
     it('reports gaussian: false for a non-splat (point cloud) PLY', async () => {
@@ -111,7 +110,7 @@ describe('readFileInfo', () => {
         });
         assert.strictEqual(info.gaussian, false);
         assert.deepStrictEqual(info.layers, ['position', 'other']);
-        assert.deepStrictEqual(info.columns, ['x', 'y', 'z', 'red', 'green', 'blue']);
+        assert.deepStrictEqual(info.extraColumns.map(e => e.name), ['red', 'green', 'blue']);
     });
 
     it('rejects a truncated PLY via the reader size guard', async () => {
@@ -133,11 +132,11 @@ describe('readFileInfo', () => {
         assert.strictEqual(info.gaussian, true);
         assert.strictEqual(info.numGaussians, 4);
         assert.strictEqual(info.shBands, 0);
-        assert.deepStrictEqual(info.columns, STANDARD);
+        assert.deepStrictEqual(info.extraColumns, []);
 
         const [full] = await readFile({ filename: 'minimal.splat', inputFormat: 'splat', options, params: [], fileSystem });
         assert.strictEqual(info.numGaussians, full.meta.numGaussians);
-        assert.deepStrictEqual(info.columns, columnNamesFromMeta(full.meta));
+        assert.deepStrictEqual(info.extraColumns, [...full.meta.extraColumns]);
         await full.close();
     });
 
@@ -147,7 +146,7 @@ describe('readFileInfo', () => {
         const info = await readFileInfo({ filename: 'minimal.spz', inputFormat: 'spz', options, params: [], fileSystem });
         assert.strictEqual(info.format, 'spz');
         assert.ok(info.numGaussians > 0);
-        assert.ok(info.columns.includes('x') && info.columns.includes('opacity'));
+        assert.ok(info.layers.includes('position') && info.layers.includes('geometric'));
     });
 });
 
@@ -205,7 +204,32 @@ describe('info process action', () => {
         assert.deepStrictEqual(info.lodCounts, [20]);
         assert.strictEqual(info.shBands, 1);
         assert.deepStrictEqual(info.layers, ['position', 'geometric', 'color']);
-        assert.deepStrictEqual(info.columns, columnNamesFromMeta(src.meta));
+        assert.deepStrictEqual(info.extraColumns, src.meta.extraColumns.map(e => ({ name: e.name, type: e.type })));
+    });
+
+    it('lists only extra (other-layer) columns, with their type', async () => {
+        const pool = createChunkDataPool();
+        const base = createTestDataTable(6);
+        const dt = new DataTable([...base.columns, new Column('my_extra', new Float32Array(6))]);
+        const src = dataTableToChunkSource(dt);
+
+        const text = (await captureOutput(() => processSource(src, [{ kind: 'info' }], pool)))[0];
+        assert.match(text, /extra columns: my_extra \(float32\)/);
+
+        const json = JSON.parse((await captureOutput(() => processSource(src, [{ kind: 'info', format: 'json' }], pool)))[0]);
+        assert.deepStrictEqual(json.extraColumns, [{ name: 'my_extra', type: 'float32' }]);
+        assert.ok(!('columns' in json), 'no legacy full-column list');
+    });
+
+    it('reports the input format when one is provided', async () => {
+        const pool = createChunkDataPool();
+        const src = dataTableToChunkSource(createTestDataTable(10));
+
+        const text = (await captureOutput(() => processSource(src, [{ kind: 'info' }], pool, { sourceFormat: 'ply' })))[0];
+        assert.match(text, /^format: ply\n/);
+
+        const json = JSON.parse((await captureOutput(() => processSource(src, [{ kind: 'info', format: 'json' }], pool, { sourceFormat: 'ply' })))[0]);
+        assert.strictEqual(json.format, 'ply');
     });
 
     it('reports gaussian: false for a non-splat source', async () => {

--- a/test/stats.test.mjs
+++ b/test/stats.test.mjs
@@ -16,7 +16,7 @@ import { describe, it } from 'node:test';
 import { computeStatsView } from './helpers/summary-compare.mjs';
 import { createTestDataTable } from './helpers/test-utils.mjs';
 import { createChunkDataPool, createInMemoryChunkSource } from '../src/lib/chunk/index.js';
-import { dataTableToChunkSource } from '../src/lib/compat/data-table.js';
+import { columnNamesFromMeta, dataTableToChunkSource } from '../src/lib/compat/data-table.js';
 import { Column, DataTable, Transform, computeStats, logger, processDataTable } from '../src/lib/index.js';
 import { processSource } from '../src/lib/process-source.js';
 import { forwardTransforms } from '../src/lib/value-transforms.js';
@@ -93,9 +93,9 @@ describe('stats process action', () => {
         assert.strictEqual(lods.length, 1);
         assert.strictEqual(lods[0].lod, 0);
         assert.strictEqual(lods[0].numGaussians, 20);
-        assert.deepStrictEqual(lods[0].columns, info.columns);
+        assert.deepStrictEqual(lods[0].columns, columnNamesFromMeta(src.meta));
         for (const field of ['min', 'max', 'median', 'mean', 'stdDev', 'nanCount', 'infCount', 'histogram']) {
-            assert.strictEqual(lods[0].data[field].length, info.columns.length, `${field} length`);
+            assert.strictEqual(lods[0].data[field].length, lods[0].columns.length, `${field} length`);
         }
         for (const counts of lods[0].data.histogram) {
             assert.strictEqual(counts.length, 16);

--- a/test/write-lod.test.mjs
+++ b/test/write-lod.test.mjs
@@ -284,6 +284,46 @@ describe('readLodSource: streamed SOG input', function () {
         await source.close();
     });
 
+    it('reads a pre-v1 manifest (no version/count/counts), deriving counts from the tree', async function () {
+        const { fs, meta } = await writeScene([3, 2], 0);
+
+        // Simulate an older published manifest: drop the fields #261 introduced.
+        delete meta.version;
+        delete meta.count;
+        delete meta.counts;
+        fs.results.set('/scene/lod-meta.json', new TextEncoder().encode(JSON.stringify(meta)));
+
+        const [source] = await readFile({
+            filename: '/scene/lod-meta.json',
+            inputFormat: 'lod',
+            options: { lodSelect: [] },
+            fileSystem: asReadFileSystem(fs)
+        });
+
+        assert.strictEqual(source.meta.numLods, 2);
+        assert.strictEqual(source.meta.numGaussians, 3);
+        assert.deepStrictEqual(source.meta.lodCounts, [3, 2]);
+        const table = await materializeToDataTable(source, createChunkDataPool());
+        assert.strictEqual(table.numRows, 5);
+        await source.close();
+    });
+
+    it('still rejects an unsupported (non-1) version', async function () {
+        const { fs, meta } = await writeScene([3], 0);
+        meta.version = 2;
+        fs.results.set('/scene/lod-meta.json', new TextEncoder().encode(JSON.stringify(meta)));
+
+        await assert.rejects(
+            readFile({
+                filename: '/scene/lod-meta.json',
+                inputFormat: 'lod',
+                options: { lodSelect: [] },
+                fileSystem: asReadFileSystem(fs)
+            }),
+            { message: 'Unsupported lod-meta.json version: 2' }
+        );
+    });
+
     it('honors LOD selection', async function () {
         const { fs } = await writeScene([3, 2], 0);
         const [source] = await readFile({


### PR DESCRIPTION
Two independent changes on this branch.

## Pre-v1 `lod-meta.json` input

Streamed-LOD manifests written before the `version`/`count`/`counts` fields existed load fine everywhere except `splat-transform`, which rejected them with `Unsupported lod-meta.json version: undefined`. This accepts a missing `version` as pre-v1 (alongside `version: 1`), still rejecting any other value, and derives the per-LOD counts from the tree when `counts` is absent. Each referenced SOG unit's real gaussian count is still validated at decode time, so no integrity is lost. This mirrors the existing legacy-V1 fallback in the SOG reader.

## `--info` / `--stats`: input format + extra columns

`--info`/`--stats` now report the detected input `format`, which was previously missing. The full `columns` list is replaced by `extraColumns` (name + type): the standard columns are already implied by `layers` + `shBands`, so only the non-standard (`other`-layer) columns carry new information. Both changes apply to the CLI output (text and JSON) and to the library `FileInfo` returned by `readFileInfo`/`getFileInfo`. The format is reported only for a single, unambiguous input; with multiple combined inputs it is omitted.

### Breaking changes

- `FileInfo.columns` (full name list) is replaced by `FileInfo.extraColumns` (`{ name, type }[]`).
- The `--info`/`--stats` output shape changes: JSON `columns` → `extraColumns`, plus a new `format` field.

### Testing

- Full suite passes; added coverage for pre-v1 loading, extra-columns-with-type in text and JSON, and the new `format` field.