### PR TITLE
Add viewer-settings subpath exposing the vendored viewer's settings api

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
       }
     },
     "./worker": "./dist/worker.mjs",
+    "./viewer-settings": {
+      "types": "./dist/viewer-settings.d.ts",
+      "import": "./dist/viewer-settings.mjs"
+    },
     "./lib/*": "./lib/*"
   },
   "bin": {

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,4 +1,5 @@
 import { execSync } from 'node:child_process';
+import { copyFileSync } from 'node:fs';
 import { resolve as resolvePath } from 'node:path';
 
 import json from '@rollup/plugin-json';
@@ -116,6 +117,40 @@ const cjs = {
     cache: false
 };
 
+// Viewer settings re-export - bundled from the same vendored viewer as the html
+// writer, so producers author settings against the exact viewer version embedded
+// in html exports, with no viewer dependency of their own. The declaration is
+// copied from the viewer package rather than emitted by tsc: an emitted d.ts
+// would just re-export from '@playcanvas/supersplat-viewer', which consumers of
+// this package do not have installed.
+const viewerSettings = {
+    input: 'src/lib/viewer-settings.ts',
+    output: {
+        dir: 'dist',
+        format: 'esm',
+        sourcemap: true,
+        entryFileNames: 'viewer-settings.mjs'
+    },
+    plugins: [
+        typescript({
+            tsconfig: './tsconfig.json',
+            declaration: false,
+            declarationDir: undefined
+        }),
+        resolve(),
+        {
+            name: 'copy-viewer-settings-dts',
+            writeBundle() {
+                copyFileSync(
+                    'node_modules/@playcanvas/supersplat-viewer/dist/settings.d.ts',
+                    'dist/viewer-settings.d.ts'
+                );
+            }
+        }
+    ],
+    cache: false
+};
+
 // CLI build - Node.js specific
 const cli = {
     input: 'src/cli/index.ts',
@@ -140,4 +175,4 @@ const cli = {
     cache: false
 };
 
-export default [worker, esm, cjs, cli];
+export default [worker, esm, cjs, viewerSettings, cli];

--- a/src/lib/viewer-settings.ts
+++ b/src/lib/viewer-settings.ts
@@ -1,0 +1,7 @@
+/**
+ * The viewer's settings api — types, shared defaults, validation and authoring ranges —
+ * re-exported from the vendored viewer. Producers building on this package author their
+ * experience settings against the exact viewer version embedded in html exports, without
+ * needing a viewer dependency of their own.
+ */
+export * from '@playcanvas/supersplat-viewer/settings';

--- a/test/viewer-settings.test.mjs
+++ b/test/viewer-settings.test.mjs
@@ -1,0 +1,34 @@
+/**
+ * Packaging tests for the viewer-settings subpath re-export.
+ */
+
+import assert from 'node:assert';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import * as viewer from '@playcanvas/supersplat-viewer/settings';
+
+// self-referencing import: resolves through this package's exports map, as a consumer would
+import * as reexport from '@playcanvas/splat-transform/viewer-settings';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('viewer-settings subpath', () => {
+    it('re-exports the complete viewer settings api', () => {
+        for (const key of Object.keys(viewer)) {
+            assert.ok(key in reexport, `missing export: ${key}`);
+        }
+    });
+
+    it('agrees with the viewer on shared defaults', () => {
+        assert.deepStrictEqual(reexport.defaultSettings(), viewer.defaultSettings());
+        assert.deepStrictEqual(reexport.defaultPostEffectSettings(), viewer.defaultPostEffectSettings());
+    });
+
+    it('ships a flattened declaration next to the bundle', () => {
+        assert.ok(existsSync(join(__dirname, '..', 'dist', 'viewer-settings.d.ts')),
+            'dist/viewer-settings.d.ts should be copied by the build');
+    });
+});


### PR DESCRIPTION
Adds a `./viewer-settings` exports subpath re-exporting `@playcanvas/supersplat-viewer/settings` (types, shared defaults, validation, migration, authoring ranges). This package already vendors and pins the viewer for its html writer, so producers like supersplat get the settings api matching the embedded viewer from a single dependency, with no version skew.