### PR TITLE
Sync README with the restructured developer-site manual section

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,18 @@ For library usage, install as a dependency:
 npm install @playcanvas/splat-transform
 ```
 
-For running on a backend with Docker (including GPU/Vulkan setup), see the [Docker Backend Guide](https://developer.playcanvas.com/user-manual/splat-transform/docker/).
+For running on a backend with Docker (including GPU/Vulkan setup), see the [Docker Backend](https://developer.playcanvas.com/user-manual/splat-transform/docker/) guide.
 
 > [!TIP]
 > For one-off conversions without installing anything, try [SuperSplat Convert](https://superspl.at/convert) — a browser-based frontend to splat-transform. See the [Convert page docs](https://developer.playcanvas.com/user-manual/supersplat/convert/) for details.
 
 ## Guides
 
-- [Streamed SOG Guide](https://developer.playcanvas.com/user-manual/splat-transform/#generating-lod-format) — build a multi-LOD streamed SOG from a single PLY.
-- [LOD Streaming Guide](https://developer.playcanvas.com/user-manual/gaussian-splatting/building/lod-streaming/) — load and render streamed SOG output in a PlayCanvas app.
-- [Collision Mesh Guide](https://developer.playcanvas.com/user-manual/splat-transform/collision/) — generate voxel/collision data from a splat scene.
-- [Docker Backend Guide](https://developer.playcanvas.com/user-manual/splat-transform/docker/) — run splat-transform on a backend (incl. GPU/Vulkan setup).
+- [Generating Streamed SOG](https://developer.playcanvas.com/user-manual/splat-transform/streamed-sog/) — build a multi-LOD Streamed SOG from a single PLY.
+- [LOD Streaming](https://developer.playcanvas.com/user-manual/gaussian-splatting/building/lod-streaming/) — load and render Streamed SOG output in a PlayCanvas app.
+- [Collision Mesh Generation](https://developer.playcanvas.com/user-manual/splat-transform/collision/) — generate voxel/collision data from a splat scene.
+- [Docker Backend](https://developer.playcanvas.com/user-manual/splat-transform/docker/) — run splat-transform on a backend (incl. GPU/Vulkan setup).
+- [Library Usage](https://developer.playcanvas.com/user-manual/splat-transform/library/) — drive splat-transform programmatically from Node.js or the browser.
 
 ## Format Specifications
 
@@ -133,7 +134,11 @@ Actions execute in the order specified and can be repeated. Any action may appea
 -m, --morton-order                      Reorder Gaussians by Morton code (Z-order curve)
 ```
 
-## General Options
+## CLI Options
+
+These options configure a run as a whole rather than operating on splat data — most groups apply only when reading or writing a specific format.
+
+### General Options
 
 ```none
 -h, --help                              Show this help and exit
@@ -145,7 +150,7 @@ Actions execute in the order specified and can be repeated. Any action may appea
 -w, --overwrite                         Overwrite output file if it exists
 ```
 
-## GPU Options
+### GPU Options
 
 Used by SOG compression and GPU voxelization (`--filter-cluster`, `--filter-floaters`, `.voxel.json` output).
 
