### PR TITLE
Add a gaussian count floor to LOD chunk splitting (--lod-chunk-min)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,10 @@ Apply when writing `lod-meta.json` (multi-LOD streaming SOG bundle).
 ```none
     --lod-chunk-count  <n>              Approximate number of Gaussians per LOD chunk in K. Default: 512
     --lod-chunk-extent <n>              Approximate size of an LOD chunk in world units (m). Default: 16
+    --lod-chunk-min    <n>              Gaussians in K below which a chunk is not split for extent. Default: 8
 ```
+
+A chunk is split when it holds more than `--lod-chunk-count` Gaussians, or when it is wider than `--lod-chunk-extent` and holds more than `--lod-chunk-min`. The minimum keeps sparse regions such as sky or distant background from being cut into thousands of near-empty chunks: below it a region stays one chunk however wide it is. Dense regions are unaffected.
 
 See [Generating Streamed SOG](https://developer.playcanvas.com/user-manual/splat-transform/streamed-sog/) for an end-to-end walkthrough.
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -161,6 +161,7 @@ const cliOptionsConfig = {
     'viewer-settings': { type: 'string', default: '' },
     'lod-chunk-count': { type: 'string', default: '512' },
     'lod-chunk-extent': { type: 'string', default: '16' },
+    'lod-chunk-min': { type: 'string', default: '8' },
     'spz-version': { type: 'string', default: '4' },
     unbundled: { type: 'boolean', default: false },
     'voxel-size': { type: 'string' },
@@ -538,6 +539,7 @@ const parseArguments = async () => {
         unbundled: v.unbundled,
         lodChunkCount: parseInteger(v['lod-chunk-count']),
         lodChunkExtent: parseInteger(v['lod-chunk-extent']),
+        lodChunkMin: parseInteger(v['lod-chunk-min']),
         spzVersion: spzVersion as 3 | 4,
         voxelResolution,
         opacityCutoff,
@@ -853,6 +855,7 @@ LOD INPUT (lod-meta.json, .lcc, .lcc2)
 LOD OUTPUT (lod-meta.json)
         --lod-chunk-count  <n>              Approximate number of Gaussians per LOD chunk in K. Default: 512
         --lod-chunk-extent <n>              Approximate size of an LOD chunk in world units (m). Default: 16
+        --lod-chunk-min    <n>              Gaussians in K below which a chunk is not split for extent. Default: 8
 
 VOXEL OUTPUT (.voxel.json)
         --voxel-size       <n>              Voxel size for .voxel.json. Default: 0.05
@@ -1413,7 +1416,8 @@ const main = async () => {
                 iterations: options.iterations,
                 createDevice: deviceCreator,
                 chunkCount: options.lodChunkCount,
-                chunkExtent: options.lodChunkExtent
+                chunkExtent: options.lodChunkExtent,
+                chunkMin: options.lodChunkMin
             }, new NodeFileSystem());
 
             await mainSource.close();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,6 +28,9 @@ type Options = {
     /** Approximate size of an LOD chunk in world units (meters). Default: 16 */
     lodChunkExtent?: number;
 
+    /** Gaussians (in thousands) below which an LOD chunk is not split for exceeding the extent. Default: 8 */
+    lodChunkMin?: number;
+
     /** SPZ format version to write. Default: 4. */
     spzVersion?: 3 | 4;
 

--- a/src/lib/writers/write-lod.ts
+++ b/src/lib/writers/write-lod.ts
@@ -39,8 +39,16 @@ type LodMeta = {
         generator: string;
         /** Gaussians per file unit the partition aimed for (`--lod-chunk-count` × 1024). */
         chunkGaussians: number;
-        /** Largest leaf extent the partition allowed, in world units (`--lod-chunk-extent`). */
+        /**
+         * Largest leaf extent the partition allowed, in world units (`--lod-chunk-extent`),
+         * for leaves holding more than `chunkMinGaussians`.
+         */
         chunkExtent: number;
+        /**
+         * Gaussians below which a leaf was not split for extent (`--lod-chunk-min` × 1024).
+         * Sparser regions form leaves as wide as they need to be to hold this many.
+         */
+        chunkMinGaussians: number;
     };
     count: number;
     counts: number[];
@@ -856,6 +864,18 @@ type WriteLodSourceOptions = {
     createDevice?: DeviceCreator;
     chunkCount: number;
     chunkExtent: number;
+    /**
+     * Gaussians, in thousands, below which a node is not split for exceeding
+     * `chunkExtent`. Default 8. A leaf is the unit of streaming, culling and LOD
+     * choice, and costs the same to stream, evaluate and describe whether it holds
+     * eighty gaussians or eight thousand; without a floor a wide sparse region —
+     * sky, floaters, distant background — is cut down to the extent limit
+     * regardless of content, into tens of thousands of near-empty leaves that
+     * inflate the manifest and the runtime's per-node work while carrying nothing
+     * the allocator would not buy whole anyway. Dense regions never reach the
+     * floor, so their leaves are unchanged.
+     */
+    chunkMin?: number;
 };
 
 /**
@@ -874,7 +894,7 @@ type WriteLodSourceOptions = {
  * @ignore
  */
 const writeLodSource = async (options: WriteLodSourceOptions, fs: FileSystem) => {
-    const { filename, envSource, iterations, createDevice, chunkCount, chunkExtent } = options;
+    const { filename, envSource, iterations, createDevice, chunkCount, chunkExtent, chunkMin = 8 } = options;
 
     // Bake the pending coordinate-space transform to PLY once, up front, so the
     // partition/bounds passes (extractSlim, calcBound, morton) and the per-unit
@@ -921,6 +941,7 @@ const writeLodSource = async (options: WriteLodSourceOptions, fs: FileSystem) =>
     // approximate number of gaussians we'll place into file units
     const binSize = chunkCount * 1024;
     const binDim = chunkExtent;
+    const binMin = chunkMin * 1024;
 
     // map of lod -> file units -> subunits (each subunit a tight Uint32Array of
     // gaussian indices). This is the bulk retained bookkeeping; Uint32Array keeps
@@ -934,7 +955,9 @@ const writeLodSource = async (options: WriteLodSourceOptions, fs: FileSystem) =>
     const chunkingBar = logger.bar('chunking', cum[numLods]);
 
     const build = async (node: BTreeNode): Promise<MetaNode> => {
-        if (!node.indices && (node.count > binSize || (node.aabb && node.aabb.largestDim() > binDim))) {
+        // Split when the node holds more than a unit, or when it is wider than the
+        // extent limit and holds enough gaussians to be worth two leaves.
+        if (!node.indices && (node.count > binSize || (node.aabb && node.aabb.largestDim() > binDim && node.count > binMin))) {
             const children = [
                 await build(node.left),
                 await build(node.right)
@@ -1019,7 +1042,8 @@ const writeLodSource = async (options: WriteLodSourceOptions, fs: FileSystem) =>
         asset: {
             generator: `splat-transform v${version}`,
             chunkGaussians: binSize,
-            chunkExtent: binDim
+            chunkExtent: binDim,
+            chunkMinGaussians: binMin
         },
         count: counts.reduce((acc, curr) => acc + curr, 0),
         counts,

--- a/test/write-lod.test.mjs
+++ b/test/write-lod.test.mjs
@@ -199,6 +199,50 @@ describe('writeLodSource: lod-meta.json contract', function () {
         assert.ok(fs.results.has('/scene/1_0/meta.json'));
     });
 
+    const wideSplats = Array.from({ length: 300 }, (_, i) => ({ x: i * 0.5 }));
+
+    it('records the chunk minimum and does not split a sparse node for extent below it', async function () {
+        // 300 splats over 150 m: wider than the 16 m extent limit (and enough for the
+        // spatial tree to have interior nodes), but far below the default minimum of
+        // 8K gaussians, so the region stays one leaf
+        const source = dataTableToChunkSource(makeSplatTable(wideSplats), 1 << 20);
+        const fs = new MemoryFileSystem();
+        await writeLodSource({
+            filename: '/scene/lod-meta.json',
+            mainSource: source,
+            envSource: null,
+            iterations: 1,
+            chunkCount: 1,
+            chunkExtent: 16
+        }, fs);
+        const meta = JSON.parse(new TextDecoder().decode(fs.results.get('/scene/lod-meta.json')));
+        assert.strictEqual(meta.asset.chunkMinGaussians, 8192);
+        assert.ok(!('children' in meta.tree), 'a sparse wide node is one leaf');
+        assert.strictEqual(meta.tree.lods['0'].count, wideSplats.length);
+    });
+
+    it('splits a wide node for extent once it holds more than the chunk minimum', async function () {
+        const source = dataTableToChunkSource(makeSplatTable(wideSplats), 1 << 20);
+        const fs = new MemoryFileSystem();
+        await writeLodSource({
+            filename: '/scene/lod-meta.json',
+            mainSource: source,
+            envSource: null,
+            iterations: 1,
+            chunkCount: 1,
+            chunkExtent: 16,
+            chunkMin: 0
+        }, fs);
+        const meta = JSON.parse(new TextDecoder().decode(fs.results.get('/scene/lod-meta.json')));
+        assert.strictEqual(meta.asset.chunkMinGaussians, 0);
+        assert.strictEqual(meta.tree.children?.length, 2, 'the extent limit splits a node above the minimum');
+        const leaves = [];
+        const walk = (n) => { if (n.children) n.children.forEach(walk); else leaves.push(n); };
+        walk(meta.tree);
+        assert.ok(leaves.length >= 2, `expected the extent limit to split the node, got ${leaves.length} leaf`);
+        assert.strictEqual(leaves.reduce((sum, l) => sum + l.lods['0'].count, 0), wideSplats.length);
+    });
+
     it('matches errors to lodLevels when trailing structural LODs are empty', async function () {
         const { meta } = await writeScene([1, 0], 0);
         assert.strictEqual(meta.lodLevels, 1);


### PR DESCRIPTION
## Summary

The streamed SOG partition splits a node when it holds more than `--lod-chunk-count` gaussians or when it is wider than `--lod-chunk-extent`. The extent rule has no regard for content, so a wide sparse region (sky, floaters, distant background) is cut down to the 16 m limit however little it holds. Scenes with large sparse volumes end up with tens of thousands of near-empty leaves that inflate `lod-meta.json` and the runtime's per-node work (culling, LOD evaluation, interval compaction) while carrying nothing the budget allocator would not buy whole anyway.

This PR adds a floor: a node wider than the extent limit is only split if it also holds more than `--lod-chunk-min` gaussians (in K, default 8). Nodes over `--lod-chunk-count` still always split, so dense regions are unaffected. The floor is recorded in the manifest as `asset.chunkMinGaussians` alongside the existing `chunkGaussians` and `chunkExtent`.

## Effect

Leaf counts before and after with the default floor of 8192:

| Scene | Leaves before | Leaves after | Manifest before | Manifest after |
|---|---|---|---|---|
| bad-cloud (rebuilt) | 39,241 | 3,928 | 17.9 MB | 1.8 MB |
| bad-snow (simulated) | 43,183 | 13,992 | | |
| superspl.at 9ece4678 (simulated) | 111,316 | 28,943 | 58 MB | 17 MB |
| superspl.at fd3083e4 San Juan (simulated) | 1,067 | 680 | | |

bad-cloud was rebuilt end to end. The other rows come from collapsing the existing manifests' trees under the new rule, which is exact for leaf count since the tree is the same BTree.

Runtime impact: fewer leaves means fewer nodes to cull, evaluate and compact each frame, and a much smaller manifest to download and parse. The merged leaves are wide but sparse, so their bounding spheres overlap more and they cull less tightly, but a leaf holding a few thousand gaussians costs the renderer little whether or not it is fully in view. Leaves in dense regions, which is where LOD choice matters, are identical to before.

## Changes

- `src/lib/writers/write-lod.ts`: `chunkMin` option (default 8) and the split condition `count > binSize || (largestDim > binDim && count > binMin)`; `chunkMinGaussians` written to `asset`.
- `src/cli/index.ts`, `src/lib/types.ts`: `--lod-chunk-min <n>` option wired through to the writer, with help text.
- `README.md`: option documented, with a paragraph explaining the split rule.
- `test/write-lod.test.mjs`: a wide sparse input stays one leaf under the default and splits with `--lod-chunk-min 0`; `asset.chunkMinGaussians` is asserted.

Lint, type check and the full test suite pass.