### PR TITLE
Rebuild HTML export on renderViewerHtml and the viewer's shared settings defaults

### DIFF
--- a/src/lib/writers/write-html.ts
+++ b/src/lib/writers/write-html.ts
@@ -1,4 +1,5 @@
-import { html, css, js } from '@playcanvas/supersplat-viewer';
+import { css, js, renderViewerHtml } from '@playcanvas/supersplat-viewer';
+import { defaultSettings } from '@playcanvas/supersplat-viewer/settings';
 import { basename, dirname, join } from 'pathe';
 
 import { logWrittenFile } from './utils';
@@ -7,30 +8,6 @@ import { DataTable } from '../data-table';
 import { type FileSystem, MemoryFileSystem, writeFile } from '../io/write';
 import type { DeviceCreator } from '../types';
 import { logger, toBase64 } from '../utils';
-
-const defaultSettings = {
-    version: 2,
-    tonemapping: 'none',
-    highPrecisionRendering: false,
-    background: { color: [0.4, 0.4, 0.4] },
-    postEffectSettings: {
-        sharpness: { enabled: false, amount: 0 },
-        bloom: { enabled: false, intensity: 1, blurLevel: 2 },
-        grading: { enabled: false, brightness: 0, contrast: 1, saturation: 1, tint: [1, 1, 1] },
-        vignette: { enabled: false, intensity: 0.5, inner: 0.3, outer: 0.75, curvature: 1 },
-        fringing: { enabled: false, intensity: 0.5 }
-    },
-    animTracks: [] as any[],
-    cameras: [{
-        initial: {
-            position: [2, 2, -2],
-            target: [0, 0, 0],
-            fov: 75
-        }
-    }],
-    annotations: [] as any[],
-    startMode: 'default'
-};
 
 type WriteHtmlOptions = {
     filename: string;
@@ -54,12 +31,7 @@ type WriteHtmlOptions = {
 const writeHtml = async (options: WriteHtmlOptions, fs: FileSystem) => {
     const { filename, dataTable, viewerSettingsJson, bundle, iterations, createDevice } = options;
 
-    const pad = (text: string, spaces: number) => {
-        const whitespace = ' '.repeat(spaces);
-        return text.split('\n').map(line => whitespace + line).join('\n');
-    };
-
-    const viewerSettings = viewerSettingsJson || defaultSettings;
+    const viewerSettings = viewerSettingsJson || defaultSettings('object');
     const encoder = new TextEncoder();
 
     if (bundle) {
@@ -79,17 +51,16 @@ const writeHtml = async (options: WriteHtmlOptions, fs: FileSystem) => {
         // get the memory buffer
         const sogData = toBase64(memoryFs.results.get(sogFilename));
 
-        const style = '<link rel="stylesheet" href="./index.css">';
-        const script = 'import { main } from \'./index.js\';';
-        const settings = 'settings: fetch(settingsUrl).then(response => response.json())';
-        const content = 'fetch(contentUrl)';
-
-        const resultHtml = html
-        .replace(style, `<style>\n${pad(css, 12)}\n        </style>`)
-        .replace(script, js)
-        .replace(settings, `settings: ${JSON.stringify(viewerSettings)}`)
-        .replace(content, `fetch("data:application/octet-stream;base64,${sogData}")`)
-        .replace('.compressed.ply', '.sog');
+        const resultHtml = renderViewerHtml({
+            bootstrap: {
+                settings: viewerSettings,
+                contentUrl: `data:application/octet-stream;base64,${sogData}`,
+                // a data: uri has no usable name, so this selects the sog parser
+                contentFilename: 'scene.sog'
+            },
+            inlineCss: true,
+            inlineJs: true
+        });
 
         const htmlBytes = encoder.encode(resultHtml);
 
@@ -134,12 +105,10 @@ const writeHtml = async (options: WriteHtmlOptions, fs: FileSystem) => {
         await writeFile(fs, settingsPath, settingsBytes);
         logWrittenFile(basename(settingsPath), settingsBytes.byteLength);
 
-        // Generate HTML with external references
-        const content = 'fetch(contentUrl)';
-
-        const resultHtml = html
-        .replace(content, `fetch("${sogFilename}")`)
-        .replace('.compressed.ply', '.sog');
+        // Generate HTML referencing the sibling files
+        const resultHtml = renderViewerHtml({
+            bootstrap: { contentUrl: sogFilename }
+        });
 
         const htmlBytes = encoder.encode(resultHtml);
         await writeFile(fs, filename, htmlBytes);

--- a/test/html-output.test.mjs
+++ b/test/html-output.test.mjs
@@ -47,6 +47,21 @@ describe('HTML Format (Output Only)', () => {
         assert(htmlText.includes('<head'), 'Should have head tag');
         assert(htmlText.includes('<body'), 'Should have body tag');
 
+        // The bootstrap block must carry the splat and settings inline; if any of these
+        // regress, the page silently falls back to fetching missing sibling files
+        assert(htmlText.includes('"contentUrl":"data:application/octet-stream;base64,'),
+            'Bootstrap should embed the splat as a data: URI');
+        assert(htmlText.includes('"contentFilename":"scene.sog"'),
+            'Bootstrap should name the data: URI content so the sog parser is selected');
+        assert(htmlText.includes('"settings":{'),
+            'Bootstrap should embed the viewer settings inline');
+
+        // Self-contained: no external stylesheet or module references. Note ./settings.json
+        // legitimately remains in the script as the default settingsUrl; the inline
+        // bootstrap settings take precedence over it
+        assert(!htmlText.includes('./index.css'), 'Stylesheet should be inlined, not linked');
+        assert(!htmlText.includes('./index.js'), 'Module bundle should be inlined, not imported');
+
         // For bundled, everything should be in one file
         assert.strictEqual(writeFs.results.size, 1, 'Bundled should only produce one file');
     });
@@ -65,6 +80,14 @@ describe('HTML Format (Output Only)', () => {
 
         const htmlText = new TextDecoder().decode(htmlData);
         assert(htmlText.includes('<html'), 'Should have html tag');
+
+        // The document must actually reference the sibling files it ships with
+        assert(htmlText.includes('"contentUrl":"viewer.sog"'),
+            'Bootstrap should point at the sibling .sog file');
+        assert(htmlText.includes('href="./index.css"'), 'Should link the sibling stylesheet');
+        assert(htmlText.includes("import { main } from './index.js';"),
+            'Should import the sibling module bundle');
+        assert(htmlText.includes('./settings.json'), 'Should fetch the sibling settings file');
 
         // For unbundled, should have additional files
         assert(writeFs.results.size > 1, 'Unbundled should produce multiple files');
@@ -96,8 +119,9 @@ describe('HTML Format (Output Only)', () => {
         const htmlData = writeFs.results.get('viewer.html');
         assert(htmlData, 'HTML file should be written');
 
-        // The settings should be embedded somehow (exact format depends on implementation)
+        // The supplied settings should be embedded in the bootstrap verbatim
         const htmlText = new TextDecoder().decode(htmlData);
-        assert(htmlText.length > 0, 'HTML should have content');
+        assert(htmlText.includes('"autoRotate":true'),
+            'Custom settings should be embedded in the bootstrap');
     });
 });


### PR DESCRIPTION
HTML export has been broken since supersplat-viewer 1.30.0: the writer patched the viewer document by exact-string replacement, and that release reformatted two of the four seams (the stylesheet link became self-closing, the settings line gained a bootstrap fallback). String.replace no-ops silently on a miss, so the CLI reported success while the exported page linked a non-existent ./index.css and fetched a non-existent ./settings.json.

This rewrites write-html.ts on the viewer's renderViewerHtml embedding API, which replaces a dedicated injection seam and throws on drift instead of silently degrading. Bundled export inlines the stylesheet and module bundle and passes the splat as a data: URI with contentFilename: 'scene.sog' — required because the engine selects its gsplat parser by filename extension, which a data: URI doesn't have (this needs viewer 1.30.1, already picked up in #306). Unbundled export passes the sibling .sog name through the bootstrap and writes index.css/index.js/settings.json as before.

The local default-settings blob is replaced by defaultSettings('object') from @playcanvas/supersplat-viewer/settings, so every tool now agrees on defaults. Note this intentionally changes export defaults: fov 75 → 85, tonemapping none → linear, background 0.4 grey → black, bloom.intensity 1 → 0.1, grading.brightness 0 → 1. Explicit --viewer-settings files are unaffected.