@@ -156,7 +161,7 @@ Used by SOG compression and GPU voxelization (`--filter-cluster`, `--filter-floa
                                           GPU-only features like --filter-cluster)
 ```
 
-## SOG Compression Options
+### SOG Compression Options
 
 Apply when writing `.sog`, `meta.json`, `lod-meta.json`, or `.html` outputs.
 
@@ -165,7 +170,7 @@ Apply when writing `.sog`, `meta.json`, `lod-meta.json`, or `.html` outputs.
     --max-workers      <n>              Worker threads for SOG encoding (0 = inline/serial). Default: 4
 ```
 
-## SPZ Output Options
+### SPZ Output Options
 
 Apply when writing `.spz` outputs.
 
@@ -173,7 +178,7 @@ Apply when writing `.spz` outputs.
     --spz-version      <3|4>            The SPZ format version to write. Default: 4
 ```
 
-## HTML Viewer Output Options
+### HTML Viewer Output Options
 
 Apply when writing `.html` outputs.
 
@@ -185,7 +190,7 @@ Apply when writing `.html` outputs.
 > [!NOTE]
 > See the [SuperSplat Viewer Settings Schema](https://github.com/playcanvas/supersplat-viewer?tab=readme-ov-file#settings-schema) for details on how to pass data to the `--viewer-settings` option.
 
-## LOD Input Options
+### LOD Input Options
 
 Apply when reading `lod-meta.json`, `.lcc`, and `.lcc2` files.
 
@@ -193,7 +198,7 @@ Apply when reading `lod-meta.json`, `.lcc`, and `.lcc2` files.
 -L, --select-lod       <n,n,...>        Comma-separated LOD levels to read from streamed SOG / LCC / LCC2 input
 ```
 
-## LOD Output Options
+### LOD Output Options
 
 Apply when writing `lod-meta.json` (multi-LOD streaming SOG bundle).
 
@@ -202,11 +207,11 @@ Apply when writing `lod-meta.json` (multi-LOD streaming SOG bundle).
     --lod-chunk-extent <n>              Approximate size of an LOD chunk in world units (m). Default: 16
 ```
 
-See [Generating Streamed SOG](https://developer.playcanvas.com/user-manual/splat-transform/#generating-lod-format) for an end-to-end walkthrough.
+See [Generating Streamed SOG](https://developer.playcanvas.com/user-manual/splat-transform/streamed-sog/) for an end-to-end walkthrough.
 
-## Voxel Output Options
+### Voxel Output Options
 
-Apply when writing `.voxel.json` (sparse voxel octree for collision detection). See the [Collision Mesh Guide](https://developer.playcanvas.com/user-manual/splat-transform/collision/) for a deep dive on each step and tuning.
+Apply when writing `.voxel.json` (sparse voxel octree for collision detection). See the [Collision Mesh](https://developer.playcanvas.com/user-manual/splat-transform/collision/) guide for a deep dive on each step and tuning.
 
 ```none
     --voxel-size       <n>              Voxel size for .voxel.json. Default: 0.05
@@ -229,7 +234,7 @@ Apply when writing `.voxel.json` (sparse voxel octree for collision detection). 
     --collision-mesh   [smooth|faces]   Generate collision mesh (.collision.glb). Default: smooth
 ```
 
-## Image Output Options
+### Image Output Options
 
 Apply when writing `.webp` (lossless WebP rendered via GPU rasterizer).
 
@@ -379,7 +384,7 @@ splat-transform gen-grid.mjs -p width=10,height=10,scale=10,color=0.1 scenes/gri
 
 The voxel format stores sparse voxel octree data for collision detection. It consists of two files: `.voxel.json` (metadata) and `.voxel.bin` (binary octree data). Pass `--collision-mesh` to also emit a `.collision.glb` mesh derived from the voxel grid.
 
-For a step-by-step walkthrough of each option (with illustrations), see the [Collision Mesh Guide](https://developer.playcanvas.com/user-manual/splat-transform/collision/).
+For a step-by-step walkthrough of each option (with illustrations), see the [Collision Mesh](https://developer.playcanvas.com/user-manual/splat-transform/collision/) guide.
 
 #### Recommended pipeline
 
@@ -500,7 +505,10 @@ splat-transform --help
 
 ## Library Usage
 
-SplatTransform exposes a programmatic API for reading, processing, and writing Gaussian splat data. Scenes flow through lazy, chunked `ChunkSource`s, so resident memory is bounded by chunk size rather than scene size — the same pipeline the CLI uses to process scenes of hundreds of millions of gaussians.
+SplatTransform exposes a programmatic API for reading, processing, and writing Gaussian splat data. Scenes flow through lazy, chunked `ChunkSource`s, so resident memory is bounded by chunk size rather than scene size — the same pipeline the CLI uses to process scenes of hundreds of millions of Gaussians.
+
+> [!NOTE]
+> This section is also available as the [Library Usage](https://developer.playcanvas.com/user-manual/splat-transform/library/) guide on the developer site. The full TypeDoc reference for every export lives at [api.playcanvas.com/splat-transform](https://api.playcanvas.com/splat-transform/).
 
 ### Basic Import
 

--- a/README.md
+++ b/README.md
@@ -507,68 +507,6 @@ splat-transform --help
 
 SplatTransform exposes a programmatic API for reading, processing, and writing Gaussian splat data. Scenes flow through lazy, chunked `ChunkSource`s, so resident memory is bounded by chunk size rather than scene size — the same pipeline the CLI uses to process scenes of hundreds of millions of Gaussians.
 
-> [!NOTE]
-> This section is also available as the [Library Usage](https://developer.playcanvas.com/user-manual/splat-transform/library/) guide on the developer site. The full TypeDoc reference for every export lives at [api.playcanvas.com/splat-transform](https://api.playcanvas.com/splat-transform/).
-
-### Basic Import
-
-```typescript
-import {
-    readFile,
-    writeSource,
-    getInputFormat,
-    getOutputFormat,
-    createChunkDataPool,
-    processSourceBridged
-} from '@playcanvas/splat-transform';
-```
-
-### Key Exports
-
-Chunk-source pipeline (the primary API):
-
-| Export | Description |
-| ------ | ----------- |
-| `readFile` | Read a splat file as lazy `ChunkSource`s |
-| `readFileInfo` | Header-only structural metadata (validate/inspect without decoding) |
-| `getInputFormat` | Detect input format from filename |
-| `getOutputFormat` | Detect output format from filename |
-| `ChunkSource` | The streaming contract: chunked/gathered reads over one scene |
-| `createChunkDataPool` | Pooled read buffers shared across a pipeline |
-| `processSource`, `processSourceBridged` | Apply a sequence of processing actions to a source |
-| `selectLod`, `stackLods`, `concatSource`, `bakeTransform` | Structural combinators (lazy views) |
-| `decimateSource` | Chunk-native, memory-bounded decimation to an exact target count |
-| `writeSource` | Stream a source to any single-scene output format |
-| `writeLodSource` | Write streamed SOG (`lod-meta.json` + chunked units) from a multi-LOD source |
-| `computeStats` | Streaming per-LOD, per-column statistics for a source or table |
-
-DataTable compat (secondary; every entry materializes the whole scene in memory):
-
-| Export | Description |
-| ------ | ----------- |
-| `DataTable`, `Column` | Legacy whole-scene table |
-| `combine` | Merge multiple DataTables into one |
-| `processDataTable` | Apply processing actions to a DataTable |
-| `dataTableToChunkSource`, `materializeToDataTable` | Bridges between the DataTable and chunk-source worlds |
-| `writeFile` | Write a DataTable to any output format |
-| `writeVoxel` | Write sparse voxel octree files |
-| `writeImage` | Render a camera view to a lossless WebP image (requires GPU) |
-
-### File System Abstractions
-
-The library uses abstract file system interfaces for maximum flexibility:
-
-**Reading:**
-- `UrlReadFileSystem` - Read from URLs (browser/Node.js)
-- `MemoryReadFileSystem` - Read from in-memory buffers
-- `ZipReadFileSystem` - Read from ZIP archives
-
-**Writing:**
-- `MemoryFileSystem` - Write to in-memory buffers
-- `ZipFileSystem` - Write to ZIP archives
-
-### Example: Reading and Processing
-
 ```typescript
 import { Vec3 } from 'playcanvas';
 import {
@@ -613,47 +551,5 @@ await processed.close();
 const outputBuffer = memFs.results.get('output.ply');
 ```
 
-Consumers still on the `DataTable` API can bridge in either direction with `materializeToDataTable(source, pool)` and `dataTableToChunkSource(dataTable)` — both materialize the full scene, so prefer staying on sources for large inputs.
-
-### Processing Actions
-
-`processSource` / `processSourceBridged` (and the compat `processDataTable`) accept an array of actions:
-
-```typescript
-type ProcessAction =
-    | { kind: 'translate'; value: Vec3 }
-    | { kind: 'rotate'; value: Vec3 }       // Euler angles in degrees
-    | { kind: 'scale'; value: number }
-    | { kind: 'filterNaN' }
-    | { kind: 'filterByValue'; columnName: string; comparator: 'lt'|'lte'|'gt'|'gte'|'eq'|'neq'; value: number }
-    | { kind: 'filterBands'; value: 0|1|2|3 }
-    | { kind: 'filterBox'; min: Vec3; max: Vec3 }
-    | { kind: 'filterSphere'; center: Vec3; radius: number }
-    | { kind: 'filterFloaters'; voxelResolution?: number; opacityCutoff?: number; minContribution?: number } // GPU
-    | { kind: 'filterCluster'; voxelResolution?: number; seed?: Vec3; opacityCutoff?: number; minContribution?: number } // GPU
-    | { kind: 'decimate'; count: number | null; percent: number | null }
-    | { kind: 'param'; name: string; value: string }
-    | { kind: 'stats'; format?: 'text' | 'json' }
-    | { kind: 'info'; format?: 'text' | 'json' }
-    | { kind: 'mortonOrder' };
-```
-
 > [!NOTE]
-> `filterFloaters` and `filterCluster` require a GPU device — pass `createDevice` via the `ProcessOptions` argument. `processSource` streams and throws on actions that need the DataTable bridge (`decimate`, `mortonOrder`, the GPU voxel filters); `processSourceBridged` handles every action, materializing only those runs.
-
-### Custom Logging
-
-Configure the logger for your environment:
-
-```typescript
-import { logger, TextRenderer } from '@playcanvas/splat-transform';
-
-// Route status output (scopes, progress bars, messages) to stderr and
-// pipeable output (e.g. JSON stats) to stdout
-logger.setRenderer(new TextRenderer({
-    write: process.stderr.write.bind(process.stderr),
-    output: process.stdout.write.bind(process.stdout)
-}));
-
-logger.setVerbosity('quiet'); // 'quiet' | 'normal' | 'verbose'
-```
+> For the full walkthrough — key exports, file system abstractions, processing actions, custom logging — see the [Library Usage](https://developer.playcanvas.com/user-manual/splat-transform/library/) guide. The TypeDoc reference for every export lives at [api.playcanvas.com/splat-transform](https://api.playcanvas.com/splat-transform/).


### PR DESCRIPTION
The [developer-site SplatTransform section](https://developer.playcanvas.com/user-manual/splat-transform/) was restructured on its `docs/splat-transform-v3-sync` branch: **Generating Streamed SOG** and **Library Usage** were split out of the index page into their own pages, and the option sections were grouped under a single **CLI Options** heading. This syncs the README with that structure.

## Link retargets

- The two deep links to `/user-manual/splat-transform/#generating-lod-format` (Guides list and LOD Output Options) now point at the dedicated `/user-manual/splat-transform/streamed-sog/` page. The old anchor survives on the docs index only as a compat stub for previously published READMEs.
- Guides entries are renamed to the new docs page titles (Generating Streamed SOG, LOD Streaming, Collision Mesh Generation, Docker Backend), and the newly split-out **Library Usage** guide is added as a fifth entry.
- Inline cross-references now match the docs' own phrasing ("the Collision Mesh guide", "the Docker Backend guide").

## CLI Options grouping

The nine option sections (General, GPU, SOG Compression, SPZ, HTML Viewer, LOD Input/Output, Voxel, Image) become H3s under one `## CLI Options` heading with the same intro sentence the docs use. GitHub's auto-generated README outline had the same problem the docs commit fixed: a flat run of option headings burying Examples. `## Actions` stays top-level, matching the docs.

## Library Usage trimmed to a quick-start

With the docs guide split out, the section's exhaustive listings existed in three places: the README, the guide, and the generated TypeDoc reference. The README section is now the intro paragraph, one complete read → process → write example, and a note pointing at the [Library Usage guide](https://developer.playcanvas.com/user-manual/splat-transform/library/) and [api.playcanvas.com/splat-transform](https://api.playcanvas.com/splat-transform/) — so the npm/GitHub landing page still shows library code, while the API surface enumeration lives where it can't drift (TypeDoc) and the walkthrough lives in the guide. The Key Exports tables, File System Abstractions, `ProcessAction` union, and Custom Logging sections are removed (−105 lines).

The CLI half of the README is deliberately untouched: it mirrors `--help` and remains the canonical copy the docs sync from.

## Reviewer note

The `streamed-sog` and `library` pages only exist on developer-site's `docs/splat-transform-v3-sync` branch (no PR opened there yet). Links to them 404 until that branch merges and deploys, so land the docs change first; the compat stub keeps the currently published README working in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)