### PR TITLE
Render the LOD error metric on the GPU instead of matching splats analytically

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Apply when writing `lod-meta.json` (multi-LOD streaming SOG bundle).
     --lod-chunk-count  <n>              Approximate number of Gaussians per LOD chunk in K. Default: 512
     --lod-chunk-extent <n>              Approximate size of an LOD chunk in world units (m). Default: 16
     --lod-chunk-min    <n>              Gaussians in K below which a chunk is not split for extent. Default: 8
+    --lod-errors                        Render per-chunk LOD error tables (needs a GPU). Default: off
 ```
 
 A chunk is split when it holds more than `--lod-chunk-count` Gaussians, or when it is wider than `--lod-chunk-extent` and holds more than `--lod-chunk-min`. The minimum keeps sparse regions such as sky or distant background from being cut into thousands of near-empty chunks: below it a region stays one chunk however wide it is. Dense regions are unaffected.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -162,6 +162,7 @@ const cliOptionsConfig = {
     'lod-chunk-count': { type: 'string', default: '512' },
     'lod-chunk-extent': { type: 'string', default: '16' },
     'lod-chunk-min': { type: 'string', default: '8' },
+    'lod-errors': { type: 'boolean', default: false },
     'spz-version': { type: 'string', default: '4' },
     unbundled: { type: 'boolean', default: false },
     'voxel-size': { type: 'string' },
@@ -540,6 +541,7 @@ const parseArguments = async () => {
         lodChunkCount: parseInteger(v['lod-chunk-count']),
         lodChunkExtent: parseInteger(v['lod-chunk-extent']),
         lodChunkMin: parseInteger(v['lod-chunk-min']),
+        lodErrors: v['lod-errors'],
         spzVersion: spzVersion as 3 | 4,
         voxelResolution,
         opacityCutoff,
@@ -856,6 +858,7 @@ LOD OUTPUT (lod-meta.json)
         --lod-chunk-count  <n>              Approximate number of Gaussians per LOD chunk in K. Default: 512
         --lod-chunk-extent <n>              Approximate size of an LOD chunk in world units (m). Default: 16
         --lod-chunk-min    <n>              Gaussians in K below which a chunk is not split for extent. Default: 8
+        --lod-errors                        Render per-chunk LOD error tables (needs a GPU). Default: off
 
 VOXEL OUTPUT (.voxel.json)
         --voxel-size       <n>              Voxel size for .voxel.json. Default: 0.05
@@ -1417,7 +1420,8 @@ const main = async () => {
                 createDevice: deviceCreator,
                 chunkCount: options.lodChunkCount,
                 chunkExtent: options.lodChunkExtent,
-                chunkMin: options.lodChunkMin
+                chunkMin: options.lodChunkMin,
+                lodErrors: options.lodErrors
             }, new NodeFileSystem());
 
             await mainSource.close();

--- a/src/lib/gpu/gpu-splat-rasterizer.ts
+++ b/src/lib/gpu/gpu-splat-rasterizer.ts
@@ -30,6 +30,7 @@ import { tileAabbEquirect } from './shaders/chunks/tile-aabb-equirect';
 import { tileAabbPinhole } from './shaders/chunks/tile-aabb-pinhole';
 import { tileWalkEquirect } from './shaders/chunks/tile-walk-equirect';
 import { tileWalkPinhole } from './shaders/chunks/tile-walk-pinhole';
+import { clearStateWgsl } from './shaders/clear-state';
 import { finalizeWgsl } from './shaders/finalize';
 import { findBoundariesWgsl } from './shaders/find-boundaries';
 import { initTileOffsetsWgsl } from './shaders/init-tile-offsets';
@@ -39,7 +40,7 @@ import { projectWgsl } from './shaders/project';
 import { rasterizeBinnedWgsl } from './shaders/rasterize-binned';
 import { tileBinEmitPairsWgsl } from './shaders/tile-bin-emit-pairs';
 import { uniformsStruct, uniformFormatEntries } from './shaders/uniforms';
-import { type Projection } from '../render/camera';
+import { type CameraBasis, type Projection } from '../render/camera';
 import { TILE_SIZE } from '../render/config';
 
 /** 12 floats per projected splat: vec4 × 3. */
@@ -82,6 +83,14 @@ interface SplatRasterizerOptions {
     groupTilesY: number;
     /** Max gaussians per chunk; sizes the input + projection + pair buffers. */
     chunkCap: number;
+    /**
+     * Number of independent running-state/output buffer pairs, default 1. With
+     * more, a caller can have that many groups in flight — encode the next
+     * group while an earlier one's readback is still pending — since every
+     * other buffer is transient per chunk and the queue executes in order.
+     * `beginGroup` picks the slot.
+     */
+    slots?: number;
     /**
      * Hard upper bound on per-splat tile coverage. The project shader
      * clamps `coverage[i] = min(rawBboxArea, maxCoveragePerSplat)`, so
@@ -135,8 +144,10 @@ const numSHCoeffsPerChannel = (bands: number): number => {
 interface PipelineBuffers {
     inputBuffer: StorageBuffer;
     projBuffer: StorageBuffer;
-    runningStateBuffer: StorageBuffer;
-    outputBuffer: StorageBuffer;
+    /** One running-state buffer per slot. */
+    runningStateBuffers: StorageBuffer[];
+    /** One RGBA8 output buffer per slot. */
+    outputBuffers: StorageBuffer[];
     /** Per-tile offset table for binned rasterize: `(numTiles + 1) × u32`. */
     tileOffsetsBuffer: StorageBuffer;
     /**
@@ -168,6 +179,7 @@ interface PipelineBuffers {
      * indices to its internal `sortedIndices` buffer.
      */
     splatValuesBuffer: StorageBuffer;
+    clearStateCompute: Compute;
     projectCompute: Compute;
     prefixSumCompute: Compute;
     emitPairsCompute: Compute;
@@ -211,6 +223,7 @@ class GpuSplatRasterizer {
     private emitPairsShader: Shader;
     private prepareIndirectShader: Shader;
     private initTileOffsetsShader: Shader;
+    private clearStateShader: Shader;
     private findBoundariesShader: Shader;
     private rasterizeBinnedShader: Shader;
     private finalizeShader: Shader;
@@ -219,6 +232,7 @@ class GpuSplatRasterizer {
     private emitPairsBgFormat: BindGroupFormat;
     private prepareIndirectBgFormat: BindGroupFormat;
     private initTileOffsetsBgFormat: BindGroupFormat;
+    private clearStateBgFormat: BindGroupFormat;
     private findBoundariesBgFormat: BindGroupFormat;
     private rasterizeBinnedBgFormat: BindGroupFormat;
     private finalizeBgFormat: BindGroupFormat;
@@ -230,9 +244,9 @@ class GpuSplatRasterizer {
     private radixSort: ComputeRadixSort;
     /** sortIndirect numBits, derived from numTiles (multiple of 4). */
     private sortKeyBits: number;
-    private clearStatePattern: Float32Array;
     /** Active group's tile dimensions, set by `beginGroup`. */
     private activeTilesX: number = 0;
+    private activeSlot: number = 0;
     private activeTilesY: number = 0;
 
     /** Floats per gaussian in the input buffer (depends on SH band count). */
@@ -258,10 +272,18 @@ class GpuSplatRasterizer {
         this.groupPixelH = options.groupTilesY * TILE_SIZE;
 
         const numTiles = options.groupTilesX * options.groupTilesY;
-        // Round up to multiple of 4 (radix sort uses 4-bit passes). Min 4
-        // because ComputeRadixSort requires numBits ≥ 4. Max 32 (u32 key).
-        const tileBits = Math.max(4, Math.min(32, Math.ceil(Math.log2(Math.max(2, numTiles)) / 4) * 4));
-        this.sortKeyBits = tileBits;
+        // Round up to a multiple of 4 (radix sort uses 4-bit passes), then to an
+        // ODD number of passes. Engine 2.21's radix sort keeps the caller's key and
+        // value buffers in its ping-pong rotation, so after an even pass count the
+        // result sits in those buffers while `sortedKeys` / `sortedIndices` point at
+        // internal ones that were never written — every splat lands in the wrong
+        // tile and the image comes out empty or scrambled. Odd counts end in the
+        // internal buffers the getters return, on that engine and on the fixed one
+        // alike. Min 4 because ComputeRadixSort requires numBits ≥ 4; 28 covers
+        // any tile count a u32 key can index.
+        let tileBits = Math.max(4, Math.ceil(Math.log2(Math.max(2, numTiles)) / 4) * 4);
+        if ((tileBits / 4) % 2 === 0) tileBits += 4;
+        this.sortKeyBits = Math.min(28, tileBits);
 
         const coeffs = numSHCoeffsPerChannel(options.numSHBands);
         this.inputStride = 14 + 3 * coeffs;
@@ -295,6 +317,10 @@ class GpuSplatRasterizer {
             new BindUniformBufferFormat('uniforms', SHADERSTAGE_COMPUTE),
             new BindStorageBufferFormat('totalPairs', SHADERSTAGE_COMPUTE, true),
             new BindStorageBufferFormat('tileOffsets', SHADERSTAGE_COMPUTE)
+        ]);
+        this.clearStateBgFormat = new BindGroupFormat(device, [
+            new BindUniformBufferFormat('uniforms', SHADERSTAGE_COMPUTE),
+            new BindStorageBufferFormat('runningState', SHADERSTAGE_COMPUTE)
         ]);
         this.findBoundariesBgFormat = new BindGroupFormat(device, [
             new BindUniformBufferFormat('uniforms', SHADERSTAGE_COMPUTE),
@@ -399,6 +425,7 @@ class GpuSplatRasterizer {
         this.emitPairsShader = mkShader('splat-tilebin-emit-pairs', tileBinEmitPairsWgsl(), this.emitPairsBgFormat);
         this.prepareIndirectShader = mkShader('splat-tilebin-prepare-indirect', prepareIndirectWgsl(), this.prepareIndirectBgFormat, prepareIndirectUniforms);
         this.initTileOffsetsShader = mkShader('splat-tilebin-init-tile-offsets', initTileOffsetsWgsl(), this.initTileOffsetsBgFormat);
+        this.clearStateShader = mkShader('splat-clear-state', clearStateWgsl(), this.clearStateBgFormat);
         this.findBoundariesShader = mkShader('splat-tilebin-find-boundaries', findBoundariesWgsl(), this.findBoundariesBgFormat);
         this.rasterizeBinnedShader = mkShader('splat-rasterize-binned', rasterizeBinnedWgsl(), this.rasterizeBinnedBgFormat);
         this.finalizeShader = mkShader('splat-finalize-pack', finalizeWgsl(), this.finalizeBgFormat);
@@ -426,8 +453,9 @@ class GpuSplatRasterizer {
 
         const inputBuffer = new StorageBuffer(device, inputBytes, BUFFERUSAGE_COPY_DST);
         const projBuffer = new StorageBuffer(device, projBytes, 0);
-        const runningStateBuffer = new StorageBuffer(device, stateBytes, BUFFERUSAGE_COPY_DST);
-        const outputBuffer = new StorageBuffer(device, outputBytes, BUFFERUSAGE_COPY_SRC);
+        const slots = Math.max(1, options.slots ?? 1);
+        const runningStateBuffers = Array.from({ length: slots }, () => new StorageBuffer(device, stateBytes, BUFFERUSAGE_COPY_DST));
+        const outputBuffers = Array.from({ length: slots }, () => new StorageBuffer(device, outputBytes, BUFFERUSAGE_COPY_SRC));
         const tileOffsetsBuffer = new StorageBuffer(device, tileOffsetsBytes, 0);
         const coverageBuffer = new StorageBuffer(device, coverageBytes, 0);
         const emitOffsetBuffer = new StorageBuffer(device, emitOffsetBytes, 0);
@@ -468,26 +496,30 @@ class GpuSplatRasterizer {
 
         const rasterizeBinnedCompute = new Compute(device, this.rasterizeBinnedShader, 'splat-rasterize-binned');
         rasterizeBinnedCompute.setParameter('projected', projBuffer);
-        rasterizeBinnedCompute.setParameter('runningState', runningStateBuffer);
+        rasterizeBinnedCompute.setParameter('runningState', runningStateBuffers[0]);
         rasterizeBinnedCompute.setParameter('tileOffsets', tileOffsetsBuffer);
         // `sortedSplatIndices` is bound per-chunk inside `dispatchChunk`,
         // pointing at the radix sort's `sortedIndices` output buffer.
 
         const finalizeCompute = new Compute(device, this.finalizeShader, 'splat-finalize');
-        finalizeCompute.setParameter('runningState', runningStateBuffer);
-        finalizeCompute.setParameter('output', outputBuffer);
+        finalizeCompute.setParameter('runningState', runningStateBuffers[0]);
+        finalizeCompute.setParameter('output', outputBuffers[0]);
+
+        const clearStateCompute = new Compute(device, this.clearStateShader, 'splat-clear-state');
+        clearStateCompute.setParameter('runningState', runningStateBuffers[0]);
 
         this.buffers = {
             inputBuffer,
             projBuffer,
-            runningStateBuffer,
-            outputBuffer,
+            runningStateBuffers,
+            outputBuffers,
             tileOffsetsBuffer,
             coverageBuffer,
             emitOffsetBuffer,
             totalPairsBuffer,
             tileKeysBuffer,
             splatValuesBuffer,
+            clearStateCompute,
             projectCompute,
             prefixSumCompute,
             emitPairsCompute,
@@ -497,13 +529,6 @@ class GpuSplatRasterizer {
             rasterizeBinnedCompute,
             finalizeCompute
         };
-
-        // CPU-side cleared running state: T = 1 per pixel, color = 0.
-        // Reused across groups; uploaded to runningStateBuffer at beginGroup.
-        this.clearStatePattern = new Float32Array(groupPixels * RUNNING_STATE_STRIDE_F32);
-        for (let i = 0; i < groupPixels; i++) {
-            this.clearStatePattern[i * 4 + 3] = 1; // T = 1
-        }
 
         // `indirect: true` is required since engine 2.19 — indirect mode
         // moved from a per-call `sortIndirect()` behaviour to a constructor
@@ -558,6 +583,7 @@ class GpuSplatRasterizer {
 
         const b = this.buffers;
         for (const c of [
+            b.clearStateCompute,
             b.projectCompute,
             b.prefixSumCompute,
             b.emitPairsCompute,
@@ -596,26 +622,63 @@ class GpuSplatRasterizer {
     }
 
     /**
+     * Point the rasterizer at another view. Takes effect at the next `beginGroup`,
+     * which uploads the uniforms; the projection stays as constructed and the
+     * image must fit the constructed group. Lets one instance, with its compiled
+     * pipelines and sized buffers, serve many renders that differ only in view.
+     *
+     * @param basis - The camera basis and focal lengths.
+     * @param near - Near plane distance in world units.
+     * @param imageWidth - Image width in pixels, at most the constructed width.
+     * @param imageHeight - Image height in pixels, at most the constructed height.
+     */
+    setView(basis: CameraBasis, near: number, imageWidth: number, imageHeight: number): void {
+        const o = this.options;
+        o.rightX = basis.right.x; o.rightY = basis.right.y; o.rightZ = basis.right.z;
+        o.downX = basis.down.x; o.downY = basis.down.y; o.downZ = basis.down.z;
+        o.forwardX = basis.forward.x; o.forwardY = basis.forward.y; o.forwardZ = basis.forward.z;
+        o.eyeX = basis.eye.x; o.eyeY = basis.eye.y; o.eyeZ = basis.eye.z;
+        o.focalX = basis.focalX; o.focalY = basis.focalY;
+        o.near = near;
+        o.imageWidth = imageWidth;
+        o.imageHeight = imageHeight;
+    }
+
+    /**
      * Begin processing a group. Clears running state and sets uniforms.
      *
      * @param groupX - Group index along X.
      * @param groupY - Group index along Y.
      * @param groupTilesX - Number of tiles in this group along X.
      * @param groupTilesY - Number of tiles in this group along Y.
+     * @param slot - Which running-state/output pair to render into; see `slots`.
      */
     beginGroup(
         groupX: number,
         groupY: number,
         groupTilesX: number,
-        groupTilesY: number
+        groupTilesY: number,
+        slot: number = 0
     ): void {
         this.setUniforms(groupX, groupY, groupTilesX, groupTilesY);
         this.activeTilesX = groupTilesX;
         this.activeTilesY = groupTilesY;
+
+        const b = this.buffers;
+        if (slot !== this.activeSlot) {
+            this.activeSlot = slot;
+            const state = b.runningStateBuffers[slot];
+            b.clearStateCompute.setParameter('runningState', state);
+            b.rasterizeBinnedCompute.setParameter('runningState', state);
+            b.finalizeCompute.setParameter('runningState', state);
+            b.finalizeCompute.setParameter('output', b.outputBuffers[slot]);
+        }
+        // Clear the running state on the GPU: colour 0, transmittance 1. Four pixels
+        // per thread, 256 threads per workgroup.
         const groupPixels = groupTilesX * groupTilesY * TILE_SIZE * TILE_SIZE;
-        this.buffers.runningStateBuffer.write(
-            0, this.clearStatePattern, 0, groupPixels * RUNNING_STATE_STRIDE_F32
-        );
+        const clear = this.buffers.clearStateCompute;
+        clear.setupDispatch(Math.ceil(groupPixels / (4 * 256)), 1, 1);
+        this.device.computeDispatch([clear], 'splat-clear-state');
     }
 
     /**
@@ -775,7 +838,7 @@ class GpuSplatRasterizer {
         const activePixelW = this.activeTilesX * TILE_SIZE;
         const activePixelH = this.activeTilesY * TILE_SIZE;
         const groupOutputBytes = activePixelW * activePixelH * 4;
-        return b.outputBuffer.read(0, groupOutputBytes, null, true) as Promise<Uint8Array>;
+        return b.outputBuffers[this.activeSlot].read(0, groupOutputBytes, null, true) as Promise<Uint8Array>;
     }
 
     /**
@@ -786,8 +849,8 @@ class GpuSplatRasterizer {
         const b = this.buffers;
         b.inputBuffer.destroy();
         b.projBuffer.destroy();
-        b.runningStateBuffer.destroy();
-        b.outputBuffer.destroy();
+        for (const buffer of b.runningStateBuffers) buffer.destroy();
+        for (const buffer of b.outputBuffers) buffer.destroy();
         b.tileOffsetsBuffer.destroy();
         b.coverageBuffer.destroy();
         b.emitOffsetBuffer.destroy();
@@ -799,6 +862,7 @@ class GpuSplatRasterizer {
         this.emitPairsShader.destroy();
         this.prepareIndirectShader.destroy();
         this.initTileOffsetsShader.destroy();
+        this.clearStateShader.destroy();
         this.findBoundariesShader.destroy();
         this.rasterizeBinnedShader.destroy();
         this.finalizeShader.destroy();
@@ -807,6 +871,7 @@ class GpuSplatRasterizer {
         this.emitPairsBgFormat.destroy();
         this.prepareIndirectBgFormat.destroy();
         this.initTileOffsetsBgFormat.destroy();
+        this.clearStateBgFormat.destroy();
         this.findBoundariesBgFormat.destroy();
         this.rasterizeBinnedBgFormat.destroy();
         this.finalizeBgFormat.destroy();

--- a/src/lib/gpu/gpu-splat-rasterizer.ts
+++ b/src/lib/gpu/gpu-splat-rasterizer.ts
@@ -92,6 +92,12 @@ interface SplatRasterizerOptions {
      */
     slots?: number;
     /**
+     * Fade out splats whose projected radius approaches the image height, default
+     * true; see `RADIUS_FADE_START_FRAC`. Off for measurement renders, where a splat
+     * that legitimately fills the frame must keep its full alpha.
+     */
+    radiusFade?: boolean;
+    /**
      * Hard upper bound on per-splat tile coverage. The project shader
      * clamps `coverage[i] = min(rawBboxArea, maxCoveragePerSplat)`, so
      * the pair buffer is bounded by `chunkCap × maxCoveragePerSplat`
@@ -271,19 +277,27 @@ class GpuSplatRasterizer {
         this.groupPixelW = options.groupTilesX * TILE_SIZE;
         this.groupPixelH = options.groupTilesY * TILE_SIZE;
 
+        // `indirect: true` is required since engine 2.19 — indirect mode
+        // moved from a per-call `sortIndirect()` behaviour to a constructor
+        // option. Without it, `sortIndirect()` silently dispatches directly
+        // with `maxElementCount` (the full pair-buffer capacity), sorting
+        // uninitialized zeros to the front and producing empty tile slices.
+        this.radixSort = new ComputeRadixSort(device, { indirect: true });
+
+        // The key width is a whole number of the sort's passes — 4 bits each on the
+        // portable implementation, 8 on the one-sweep variant the engine picks on
+        // NVIDIA — and an ODD number of them. Engine 2.21's sort keeps the caller's
+        // value buffer in its ping-pong rotation, so after an even pass count the
+        // sorted indices sit in that buffer while `sortedIndices` points at an
+        // internal one that was never written, and every splat lands in the wrong
+        // tile. Odd counts end in the buffer the getter returns, on that engine and
+        // on the fixed one alike. Capped at the widest odd pass count a u32 key holds.
         const numTiles = options.groupTilesX * options.groupTilesY;
-        // Round up to a multiple of 4 (radix sort uses 4-bit passes), then to an
-        // ODD number of passes. Engine 2.21's radix sort keeps the caller's key and
-        // value buffers in its ping-pong rotation, so after an even pass count the
-        // result sits in those buffers while `sortedKeys` / `sortedIndices` point at
-        // internal ones that were never written — every splat lands in the wrong
-        // tile and the image comes out empty or scrambled. Odd counts end in the
-        // internal buffers the getters return, on that engine and on the fixed one
-        // alike. Min 4 because ComputeRadixSort requires numBits ≥ 4; 28 covers
-        // any tile count a u32 key can index.
-        let tileBits = Math.max(4, Math.ceil(Math.log2(Math.max(2, numTiles)) / 4) * 4);
-        if ((tileBits / 4) % 2 === 0) tileBits += 4;
-        this.sortKeyBits = Math.min(28, tileBits);
+        const { radixBits } = this.radixSort;
+        const maxPasses = Math.floor(32 / radixBits);
+        let passes = Math.max(1, Math.ceil(Math.log2(Math.max(2, numTiles)) / radixBits));
+        if (passes % 2 === 0) passes += 1;
+        this.sortKeyBits = Math.min(passes, maxPasses % 2 === 0 ? maxPasses - 1 : maxPasses) * radixBits;
 
         const coeffs = numSHCoeffsPerChannel(options.numSHBands);
         this.inputStride = 14 + 3 * coeffs;
@@ -382,6 +396,7 @@ class GpuSplatRasterizer {
         if (options.numSHBands >= 1) sharedCdefines.set('SH_BAND_1', '');
         if (options.numSHBands >= 2) sharedCdefines.set('SH_BAND_2', '');
         if (options.numSHBands >= 3) sharedCdefines.set('SH_BAND_3', '');
+        if (options.radiusFade === false) sharedCdefines.set('NO_RADIUS_FADE', '');
 
         const mkShader = (
             name: string,
@@ -529,13 +544,6 @@ class GpuSplatRasterizer {
             rasterizeBinnedCompute,
             finalizeCompute
         };
-
-        // `indirect: true` is required since engine 2.19 — indirect mode
-        // moved from a per-call `sortIndirect()` behaviour to a constructor
-        // option. Without it, `sortIndirect()` silently dispatches directly
-        // with `maxElementCount` (the full pair-buffer capacity), sorting
-        // uninitialized zeros to the front and producing empty tile slices.
-        this.radixSort = new ComputeRadixSort(device, { indirect: true });
 
         // The per-chunk pipeline reserves 2 slots in the device's
         // indirect-dispatch buffer (one for the radix sort, one for

--- a/src/lib/gpu/gpu-splat-rasterizer.ts
+++ b/src/lib/gpu/gpu-splat-rasterizer.ts
@@ -284,20 +284,14 @@ class GpuSplatRasterizer {
         // uninitialized zeros to the front and producing empty tile slices.
         this.radixSort = new ComputeRadixSort(device, { indirect: true });
 
-        // The key width is a whole number of the sort's passes — 4 bits each on the
-        // portable implementation, 8 on the one-sweep variant the engine picks on
-        // NVIDIA — and an ODD number of them. Engine 2.21's sort keeps the caller's
-        // value buffer in its ping-pong rotation, so after an even pass count the
-        // sorted indices sit in that buffer while `sortedIndices` points at an
-        // internal one that was never written, and every splat lands in the wrong
-        // tile. Odd counts end in the buffer the getter returns, on that engine and
-        // on the fixed one alike. Capped at the widest odd pass count a u32 key holds.
+        // The key width is the fewest whole passes that index every tile: 4 bits
+        // each on the portable implementation, 8 on the one-sweep variant the engine
+        // picks on NVIDIA. Engine 2.22 returns the sorted indices correctly at any
+        // pass count (2.21 needed an odd one). Capped at what a u32 key holds.
         const numTiles = options.groupTilesX * options.groupTilesY;
         const { radixBits } = this.radixSort;
-        const maxPasses = Math.floor(32 / radixBits);
-        let passes = Math.max(1, Math.ceil(Math.log2(Math.max(2, numTiles)) / radixBits));
-        if (passes % 2 === 0) passes += 1;
-        this.sortKeyBits = Math.min(passes, maxPasses % 2 === 0 ? maxPasses - 1 : maxPasses) * radixBits;
+        const passes = Math.max(1, Math.ceil(Math.log2(Math.max(2, numTiles)) / radixBits));
+        this.sortKeyBits = Math.min(passes, Math.floor(32 / radixBits)) * radixBits;
 
         const coeffs = numSHCoeffsPerChannel(options.numSHBands);
         this.inputStride = 14 + 3 * coeffs;
@@ -794,8 +788,8 @@ class GpuSplatRasterizer {
         // The radix sort is stable, so within each tile the splatValues
         // remain in their input order = depth-monotonic (from the CPU
         // pre-sort), giving depth-ordered compositing per tile for free.
-        // numBits = sortKeyBits (rounded up to multiple of 4 from
-        // ceil(log2(numTiles))) — only the minimum required passes run.
+        // numBits = sortKeyBits (ceil(log2(numTiles)) rounded up to the
+        // sort's pass width) — only the minimum required passes run.
         const pairsCap = this.chunkCap * this.options.maxCoveragePerSplat;
         this.radixSort.sortIndirect(
             b.tileKeysBuffer, pairsCap, this.sortKeyBits, sortSlot,

--- a/src/lib/gpu/shaders/clear-state.ts
+++ b/src/lib/gpu/shaders/clear-state.ts
@@ -1,0 +1,34 @@
+/**
+ * Resets the running state of every pixel in the active group to "nothing
+ * painted yet": colour 0 and transmittance 1. Runs on the GPU at `beginGroup`
+ * so a group of any size costs no upload — a 4096-square group is 268 MB of
+ * state, which would otherwise be written from the CPU for every image.
+ *
+ * Each thread clears four pixels so a maximal group stays within the dispatch
+ * limit of 65535 workgroups.
+ *
+ * @returns WGSL source for the clear-state compute shader.
+ */
+const clearStateWgsl = () => /* wgsl */`
+#include "uniformsStruct"
+#include "constants"
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(1) var<storage, read_write> runningState: array<vec4<f32>>;
+
+const PIXELS_PER_THREAD: u32 = 4u;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let numPixels = uniforms.groupTilesX * uniforms.groupTilesY * TILE_SIZE * TILE_SIZE;
+    let base = gid.x * PIXELS_PER_THREAD;
+    for (var k: u32 = 0u; k < PIXELS_PER_THREAD; k = k + 1u) {
+        let i = base + k;
+        if (i < numPixels) {
+            runningState[i] = vec4<f32>(0.0, 0.0, 0.0, 1.0);
+        }
+    }
+}
+`;
+
+export { clearStateWgsl };

--- a/src/lib/gpu/shaders/project.ts
+++ b/src/lib/gpu/shaders/project.ts
@@ -134,11 +134,20 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     // splats fade at every render resolution — preserves cross-
     // resolution consistency (e.g. 8K-downsampled-to-1080p matches
     // 1080p direct).
+    //
+    // NO_RADIUS_FADE (measurement renders) keeps every splat at full
+    // alpha whatever its footprint; the group AABB and coverage cap
+    // still bound the work.
+#ifdef NO_RADIUS_FADE
+    let radiusFade = 1.0;
+    let radius = ceil(radiusRaw);
+#else
     let fadeStart = RADIUS_FADE_START_FRAC * f32(uniforms.imageHeight);
     let fadeEnd = RADIUS_FADE_END_FRAC * f32(uniforms.imageHeight);
     let radiusFade = clamp((fadeEnd - radiusRaw) / (fadeEnd - fadeStart), 0.0, 1.0);
     if (radiusFade <= 0.0) { writeInvalid(i); return; }
     let radius = ceil(min(radiusRaw, fadeEnd));
+#endif
 
     // Group AABB cull. The BVH frustum query may include splats whose
     // 3D AABB grazes the frustum but whose 2D footprint misses the group.

--- a/src/lib/render/config.ts
+++ b/src/lib/render/config.ts
@@ -1,3 +1,5 @@
+import { type GraphicsDevice } from 'playcanvas';
+
 /**
  * Centralised render-time tunables. Constants that today live as magic
  * numbers in the project/rasterize WGSL shaders, in `gaussian-aabb.ts`'s
@@ -132,6 +134,33 @@ export const PAIR_BUFFER_BUDGET_BYTES = 768 * 1024 * 1024;
  * pipeline.
  */
 export const PAIR_BUFFER_TOTAL_BYTES_PER_ELEMENT = 4 * 6;
+
+/**
+ * Largest storage buffer one binding may reference, from the device's WebGPU
+ * limits, or the spec's 128 MiB baseline when the device does not expose them.
+ *
+ * @param device - The graphics device.
+ * @returns The limit in bytes.
+ */
+export const storageBindingLimit = (device: GraphicsDevice): number => {
+    const limits = (device as { limits?: { maxStorageBufferBindingSize?: number } }).limits;
+    return limits?.maxStorageBufferBindingSize ?? 128 * 1024 * 1024;
+};
+
+/**
+ * Gaussians per rasterizer chunk within the two pair-buffer limits: each of the
+ * six pair-sized buffers must fit one storage binding, and together they must
+ * fit `budgetBytes`.
+ *
+ * @param device - The graphics device.
+ * @param maxCoveragePerSplat - Most tiles one splat may cover, so pairs per gaussian.
+ * @param budgetBytes - Total bytes for all pair-sized buffers; {@link PAIR_BUFFER_BUDGET_BYTES} by default.
+ * @returns The chunk cap, at least 1.
+ */
+export const rasterChunkCap = (device: GraphicsDevice, maxCoveragePerSplat: number, budgetBytes = PAIR_BUFFER_BUDGET_BYTES): number => Math.max(1, Math.min(
+    Math.floor(storageBindingLimit(device) / (maxCoveragePerSplat * 4)),
+    Math.floor(budgetBytes / (maxCoveragePerSplat * PAIR_BUFFER_TOTAL_BYTES_PER_ELEMENT))
+));
 
 /**
  * Screen-radius fade thresholds, expressed as fractions of image

--- a/src/lib/render/raster-pass.ts
+++ b/src/lib/render/raster-pass.ts
@@ -87,13 +87,17 @@ interface BackgroundRGBA {
  * @param dataTable - Gaussian splat data in PlayCanvas-identity space.
  * @param camera - Camera parameters.
  * @param background - RGBA background composited under residual transmittance.
+ * @param options - Render options.
+ * @param options.quiet - Suppress the progress group and bar, for callers
+ * rendering many small images in a loop.
  * @returns RGBA byte array of length `camera.width × camera.height × 4`.
  */
 const renderRasterPass = async (
     device: GraphicsDevice,
     dataTable: DataTable,
     camera: RenderCamera,
-    background: BackgroundRGBA
+    background: BackgroundRGBA,
+    options: { quiet?: boolean } = {}
 ): Promise<Uint8Array> => {
     if (!Number.isInteger(camera.width) || !Number.isInteger(camera.height) ||
         camera.width <= 0 || camera.height <= 0) {
@@ -123,7 +127,7 @@ const renderRasterPass = async (
     // test, which uses the actual screen-space radius — strictly
     // tighter than the L∞-bound CPU test. For equirect the cone test
     // doesn't apply at all: every direction is in-view.
-    const cullGroup = logger.group('Cull');
+    const cullGroup = options.quiet ? null : logger.group('Cull');
     const xCol = dataTable.getColumnByName('x')!.data as Float32Array;
     const yCol = dataTable.getColumnByName('y')!.data as Float32Array;
     const zCol = dataTable.getColumnByName('z')!.data as Float32Array;
@@ -150,7 +154,7 @@ const renderRasterPass = async (
             if (dx * dx + dy * dy + dz * dz > nearSq) candidates[candidateCount++] = i;
         }
     }
-    cullGroup.end();
+    cullGroup?.end();
 
     // ---- Image tile grid + sub-frame partition ----
     // Pinhole renders larger than ~1080p are split into sub-frames so
@@ -397,7 +401,7 @@ const renderRasterPass = async (
     for (let s = 0; s < numSubFrames; s++) {
         totalChunks += Math.ceil(subFrameLists[s].length / effectiveChunkCap);
     }
-    const rasterBar = logger.bar('rasterizing', Math.max(1, totalChunks));
+    const rasterBar = options.quiet ? null : logger.bar('rasterizing', Math.max(1, totalChunks));
     let completed = 0;
 
     for (let sy = 0; sy < numSubFramesY; sy++) {
@@ -413,7 +417,7 @@ const renderRasterPass = async (
                 const chunkSize = Math.min(effectiveChunkCap, sfCount - chunkStart);
                 packChunkInput(cols, sfCandidates, chunkStart, chunkSize, numSHBands, chunkInput);
                 rasterizer.dispatchChunk(chunkInput, chunkSize);
-                rasterBar.update(++completed);
+                rasterBar?.update(++completed);
             }
 
             const subFrameBytes = await rasterizer.finishGroup();
@@ -438,7 +442,7 @@ const renderRasterPass = async (
             }
         }
     }
-    rasterBar.end();
+    rasterBar?.end();
 
     rasterizer.destroy();
 

--- a/src/lib/render/raster-pass.ts
+++ b/src/lib/render/raster-pass.ts
@@ -87,17 +87,13 @@ interface BackgroundRGBA {
  * @param dataTable - Gaussian splat data in PlayCanvas-identity space.
  * @param camera - Camera parameters.
  * @param background - RGBA background composited under residual transmittance.
- * @param options - Render options.
- * @param options.quiet - Suppress the progress group and bar, for callers
- * rendering many small images in a loop.
  * @returns RGBA byte array of length `camera.width × camera.height × 4`.
  */
 const renderRasterPass = async (
     device: GraphicsDevice,
     dataTable: DataTable,
     camera: RenderCamera,
-    background: BackgroundRGBA,
-    options: { quiet?: boolean } = {}
+    background: BackgroundRGBA
 ): Promise<Uint8Array> => {
     if (!Number.isInteger(camera.width) || !Number.isInteger(camera.height) ||
         camera.width <= 0 || camera.height <= 0) {
@@ -127,7 +123,7 @@ const renderRasterPass = async (
     // test, which uses the actual screen-space radius — strictly
     // tighter than the L∞-bound CPU test. For equirect the cone test
     // doesn't apply at all: every direction is in-view.
-    const cullGroup = options.quiet ? null : logger.group('Cull');
+    const cullGroup = logger.group('Cull');
     const xCol = dataTable.getColumnByName('x')!.data as Float32Array;
     const yCol = dataTable.getColumnByName('y')!.data as Float32Array;
     const zCol = dataTable.getColumnByName('z')!.data as Float32Array;
@@ -154,7 +150,7 @@ const renderRasterPass = async (
             if (dx * dx + dy * dy + dz * dz > nearSq) candidates[candidateCount++] = i;
         }
     }
-    cullGroup?.end();
+    cullGroup.end();
 
     // ---- Image tile grid + sub-frame partition ----
     // Pinhole renders larger than ~1080p are split into sub-frames so
@@ -401,7 +397,7 @@ const renderRasterPass = async (
     for (let s = 0; s < numSubFrames; s++) {
         totalChunks += Math.ceil(subFrameLists[s].length / effectiveChunkCap);
     }
-    const rasterBar = options.quiet ? null : logger.bar('rasterizing', Math.max(1, totalChunks));
+    const rasterBar = logger.bar('rasterizing', Math.max(1, totalChunks));
     let completed = 0;
 
     for (let sy = 0; sy < numSubFramesY; sy++) {
@@ -417,7 +413,7 @@ const renderRasterPass = async (
                 const chunkSize = Math.min(effectiveChunkCap, sfCount - chunkStart);
                 packChunkInput(cols, sfCandidates, chunkStart, chunkSize, numSHBands, chunkInput);
                 rasterizer.dispatchChunk(chunkInput, chunkSize);
-                rasterBar?.update(++completed);
+                rasterBar.update(++completed);
             }
 
             const subFrameBytes = await rasterizer.finishGroup();
@@ -442,7 +438,7 @@ const renderRasterPass = async (
             }
         }
     }
-    rasterBar?.end();
+    rasterBar.end();
 
     rasterizer.destroy();
 

--- a/src/lib/render/raster-pass.ts
+++ b/src/lib/render/raster-pass.ts
@@ -5,10 +5,9 @@ import {
     AA_DILATION_COV,
     DISCRIMINANT_FLOOR,
     JACOBIAN_LIMIT_FACTOR,
-    PAIR_BUFFER_BUDGET_BYTES,
-    PAIR_BUFFER_TOTAL_BYTES_PER_ELEMENT,
     SIGMA_CUTOFF,
-    TILE_SIZE
+    TILE_SIZE,
+    rasterChunkCap
 } from './config';
 import {
     SortScratch,
@@ -341,14 +340,9 @@ const renderRasterPass = async (
     //      within `PAIR_BUFFER_BUDGET_BYTES` — bounds the rasterizer's
     //      peak GPU footprint when chunkCap could otherwise saturate
     //      the binding limit on adapters with very large bindings.
-    // @ts-ignore - limits is exposed by WebgpuGraphicsDevice
-    const wgpuLimits = (device as { limits?: { maxStorageBufferBindingSize?: number } }).limits;
-    const maxBindingBytes = wgpuLimits?.maxStorageBufferBindingSize ?? 128 * 1024 * 1024;
-    const bindingChunkCap = Math.floor(maxBindingBytes / (maxCoveragePerSplat * 4));
-    const budgetChunkCap = Math.floor(PAIR_BUFFER_BUDGET_BYTES / (maxCoveragePerSplat * PAIR_BUFFER_TOTAL_BYTES_PER_ELEMENT));
     const effectiveChunkCap = Math.max(
         1,
-        Math.min(CHUNK_CAP, budgetChunkCap, bindingChunkCap, candidateCount)
+        Math.min(CHUNK_CAP, rasterChunkCap(device, maxCoveragePerSplat), candidateCount)
     );
 
     const rasterizer = new GpuSplatRasterizer(device, {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -31,6 +31,9 @@ type Options = {
     /** Gaussians (in thousands) below which an LOD chunk is not split for exceeding the extent. Default: 8 */
     lodChunkMin?: number;
 
+    /** Whether to render and write per-leaf LOD error tables (needs a GPU). Default: false */
+    lodErrors?: boolean;
+
     /** SPZ format version to write. Default: 4. */
     spzVersion?: 3 | 4;
 

--- a/src/lib/writers/lod-error.ts
+++ b/src/lib/writers/lod-error.ts
@@ -1,0 +1,656 @@
+import { type GraphicsDevice, Vec3 } from 'playcanvas';
+
+import { Column, DataTable } from '../data-table';
+import { GpuSplatRasterizer } from '../gpu';
+import { type RenderCamera, buildCameraBasis } from '../render/camera';
+import { PAIR_BUFFER_BUDGET_BYTES, PAIR_BUFFER_TOTAL_BYTES_PER_ELEMENT, TILE_SIZE } from '../render/config';
+import {
+    SortScratch, getSplatColumnRefs, packChunkInput, sortCandidatesByDepth, splatInputStride
+} from '../render/preprocess';
+import { Transform } from '../utils';
+
+/**
+ * Rendering side of the per-leaf LOD error metric: the views a leaf is judged
+ * from, the renderers that draw its levels from those views (alone, or many
+ * small leaves per image), and the image comparison. The writer gathers the
+ * levels and orchestrates.
+ */
+
+type Aabb = {
+    min: number[],
+    max: number[]
+};
+
+/** A leaf's levels, gathered as tables in one shared space, plus its ellipsoid AABB. */
+type LeafLevels = {
+    bound: Aabb;
+    levels: Map<number, DataTable>;
+};
+
+/**
+ * Most pixels across a leaf's render. This is the metric's calibration: it fixes
+ * the on-screen size at which a level is judged, since detail finer than a pixel
+ * of the render is invisible to it. 512 across a leaf corresponds to a leaf
+ * spanning roughly a quarter of a 2K-wide viewport — the band in which the
+ * engine's budget allocator is actually trading levels off against each other.
+ * The nearest leaves are bought first whatever their error says, and the far
+ * field sits at its coarsest level regardless, so accuracy elsewhere buys little.
+ */
+const ERROR_VIEW_MAX_SIZE = 512;
+
+/** Fewest pixels across a leaf's render. */
+const ERROR_VIEW_MIN_SIZE = 64;
+
+/**
+ * Camera distance from the leaf centre, in bounding-sphere radii, when a leaf is
+ * rendered alone. Far enough to be orthographic to within a pixel: the view
+ * direction varies by under 0.3 degrees across the frame, so a thin slab seen
+ * edge-on stays a sliver at the frame's edges as at its centre, and a leaf
+ * measures the same alone as in an atlas, whose camera is equally distant.
+ * Positions stay well within f32 precision at this range.
+ */
+const ERROR_VIEW_DISTANCE = 200;
+
+/** Margin around a leaf's bounding sphere in its frame, as a factor of the radius. */
+const ERROR_VIEW_MARGIN = 1.05;
+
+/** The six axis-aligned directions a leaf is viewed from. */
+const ERROR_VIEW_DIRECTIONS = [[1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0], [0, 0, 1], [0, 0, -1]];
+
+/** Gaussians per GPU dispatch; bounds the input and pair buffers. */
+const CHUNK_CAP = 200_000;
+
+/**
+ * Renders the solo path keeps in flight before waiting for their readbacks: a
+ * leaf's six views. A render's wall time is mostly the GPU round trip, not the
+ * work, so issuing the views together and waiting once turns six round trips
+ * into one.
+ */
+const SOLO_SLOTS = ERROR_VIEW_DIRECTIONS.length;
+
+/** Gaussians sampled when estimating a leaf's finest splat footprint. */
+const FOOTPRINT_SAMPLES = 4096;
+
+/**
+ * Pixels across the image that batches of leaves are rendered into. 256 tiles a
+ * side: with cells two frames wide this holds 16 leaves at the full 512-pixel
+ * frame and over a thousand at a 64-pixel one. Image sizes are kept to powers of
+ * two.
+ */
+const ATLAS_SIZE = 4096;
+
+/**
+ * Atlas cells are this many leaf frames across, the leaf frame centred, so that a
+ * neighbour's splats cannot reach into a leaf's frame. A leaf is normalised to
+ * unit bounding radius and the rasterizer cuts a splat off at three sigma, so a
+ * splat of sigma `s` reaches `1 + 3 s` units from its cell centre; the next
+ * cell's frame edge is `2 * 2.1 - 1.05 = 3.15` units away, so `s <= 0.5` leaves
+ * a margin of over half a unit for the rasterizer's anti-alias dilation and the
+ * pixel rounding of the frame. Leaves with a larger splat are rendered alone
+ * ({@link fitsAtlas}).
+ */
+const ATLAS_CELL_FRAMES = 2;
+
+/**
+ * Largest splat sigma, as a fraction of the leaf's bounding radius, for the leaf
+ * to share an atlas without reaching a neighbour's frame — see
+ * {@link ATLAS_CELL_FRAMES}. A leaf's bound is the union of its splats' one-sigma
+ * boxes, so the ratio never exceeds 1; for an isotropic splat alone in its leaf it
+ * is 1 / sqrt(3), so such leaves render alone.
+ */
+const ATLAS_MAX_SIGMA_RATIO = 0.5;
+
+/**
+ * Camera distance for an atlas, as a multiple of the atlas width. Cells sit off
+ * the camera axis, so this sets how far their view direction departs from the
+ * axis-aligned one a solo render has: at 200 widths it is under 0.15 degrees,
+ * under a pixel of skew across a frame.
+ */
+const ATLAS_DISTANCE = 200;
+
+/** Largest leaf frame that goes into an atlas. */
+const ATLAS_MAX_FRAME = ERROR_VIEW_MAX_SIZE;
+
+/** Most gaussians in a leaf's finest level for it to go into an atlas. */
+const ATLAS_MAX_GAUSSIANS = 8192;
+
+/** Most finest-level gaussians in one atlas batch; keeps a batch to a few GPU chunks. */
+const ATLAS_MAX_BATCH_GAUSSIANS = 1 << 16;
+
+/**
+ * Pixels across the renders of a leaf: enough to resolve the reference level's
+ * finest content, up to {@link ERROR_VIEW_MAX_SIZE}.
+ *
+ * Beyond the point where every splat spans a few pixels, more resolution changes
+ * nothing about a relative image error, so it only costs time. A dense leaf, whose
+ * footprints are far smaller than a pixel at any affordable size, gets the full
+ * calibration; a sparse leaf of large soft splats is judged at a size that resolves
+ * them and no more, which is also what lets it share an atlas with other leaves.
+ *
+ * The footprint is the tenth percentile of the per-gaussian largest scale over a
+ * sample of the level, so a few degenerate splats cannot drive the size.
+ *
+ * @param bound - The leaf's ellipsoid AABB.
+ * @param reference - The leaf's finest level.
+ * @returns A multiple of the tile size in `[ERROR_VIEW_MIN_SIZE, ERROR_VIEW_MAX_SIZE]`.
+ */
+const leafViewSize = (bound: Aabb, reference: DataTable): number => {
+    const sx = reference.getColumnByName('scale_0')!.data as Float32Array;
+    const sy = reference.getColumnByName('scale_1')!.data as Float32Array;
+    const sz = reference.getColumnByName('scale_2')!.data as Float32Array;
+    const n = sx.length;
+    const step = Math.max(1, Math.floor(n / FOOTPRINT_SAMPLES));
+    const radii: number[] = [];
+    for (let i = 0; i < n; i += step) {
+        radii.push(Math.exp(Math.max(sx[i], sy[i], sz[i])));
+    }
+    radii.sort((a, b) => a - b);
+    const footprint = Math.max(radii[Math.floor(radii.length * 0.1)], 1e-6);
+
+    const { min, max } = bound;
+    const extent = Math.hypot(max[0] - min[0], max[1] - min[1], max[2] - min[2]);
+    // four pixels across the finest footprint's diameter
+    const wanted = 2 * extent / footprint;
+    const size = Math.min(ERROR_VIEW_MAX_SIZE, Math.max(ERROR_VIEW_MIN_SIZE, wanted));
+    return Math.ceil(size / TILE_SIZE) * TILE_SIZE;
+};
+
+const boundRadius = (bound: Aabb): number => {
+    const { min, max } = bound;
+    return Math.max(Math.hypot(max[0] - min[0], max[1] - min[1], max[2] - min[2]) / 2, 1e-3);
+};
+
+// any vector not parallel to the view direction
+const viewUp = (dy: number): Vec3 => (dy !== 0 ? new Vec3(0, 0, 1) : new Vec3(0, 1, 0));
+
+/**
+ * The six views of a leaf rendered alone: pinhole cameras on each axis, far enough
+ * out to frame the leaf's bounding sphere with a little margin.
+ *
+ * @param bound - The leaf's ellipsoid AABB (the same volume the engine derives its
+ * screen coverage from).
+ * @param size - Pixels across each render, from {@link leafViewSize}.
+ * @returns One camera per view direction.
+ */
+const leafCameras = (bound: Aabb, size: number): RenderCamera[] => {
+    const { min, max } = bound;
+    const cx = (min[0] + max[0]) / 2;
+    const cy = (min[1] + max[1]) / 2;
+    const cz = (min[2] + max[2]) / 2;
+    const radius = boundRadius(bound);
+    const distance = ERROR_VIEW_DISTANCE * radius;
+    const fovY = 2 * Math.atan(ERROR_VIEW_MARGIN * radius / distance);
+
+    return ERROR_VIEW_DIRECTIONS.map(([dx, dy, dz]) => ({
+        projection: 'pinhole',
+        position: new Vec3(cx + dx * distance, cy + dy * distance, cz + dz * distance),
+        target: new Vec3(cx, cy, cz),
+        up: viewUp(dy),
+        fovY,
+        width: size,
+        height: size,
+        // the leaf occupies [distance - radius, distance + radius] in depth
+        near: radius
+    }));
+};
+
+/**
+ * Renders a table from a view into a square RGBA image over a transparent black
+ * background, so coverage lands in alpha and colour arrives premultiplied by it:
+ * thinning and colour drift both register as a difference.
+ *
+ * One instance serves every render of one image size. The GPU rasterizer compiles
+ * its pipelines per instance and the device caches them by bind-group identity,
+ * so creating a rasterizer per render (as the general image writer does) would
+ * recompile eight pipelines per image and grow that cache without bound over the
+ * tens of thousands of renders a scene needs. Here only the view changes between
+ * renders.
+ */
+class ViewRenderer {
+    private device: GraphicsDevice;
+
+    private rasterizer: GpuSplatRasterizer;
+
+    private numSHBands: 0 | 1 | 2 | 3;
+
+    private chunkCap: number;
+
+    private chunkInput: Float32Array;
+
+    private indices = new Uint32Array(0);
+
+    private sortScratch = new SortScratch();
+
+    /**
+     * @param device - Graphics device the renders run on.
+     * @param numSHBands - The scene's SH band count; fixes the input stride.
+     * @param maxSize - Most pixels across an image; sizes the group.
+     * @param maxCoveragePerSplat - Most tiles any one splat's footprint can cover, a
+     * power of two; sizes the pair buffers.
+     * @param slots - Renders that may be in flight at once; see {@link issue}.
+     */
+    constructor(device: GraphicsDevice, numSHBands: 0 | 1 | 2 | 3, maxSize: number, maxCoveragePerSplat: number, slots = 1) {
+        const maxTiles = maxSize / TILE_SIZE;
+
+        // Same two GPU limits the image writer honours: each pair buffer must fit one
+        // storage binding, and all of them together must fit the pair budget.
+        // @ts-ignore - limits is exposed by WebgpuGraphicsDevice
+        const wgpuLimits = (device as { limits?: { maxStorageBufferBindingSize?: number } }).limits;
+        const maxBindingBytes = wgpuLimits?.maxStorageBufferBindingSize ?? 128 * 1024 * 1024;
+        this.chunkCap = Math.max(1, Math.min(
+            CHUNK_CAP,
+            Math.floor(maxBindingBytes / (maxCoveragePerSplat * 4)),
+            Math.floor(PAIR_BUFFER_BUDGET_BYTES / (maxCoveragePerSplat * PAIR_BUFFER_TOTAL_BYTES_PER_ELEMENT))
+        ));
+
+        this.device = device;
+        this.numSHBands = numSHBands;
+        this.chunkInput = new Float32Array(this.chunkCap * splatInputStride(numSHBands));
+
+        // The view fields are placeholders; setView supplies them per render.
+        this.rasterizer = new GpuSplatRasterizer(device, {
+            numSHBands,
+            projection: 'pinhole',
+            groupTilesX: maxTiles,
+            groupTilesY: maxTiles,
+            chunkCap: this.chunkCap,
+            slots,
+            maxCoveragePerSplat,
+            imageWidth: maxSize,
+            imageHeight: maxSize,
+            near: 0,
+            rightX: 1,
+            rightY: 0,
+            rightZ: 0,
+            downX: 0,
+            downY: 1,
+            downZ: 0,
+            forwardX: 0,
+            forwardY: 0,
+            forwardZ: 1,
+            eyeX: 0,
+            eyeY: 0,
+            eyeZ: 0,
+            focalX: 1,
+            focalY: 1,
+            focusDistance: 0,
+            apertureScale: 0,
+            bgR: 0,
+            bgG: 0,
+            bgB: 0,
+            bgA: 0
+        });
+    }
+
+    /**
+     * Encode a render and start its readback without waiting for it. Up to `slots`
+     * renders may be issued into distinct slots before {@link settle}; the
+     * per-chunk buffers they share are safe because the queue executes in order.
+     *
+     * @param table - Splats in the same space as `camera`.
+     * @param camera - The view; its image must fit the constructed size.
+     * @param slot - Which in-flight slot to render into.
+     * @returns The RGBA bytes of the render, `camera.width` square.
+     */
+    issue(table: DataTable, camera: RenderCamera, slot = 0): Promise<Uint8Array> {
+        const count = table.numRows;
+        const basis = buildCameraBasis(camera);
+
+        // No frustum cull: every centre lies inside the framed bound, in front of
+        // the camera. The project shader still drops anything the view misses.
+        if (this.indices.length < count) this.indices = new Uint32Array(count);
+        const indices = this.indices;
+        for (let i = 0; i < count; i++) indices[i] = i;
+
+        const cols = getSplatColumnRefs(table, this.numSHBands);
+        sortCandidatesByDepth(cols, indices, count, basis, 'pinhole', this.sortScratch);
+
+        const tiles = camera.width / TILE_SIZE;
+        this.rasterizer.setView(basis, camera.near, camera.width, camera.height);
+        this.rasterizer.beginGroup(0, 0, tiles, tiles, slot);
+        for (let start = 0; start < count; start += this.chunkCap) {
+            const size = Math.min(this.chunkCap, count - start);
+            packChunkInput(cols, indices, start, size, this.numSHBands, this.chunkInput);
+            this.rasterizer.dispatchChunk(this.chunkInput, size);
+        }
+        return this.rasterizer.finishGroup();
+    }
+
+    /**
+     * Wait for issued renders, then end the device frame. Each chunk reserves
+     * slots in the device's indirect-dispatch buffer, which the device only
+     * recycles at frame end; the readbacks have drained the queue, so ending the
+     * frame here is safe and keeps a pass of any length within the buffer.
+     *
+     * @param pending - The renders issued since the last settle.
+     * @returns Their images, in order.
+     */
+    async settle(pending: Promise<Uint8Array>[]): Promise<Uint8Array[]> {
+        const images = await Promise.all(pending);
+        this.device.frameEnd();
+        return images;
+    }
+
+    /**
+     * @param table - Splats in the same space as `camera`.
+     * @param camera - The view; its image must fit the constructed size.
+     * @returns The RGBA bytes of the render, `camera.width` square.
+     */
+    async render(table: DataTable, camera: RenderCamera): Promise<Uint8Array> {
+        return (await this.settle([this.issue(table, camera)]))[0];
+    }
+
+    destroy(): void {
+        this.rasterizer.destroy();
+    }
+}
+
+/**
+ * @param image - RGBA bytes.
+ * @param width - Image width in pixels.
+ * @param x0 - Left edge of the rectangle.
+ * @param y0 - Top edge of the rectangle.
+ * @param size - Pixels across the square rectangle.
+ * @returns The sum of squared channel values over the rectangle, channels in [0, 1].
+ */
+const sumSquaredRect = (image: Uint8Array, width: number, x0: number, y0: number, size: number): number => {
+    let total = 0;
+    for (let y = y0; y < y0 + size; y++) {
+        const row = (y * width + x0) * 4;
+        for (let i = row; i < row + size * 4; i++) {
+            const v = image[i] / 255;
+            total += v * v;
+        }
+    }
+    return total;
+};
+
+/**
+ * @param a - RGBA bytes.
+ * @param b - RGBA bytes of the same size.
+ * @param width - Image width in pixels.
+ * @param x0 - Left edge of the rectangle.
+ * @param y0 - Top edge of the rectangle.
+ * @param size - Pixels across the square rectangle.
+ * @returns The sum of squared channel differences over the rectangle, channels in [0, 1].
+ */
+const sumSquaredDifferenceRect = (
+    a: Uint8Array, b: Uint8Array, width: number, x0: number, y0: number, size: number
+): number => {
+    let total = 0;
+    for (let y = y0; y < y0 + size; y++) {
+        const row = (y * width + x0) * 4;
+        for (let i = row; i < row + size * 4; i++) {
+            const d = (a[i] - b[i]) / 255;
+            total += d * d;
+        }
+    }
+    return total;
+};
+
+/** A leaf placed in an atlas: where its frame lands and how to move its splats there. */
+type AtlasSlot = {
+    leaf: LeafLevels;
+    /** Leaf centre in scene space. */
+    centre: number[];
+    /** Scene units per atlas unit: the leaf's bounding radius. */
+    radius: number;
+    /** Atlas-plane coordinates of the cell centre, in atlas units. */
+    u: number;
+    v: number;
+};
+
+/**
+ * One level of a batch of leaves, each normalised to unit bounding radius and
+ * moved to its cell on the atlas plane. Translation and uniform scaling leave a
+ * render unchanged up to the pixel grid, so rotations, opacities and colours are
+ * copied as they are; log scales shift by the scale factor.
+ *
+ * @param members - The slots whose leaves have this level.
+ * @param lod - The level.
+ * @param right - Camera right axis: atlas `u` runs along it.
+ * @param down - Camera down axis: atlas `v` runs along it.
+ * @returns The level's splats for the whole batch, in atlas space.
+ */
+const assembleAtlas = (members: AtlasSlot[], lod: number, right: Vec3, down: Vec3): DataTable => {
+    const first = members[0].leaf.levels.get(lod)!;
+    const names = first.columns.map(c => c.name);
+    const total = members.reduce((sum, m) => sum + m.leaf.levels.get(lod)!.numRows, 0);
+    const out = names.map(() => new Float32Array(total));
+
+    const ix = first.getColumnIndex('x'), iy = first.getColumnIndex('y'), iz = first.getColumnIndex('z');
+    const scaleIndices = ['scale_0', 'scale_1', 'scale_2'].map(name => first.getColumnIndex(name));
+
+    let row = 0;
+    for (const m of members) {
+        const table = m.leaf.levels.get(lod)!;
+        const n = table.numRows;
+        for (let c = 0; c < names.length; c++) out[c].set(table.columns[c].data as Float32Array, row);
+
+        const inv = 1 / m.radius;
+        const logInv = Math.log(inv);
+        const ox = right.x * m.u + down.x * m.v;
+        const oy = right.y * m.u + down.y * m.v;
+        const oz = right.z * m.u + down.z * m.v;
+        const x = out[ix], y = out[iy], z = out[iz];
+        for (let r = row; r < row + n; r++) {
+            x[r] = (x[r] - m.centre[0]) * inv + ox;
+            y[r] = (y[r] - m.centre[1]) * inv + oy;
+            z[r] = (z[r] - m.centre[2]) * inv + oz;
+        }
+        for (const s of scaleIndices) {
+            const scale = out[s];
+            for (let r = row; r < row + n; r++) scale[r] += logInv;
+        }
+        row += n;
+    }
+
+    return new DataTable(names.map((name, c) => new Column(name, out[c])), Transform.PLY);
+};
+
+/**
+ * Measures per-leaf, per-level approximation error on rendered images.
+ *
+ * Each level present in a leaf is rendered from the six {@link ERROR_VIEW_DIRECTIONS}
+ * and compared against the finest level present, which is the reference and
+ * carries no error. A level's error is the squared RGBA difference summed over
+ * every pixel of the leaf's frame in every view, divided by the reference's summed
+ * squared RGBA — a relative image error that is zero for an identical level, grows
+ * without bound as a level departs from the reference, and is dimensionless so
+ * leaves of any physical size compare on one scale.
+ *
+ * A render costs about a millisecond whatever its size, so the pass is priced by
+ * renders, and a scene cut into tens of thousands of small leaves would take
+ * hours one leaf at a time. Small leaves are therefore batched: each is
+ * normalised to unit bounding radius, placed in its own cell of an atlas in front
+ * of one distant camera, and rendered together with the rest of the batch, once
+ * per level per view. A leaf's frame in the atlas is the same size, seen from the
+ * same six directions, as it would be alone; only the round trips are shared.
+ * Leaves too detailed or too populous for that are still rendered alone.
+ */
+class ErrorRenderer {
+    private solo: ViewRenderer;
+
+    private atlas: ViewRenderer;
+
+    /**
+     * @param device - Graphics device the renders run on.
+     * @param numSHBands - The scene's SH band count.
+     */
+    constructor(device: GraphicsDevice, numSHBands: 0 | 1 | 2 | 3) {
+        // Alone, a splat's footprint can span the whole image.
+        const soloTiles = ERROR_VIEW_MAX_SIZE / TILE_SIZE;
+        this.solo = new ViewRenderer(device, numSHBands, ERROR_VIEW_MAX_SIZE, 1 << Math.ceil(Math.log2(soloTiles * soloTiles)), SOLO_SLOTS);
+
+        // In an atlas a splat's footprint radius is at most three sigma, sigma at
+        // most ATLAS_MAX_SIGMA_RATIO of a unit-radius leaf; widest at the widest frame.
+        const largestCell = ATLAS_CELL_FRAMES * ATLAS_MAX_FRAME;
+        const footprintPixels = 2 * 3 * ATLAS_MAX_SIGMA_RATIO * largestCell / (ATLAS_CELL_FRAMES * 2 * ERROR_VIEW_MARGIN);
+        const footprintTiles = Math.ceil(footprintPixels / TILE_SIZE) + 2;
+        this.atlas = new ViewRenderer(device, numSHBands, ATLAS_SIZE, 1 << Math.ceil(Math.log2(footprintTiles * footprintTiles)));
+    }
+
+    /**
+     * @param frame - Pixels across a leaf's frame, from {@link leafViewSize}.
+     * @returns Most leaves of that frame one atlas holds.
+     */
+    static atlasCapacity(frame: number): number {
+        const cells = Math.floor(ATLAS_SIZE / (ATLAS_CELL_FRAMES * frame));
+        return cells * cells;
+    }
+
+    /**
+     * Whether a leaf can share an atlas rather than needing renders of its own:
+     * its frame and finest level must be small enough, and no splat of any level
+     * may be large enough, relative to the leaf's bound, to reach a neighbour's
+     * frame.
+     *
+     * @param frame - Pixels across the leaf's frame, from {@link leafViewSize}.
+     * @param leaf - The leaf's levels and bound.
+     * @returns True when the leaf goes into an atlas.
+     */
+    static fitsAtlas(frame: number, leaf: LeafLevels): boolean {
+        if (frame > ATLAS_MAX_FRAME) return false;
+        const reference = leaf.levels.get(Math.min(...leaf.levels.keys()))!;
+        if (reference.numRows > ATLAS_MAX_GAUSSIANS) return false;
+
+        const limit = Math.log(ATLAS_MAX_SIGMA_RATIO * boundRadius(leaf.bound));
+        for (const table of leaf.levels.values()) {
+            for (const name of ['scale_0', 'scale_1', 'scale_2']) {
+                const scale = table.getColumnByName(name)!.data as Float32Array;
+                for (let i = 0; i < scale.length; i++) {
+                    if (scale[i] > limit) return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Errors of one leaf rendered alone.
+     *
+     * @param leaf - The leaf's levels and bound.
+     * @param numLods - Number of structural LODs in the source.
+     * @returns One raw (not yet monotone) error per LOD; zero for the reference and
+     * for levels absent from the leaf.
+     */
+    async leafErrors(leaf: LeafLevels, numLods: number): Promise<number[]> {
+        const errors = new Array(numLods).fill(0);
+        const levels = [...leaf.levels.keys()].sort((a, b) => a - b);
+        if (levels.length < 2) return errors;
+
+        const reference = leaf.levels.get(levels[0])!;
+        const size = leafViewSize(leaf.bound, reference);
+        const cameras = leafCameras(leaf.bound, size);
+
+        // All six views of a level go out together and are waited for once.
+        const renderViews = (table: DataTable) => this.solo.settle(cameras.map((camera, v) => this.solo.issue(table, camera, v)));
+
+        const referenceImages = await renderViews(reference);
+        let energy = 0;
+        for (const image of referenceImages) energy += sumSquaredRect(image, size, 0, 0, size);
+
+        for (let i = 1; i < levels.length; i++) {
+            const images = await renderViews(leaf.levels.get(levels[i])!);
+            let difference = 0;
+            for (let v = 0; v < cameras.length; v++) {
+                difference += sumSquaredDifferenceRect(referenceImages[v], images[v], size, 0, 0, size);
+            }
+            errors[levels[i]] = energy > 0 ? difference / energy : 0;
+        }
+        return errors;
+    }
+
+    /**
+     * Errors of a batch of small leaves rendered together.
+     *
+     * Every leaf gets a frame of exactly `frame` pixels, the density a solo render
+     * at that frame would have, in a cell three frames wide. The image is the
+     * smallest power of two that holds the batch's cells, so a small or trailing
+     * batch does not pay for a full-size readback.
+     *
+     * @param leaves - At most {@link atlasCapacity} leaves, each accepted by {@link fitsAtlas}.
+     * @param frame - Pixels across each leaf's frame, at least each leaf's {@link leafViewSize}.
+     * @param numLods - Number of structural LODs in the source.
+     * @returns Per leaf, one raw (not yet monotone) error per LOD.
+     */
+    async atlasErrors(leaves: LeafLevels[], frame: number, numLods: number): Promise<number[][]> {
+        const cells = Math.ceil(Math.sqrt(leaves.length));
+        const cellPx = ATLAS_CELL_FRAMES * frame;
+        const framePx = frame;
+        const size = Math.min(ATLAS_SIZE, 1 << Math.ceil(Math.log2(Math.max(TILE_SIZE, cells * cellPx))));
+        const cellUnits = ATLAS_CELL_FRAMES * 2 * ERROR_VIEW_MARGIN;
+        const pixelsPerUnit = cellPx / cellUnits;
+        const extent = size / pixelsPerUnit;
+        const distance = ATLAS_DISTANCE * extent;
+        const fovY = 2 * Math.atan((size / 2) / (pixelsPerUnit * distance));
+
+        const slots: AtlasSlot[] = leaves.map((leaf, k) => {
+            const { min, max } = leaf.bound;
+            return {
+                leaf,
+                centre: [0, 1, 2].map(i => (min[i] + max[i]) / 2),
+                radius: boundRadius(leaf.bound),
+                u: ((k % cells) - (cells - 1) / 2) * cellUnits,
+                v: (Math.floor(k / cells) - (cells - 1) / 2) * cellUnits
+            };
+        });
+
+        const levels = [...new Set(leaves.flatMap(leaf => [...leaf.levels.keys()]))].sort((a, b) => a - b);
+        const referenceOf = leaves.map(leaf => Math.min(...leaf.levels.keys()));
+        const energy = new Array(leaves.length).fill(0);
+        const difference = leaves.map(() => new Array(numLods).fill(0));
+
+        for (const [dx, dy, dz] of ERROR_VIEW_DIRECTIONS) {
+            const camera: RenderCamera = {
+                projection: 'pinhole',
+                position: new Vec3(dx * distance, dy * distance, dz * distance),
+                target: new Vec3(0, 0, 0),
+                up: viewUp(dy),
+                fovY,
+                width: size,
+                height: size,
+                near: distance - extent
+            };
+            const { right, down } = buildCameraBasis(camera);
+
+            // Pixel rectangle of each leaf's frame, centred in its cell.
+            const frames = slots.map(s => ({
+                x0: Math.round(size / 2 + s.u * pixelsPerUnit - framePx / 2),
+                y0: Math.round(size / 2 + s.v * pixelsPerUnit - framePx / 2)
+            }));
+
+            const images = new Map<number, Uint8Array>();
+            for (const lod of levels) {
+                const members = slots.filter(s => s.leaf.levels.has(lod));
+                const table = assembleAtlas(members, lod, right, down);
+                images.set(lod, await this.atlas.render(table, camera));
+            }
+
+            for (let k = 0; k < leaves.length; k++) {
+                const reference = images.get(referenceOf[k])!;
+                const { x0, y0 } = frames[k];
+                energy[k] += sumSquaredRect(reference, size, x0, y0, framePx);
+                for (const lod of leaves[k].levels.keys()) {
+                    if (lod === referenceOf[k]) continue;
+                    difference[k][lod] += sumSquaredDifferenceRect(reference, images.get(lod)!, size, x0, y0, framePx);
+                }
+            }
+        }
+
+        return leaves.map((leaf, k) => {
+            const errors = new Array(numLods).fill(0);
+            for (const lod of leaf.levels.keys()) {
+                if (lod !== referenceOf[k]) errors[lod] = energy[k] > 0 ? difference[k][lod] / energy[k] : 0;
+            }
+            return errors;
+        });
+    }
+
+    destroy(): void {
+        this.solo.destroy();
+        this.atlas.destroy();
+    }
+}
+
+export { ATLAS_MAX_BATCH_GAUSSIANS, ErrorRenderer, leafViewSize, type LeafLevels };

--- a/src/lib/writers/lod-error.ts
+++ b/src/lib/writers/lod-error.ts
@@ -72,12 +72,17 @@ const SOLO_SLOTS = ERROR_VIEW_DIRECTIONS.length;
 const FOOTPRINT_SAMPLES = 4096;
 
 /**
- * Pixels across the image that batches of leaves are rendered into. 256 tiles a
- * side: with cells two frames wide this holds 16 leaves at the full 512-pixel
- * frame and over a thousand at a 64-pixel one. Image sizes are kept to powers of
- * two.
+ * Most pixels across the image that batches of leaves are rendered into. 256
+ * tiles a side: with cells two frames wide this holds 16 leaves at the full
+ * 512-pixel frame and over a thousand at a 64-pixel one. Image sizes are kept to
+ * powers of two. The rasterizer keeps 16 bytes of running state per pixel in one
+ * storage buffer, 256 MiB at this size, so a device whose storage binding limit
+ * is smaller gets a smaller atlas ({@link ErrorRenderer}).
  */
-const ATLAS_SIZE = 4096;
+const ATLAS_MAX_SIZE = 4096;
+
+/** Bytes of rasterizer running state per atlas pixel, one vec4f. */
+const ATLAS_STATE_BYTES_PER_PIXEL = 16;
 
 /**
  * Atlas cells are this many leaf frames across, the leaf frame centred, so that a
@@ -473,11 +478,21 @@ class ErrorRenderer {
 
     private atlas: ViewRenderer;
 
+    /** Pixels across an atlas: {@link ATLAS_MAX_SIZE} or what the device can bind. */
+    private atlasSize: number;
+
     /**
      * @param device - Graphics device the renders run on.
      * @param numSHBands - The scene's SH band count.
      */
     constructor(device: GraphicsDevice, numSHBands: 0 | 1 | 2 | 3) {
+        // The atlas running state must fit one storage binding: the largest power
+        // of two side whose pixels do. The WebGPU baseline of 128 MiB gives 2048.
+        // @ts-ignore - limits is exposed by WebgpuGraphicsDevice
+        const wgpuLimits = (device as { limits?: { maxStorageBufferBindingSize?: number } }).limits;
+        const maxBindingBytes = wgpuLimits?.maxStorageBufferBindingSize ?? 128 * 1024 * 1024;
+        this.atlasSize = Math.min(ATLAS_MAX_SIZE, 1 << Math.floor(Math.log2(Math.sqrt(maxBindingBytes / ATLAS_STATE_BYTES_PER_PIXEL))));
+
         // Alone, a splat's footprint can span the whole image.
         const soloTiles = ERROR_VIEW_MAX_SIZE / TILE_SIZE;
         this.solo = new ViewRenderer(device, numSHBands, ERROR_VIEW_MAX_SIZE, 1 << Math.ceil(Math.log2(soloTiles * soloTiles)), SOLO_SLOTS);
@@ -487,15 +502,15 @@ class ErrorRenderer {
         const largestCell = ATLAS_CELL_FRAMES * ATLAS_MAX_FRAME;
         const footprintPixels = 2 * 3 * ATLAS_MAX_SIGMA_RATIO * largestCell / (ATLAS_CELL_FRAMES * 2 * ERROR_VIEW_MARGIN);
         const footprintTiles = Math.ceil(footprintPixels / TILE_SIZE) + 2;
-        this.atlas = new ViewRenderer(device, numSHBands, ATLAS_SIZE, 1 << Math.ceil(Math.log2(footprintTiles * footprintTiles)));
+        this.atlas = new ViewRenderer(device, numSHBands, this.atlasSize, 1 << Math.ceil(Math.log2(footprintTiles * footprintTiles)));
     }
 
     /**
      * @param frame - Pixels across a leaf's frame, from {@link leafViewSize}.
      * @returns Most leaves of that frame one atlas holds.
      */
-    static atlasCapacity(frame: number): number {
-        const cells = Math.floor(ATLAS_SIZE / (ATLAS_CELL_FRAMES * frame));
+    atlasCapacity(frame: number): number {
+        const cells = Math.floor(this.atlasSize / (ATLAS_CELL_FRAMES * frame));
         return cells * cells;
     }
 
@@ -509,7 +524,7 @@ class ErrorRenderer {
      * @param leaf - The leaf's levels and bound.
      * @returns True when the leaf goes into an atlas.
      */
-    static fitsAtlas(frame: number, leaf: LeafLevels): boolean {
+    fitsAtlas(frame: number, leaf: LeafLevels): boolean {
         if (frame > ATLAS_MAX_FRAME) return false;
         const reference = leaf.levels.get(Math.min(...leaf.levels.keys()))!;
         if (reference.numRows > ATLAS_MAX_GAUSSIANS) return false;
@@ -578,7 +593,7 @@ class ErrorRenderer {
         const cells = Math.ceil(Math.sqrt(leaves.length));
         const cellPx = ATLAS_CELL_FRAMES * frame;
         const framePx = frame;
-        const size = Math.min(ATLAS_SIZE, 1 << Math.ceil(Math.log2(Math.max(TILE_SIZE, cells * cellPx))));
+        const size = Math.min(this.atlasSize, 1 << Math.ceil(Math.log2(Math.max(TILE_SIZE, cells * cellPx))));
         const cellUnits = ATLAS_CELL_FRAMES * 2 * ERROR_VIEW_MARGIN;
         const pixelsPerUnit = cellPx / cellUnits;
         const extent = size / pixelsPerUnit;

--- a/src/lib/writers/lod-error.ts
+++ b/src/lib/writers/lod-error.ts
@@ -1,4 +1,4 @@
-import { type GraphicsDevice, Vec3 } from 'playcanvas';
+import { type GraphicsDevice, Quat, Vec3 } from 'playcanvas';
 
 import { Column, DataTable } from '../data-table';
 import { GpuSplatRasterizer } from '../gpu';
@@ -54,8 +54,24 @@ const ERROR_VIEW_DISTANCE = 200;
 /** Margin around a leaf's bounding sphere in its frame, as a factor of the radius. */
 const ERROR_VIEW_MARGIN = 1.05;
 
-/** The six axis-aligned directions a leaf is viewed from. */
-const ERROR_VIEW_DIRECTIONS = [[1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0], [0, 0, 1], [0, 0, -1]];
+/**
+ * The six directions a leaf is viewed from, each with an up vector: the coordinate
+ * axes under one fixed, generic rotation. Colour is stored as spherical harmonics
+ * and evaluated along the view direction, and on a bare axis the basis functions
+ * xy, yz, xz, xyz and z(x² − y²) are exactly zero, so colour held in those
+ * coefficients would be invisible to axis-aligned views. Under this rotation every
+ * basis function of bands 1 to 3 has magnitude at least 0.09 in every view.
+ * Opposite views still agree on even bands and negate odd ones, so six views sample
+ * each band at three directions: band 1 is seen whole, bands 2 and 3 in part.
+ */
+const ERROR_VIEWS: { direction: Vec3, up: Vec3 }[] = (() => {
+    const rotation = new Quat().setFromEulerAngles(45, 20, 35);
+    const axes = [Vec3.RIGHT, Vec3.UP, Vec3.FORWARD].map(axis => rotation.transformVector(axis, new Vec3()));
+    return axes.flatMap((axis, i) => [1, -1].map(sign => ({
+        direction: axis.clone().mulScalar(sign),
+        up: axes[(i + 1) % 3]
+    })));
+})();
 
 /** Gaussians per GPU dispatch; bounds the input and pair buffers. */
 const CHUNK_CAP = 200_000;
@@ -66,7 +82,7 @@ const CHUNK_CAP = 200_000;
  * work, so issuing the views together and waiting once turns six round trips
  * into one.
  */
-const SOLO_SLOTS = ERROR_VIEW_DIRECTIONS.length;
+const SOLO_SLOTS = ERROR_VIEWS.length;
 
 /** Gaussians sampled when estimating a leaf's finest splat footprint. */
 const FOOTPRINT_SAMPLES = 4096;
@@ -108,7 +124,7 @@ const ATLAS_MAX_SIGMA_RATIO = 0.5;
 /**
  * Camera distance for an atlas, as a multiple of the atlas width. Cells sit off
  * the camera axis, so this sets how far their view direction departs from the
- * axis-aligned one a solo render has: at 200 widths it is under 0.15 degrees,
+ * one a solo render has: at 200 widths it is under 0.15 degrees,
  * under a pixel of skew across a frame.
  */
 const ATLAS_DISTANCE = 200;
@@ -165,12 +181,10 @@ const boundRadius = (bound: Aabb): number => {
     return Math.max(Math.hypot(max[0] - min[0], max[1] - min[1], max[2] - min[2]) / 2, 1e-3);
 };
 
-// any vector not parallel to the view direction
-const viewUp = (dy: number): Vec3 => (dy !== 0 ? new Vec3(0, 0, 1) : new Vec3(0, 1, 0));
-
 /**
- * The six views of a leaf rendered alone: pinhole cameras on each axis, far enough
- * out to frame the leaf's bounding sphere with a little margin.
+ * The six views of a leaf rendered alone: pinhole cameras along each of the
+ * {@link ERROR_VIEWS}, far enough out to frame the leaf's bounding sphere with a
+ * little margin.
  *
  * @param bound - The leaf's ellipsoid AABB (the same volume the engine derives its
  * screen coverage from).
@@ -186,11 +200,11 @@ const leafCameras = (bound: Aabb, size: number): RenderCamera[] => {
     const distance = ERROR_VIEW_DISTANCE * radius;
     const fovY = 2 * Math.atan(ERROR_VIEW_MARGIN * radius / distance);
 
-    return ERROR_VIEW_DIRECTIONS.map(([dx, dy, dz]) => ({
+    return ERROR_VIEWS.map(({ direction, up }) => ({
         projection: 'pinhole',
-        position: new Vec3(cx + dx * distance, cy + dy * distance, cz + dz * distance),
+        position: new Vec3(cx + direction.x * distance, cy + direction.y * distance, cz + direction.z * distance),
         target: new Vec3(cx, cy, cz),
-        up: viewUp(dy),
+        up,
         fovY,
         width: size,
         height: size,
@@ -456,7 +470,7 @@ const assembleAtlas = (members: AtlasSlot[], lod: number, right: Vec3, down: Vec
 /**
  * Measures per-leaf, per-level approximation error on rendered images.
  *
- * Each level present in a leaf is rendered from the six {@link ERROR_VIEW_DIRECTIONS}
+ * Each level present in a leaf is rendered from the six {@link ERROR_VIEWS}
  * and compared against the finest level present, which is the reference and
  * carries no error. A level's error is the squared RGBA difference summed over
  * every pixel of the leaf's frame in every view, divided by the reference's summed
@@ -571,7 +585,9 @@ class ErrorRenderer {
             for (let v = 0; v < cameras.length; v++) {
                 difference += sumSquaredDifferenceRect(referenceImages[v], images[v], size, 0, 0, size);
             }
-            errors[levels[i]] = energy > 0 ? difference / energy : 0;
+            // A reference that renders nothing leaves no energy to compare against: a
+            // level that then draws anything is wholly wrong, one that draws nothing exact.
+            errors[levels[i]] = energy > 0 ? difference / energy : (difference > 0 ? 1 : 0);
         }
         return errors;
     }
@@ -616,12 +632,12 @@ class ErrorRenderer {
         const energy = new Array(leaves.length).fill(0);
         const difference = leaves.map(() => new Array(numLods).fill(0));
 
-        for (const [dx, dy, dz] of ERROR_VIEW_DIRECTIONS) {
+        for (const { direction, up } of ERROR_VIEWS) {
             const camera: RenderCamera = {
                 projection: 'pinhole',
-                position: new Vec3(dx * distance, dy * distance, dz * distance),
+                position: direction.clone().mulScalar(distance),
                 target: new Vec3(0, 0, 0),
-                up: viewUp(dy),
+                up,
                 fovY,
                 width: size,
                 height: size,
@@ -656,7 +672,7 @@ class ErrorRenderer {
         return leaves.map((leaf, k) => {
             const errors = new Array(numLods).fill(0);
             for (const lod of leaf.levels.keys()) {
-                if (lod !== referenceOf[k]) errors[lod] = energy[k] > 0 ? difference[k][lod] / energy[k] : 0;
+                if (lod !== referenceOf[k]) errors[lod] = energy[k] > 0 ? difference[k][lod] / energy[k] : (difference[k][lod] > 0 ? 1 : 0);
             }
             return errors;
         });

--- a/src/lib/writers/lod-error.ts
+++ b/src/lib/writers/lod-error.ts
@@ -3,7 +3,7 @@ import { type GraphicsDevice, Quat, Vec3 } from 'playcanvas';
 import { Column, DataTable } from '../data-table';
 import { GpuSplatRasterizer } from '../gpu';
 import { type RenderCamera, buildCameraBasis } from '../render/camera';
-import { PAIR_BUFFER_BUDGET_BYTES, PAIR_BUFFER_TOTAL_BYTES_PER_ELEMENT, TILE_SIZE } from '../render/config';
+import { PAIR_BUFFER_BUDGET_BYTES, TILE_SIZE, rasterChunkCap, storageBindingLimit } from '../render/config';
 import {
     SortScratch, getSplatColumnRefs, packChunkInput, sortCandidatesByDepth, splatInputStride
 } from '../render/preprocess';
@@ -83,6 +83,14 @@ const CHUNK_CAP = 200_000;
  * into one.
  */
 const SOLO_SLOTS = ERROR_VIEWS.length;
+
+/**
+ * Renders the atlas path keeps in flight: the levels of one view are issued into
+ * alternating slots, so the next level's atlas is assembled on the CPU while the
+ * GPU draws and reads back the current one. Two is enough to overlap the two;
+ * every further slot costs another full-size running state ({@link ATLAS_MAX_SIZE}).
+ */
+const ATLAS_SLOTS = 2;
 
 /** Gaussians sampled when estimating a leaf's finest splat footprint. */
 const FOOTPRINT_SAMPLES = 4096;
@@ -246,27 +254,20 @@ class ViewRenderer {
      * @param maxSize - Most pixels across an image; sizes the group.
      * @param maxCoveragePerSplat - Most tiles any one splat's footprint can cover, a
      * power of two; sizes the pair buffers.
+     * @param pairBudgetBytes - GPU bytes for this renderer's pair buffers; sizes the chunk.
      * @param slots - Renders that may be in flight at once; see {@link issue}.
      */
-    constructor(device: GraphicsDevice, numSHBands: 0 | 1 | 2 | 3, maxSize: number, maxCoveragePerSplat: number, slots = 1) {
+    constructor(device: GraphicsDevice, numSHBands: 0 | 1 | 2 | 3, maxSize: number, maxCoveragePerSplat: number, pairBudgetBytes: number, slots = 1) {
         const maxTiles = maxSize / TILE_SIZE;
-
-        // Same two GPU limits the image writer honours: each pair buffer must fit one
-        // storage binding, and all of them together must fit the pair budget.
-        // @ts-ignore - limits is exposed by WebgpuGraphicsDevice
-        const wgpuLimits = (device as { limits?: { maxStorageBufferBindingSize?: number } }).limits;
-        const maxBindingBytes = wgpuLimits?.maxStorageBufferBindingSize ?? 128 * 1024 * 1024;
-        this.chunkCap = Math.max(1, Math.min(
-            CHUNK_CAP,
-            Math.floor(maxBindingBytes / (maxCoveragePerSplat * 4)),
-            Math.floor(PAIR_BUFFER_BUDGET_BYTES / (maxCoveragePerSplat * PAIR_BUFFER_TOTAL_BYTES_PER_ELEMENT))
-        ));
+        this.chunkCap = Math.min(CHUNK_CAP, rasterChunkCap(device, maxCoveragePerSplat, pairBudgetBytes));
 
         this.device = device;
         this.numSHBands = numSHBands;
         this.chunkInput = new Float32Array(this.chunkCap * splatInputStride(numSHBands));
 
-        // The view fields are placeholders; setView supplies them per render.
+        // The view fields are placeholders; setView supplies them per render. No
+        // radius fade: a leaf's frame is sized to its bound, so a splat spanning the
+        // whole frame is the scene, not an outlier, and must render at full alpha.
         this.rasterizer = new GpuSplatRasterizer(device, {
             numSHBands,
             projection: 'pinhole',
@@ -274,6 +275,7 @@ class ViewRenderer {
             groupTilesY: maxTiles,
             chunkCap: this.chunkCap,
             slots,
+            radiusFade: false,
             maxCoveragePerSplat,
             imageWidth: maxSize,
             imageHeight: maxSize,
@@ -348,15 +350,6 @@ class ViewRenderer {
         const images = await Promise.all(pending);
         this.device.frameEnd();
         return images;
-    }
-
-    /**
-     * @param table - Splats in the same space as `camera`.
-     * @param camera - The view; its image must fit the constructed size.
-     * @returns The RGBA bytes of the render, `camera.width` square.
-     */
-    async render(table: DataTable, camera: RenderCamera): Promise<Uint8Array> {
-        return (await this.settle([this.issue(table, camera)]))[0];
     }
 
     destroy(): void {
@@ -478,9 +471,9 @@ const assembleAtlas = (members: AtlasSlot[], lod: number, right: Vec3, down: Vec
  * without bound as a level departs from the reference, and is dimensionless so
  * leaves of any physical size compare on one scale.
  *
- * A render costs about a millisecond whatever its size, so the pass is priced by
- * renders, and a scene cut into tens of thousands of small leaves would take
- * hours one leaf at a time. Small leaves are therefore batched: each is
+ * A render's cost is dominated by its GPU round trip rather than by what it
+ * draws, so the pass is priced by renders, and a scene cut into tens of thousands
+ * of small leaves would take hours one leaf at a time. Small leaves are therefore batched: each is
  * normalised to unit bounding radius, placed in its own cell of an atlas in front
  * of one distant camera, and rendered together with the rest of the batch, once
  * per level per view. A leaf's frame in the atlas is the same size, seen from the
@@ -502,21 +495,22 @@ class ErrorRenderer {
     constructor(device: GraphicsDevice, numSHBands: 0 | 1 | 2 | 3) {
         // The atlas running state must fit one storage binding: the largest power
         // of two side whose pixels do. The WebGPU baseline of 128 MiB gives 2048.
-        // @ts-ignore - limits is exposed by WebgpuGraphicsDevice
-        const wgpuLimits = (device as { limits?: { maxStorageBufferBindingSize?: number } }).limits;
-        const maxBindingBytes = wgpuLimits?.maxStorageBufferBindingSize ?? 128 * 1024 * 1024;
-        this.atlasSize = Math.min(ATLAS_MAX_SIZE, 1 << Math.floor(Math.log2(Math.sqrt(maxBindingBytes / ATLAS_STATE_BYTES_PER_PIXEL))));
+        this.atlasSize = Math.min(ATLAS_MAX_SIZE, 1 << Math.floor(Math.log2(Math.sqrt(storageBindingLimit(device) / ATLAS_STATE_BYTES_PER_PIXEL))));
+
+        // The two renderers live for the whole pass, so they share the one pair
+        // budget the image writer gives its single rasterizer.
+        const pairBudget = PAIR_BUFFER_BUDGET_BYTES / 2;
 
         // Alone, a splat's footprint can span the whole image.
         const soloTiles = ERROR_VIEW_MAX_SIZE / TILE_SIZE;
-        this.solo = new ViewRenderer(device, numSHBands, ERROR_VIEW_MAX_SIZE, 1 << Math.ceil(Math.log2(soloTiles * soloTiles)), SOLO_SLOTS);
+        this.solo = new ViewRenderer(device, numSHBands, ERROR_VIEW_MAX_SIZE, 1 << Math.ceil(Math.log2(soloTiles * soloTiles)), pairBudget, SOLO_SLOTS);
 
         // In an atlas a splat's footprint radius is at most three sigma, sigma at
         // most ATLAS_MAX_SIGMA_RATIO of a unit-radius leaf; widest at the widest frame.
         const largestCell = ATLAS_CELL_FRAMES * ATLAS_MAX_FRAME;
         const footprintPixels = 2 * 3 * ATLAS_MAX_SIGMA_RATIO * largestCell / (ATLAS_CELL_FRAMES * 2 * ERROR_VIEW_MARGIN);
         const footprintTiles = Math.ceil(footprintPixels / TILE_SIZE) + 2;
-        this.atlas = new ViewRenderer(device, numSHBands, this.atlasSize, 1 << Math.ceil(Math.log2(footprintTiles * footprintTiles)));
+        this.atlas = new ViewRenderer(device, numSHBands, this.atlasSize, 1 << Math.ceil(Math.log2(footprintTiles * footprintTiles)), pairBudget, ATLAS_SLOTS);
     }
 
     /**
@@ -596,9 +590,11 @@ class ErrorRenderer {
      * Errors of a batch of small leaves rendered together.
      *
      * Every leaf gets a frame of exactly `frame` pixels, the density a solo render
-     * at that frame would have, in a cell three frames wide. The image is the
-     * smallest power of two that holds the batch's cells, so a small or trailing
-     * batch does not pay for a full-size readback.
+     * at that frame would have, in a cell {@link ATLAS_CELL_FRAMES} frames wide. The
+     * image is the smallest power of two that holds the batch's cells, so a small
+     * or trailing batch does not pay for a full-size readback. Within a view the
+     * levels are double-buffered ({@link ATLAS_SLOTS}): the next level's atlas is
+     * assembled while the current one renders.
      *
      * @param leaves - At most {@link atlasCapacity} leaves, each accepted by {@link fitsAtlas}.
      * @param frame - Pixels across each leaf's frame, at least each leaf's {@link leafViewSize}.
@@ -651,12 +647,16 @@ class ErrorRenderer {
                 y0: Math.round(size / 2 + s.v * pixelsPerUnit - framePx / 2)
             }));
 
-            const images = new Map<number, Uint8Array>();
-            for (const lod of levels) {
-                const members = slots.filter(s => s.leaf.levels.has(lod));
-                const table = assembleAtlas(members, lod, right, down);
-                images.set(lod, await this.atlas.render(table, camera));
+            const pending: Promise<Uint8Array>[] = [];
+            for (let i = 0; i < levels.length; i++) {
+                const members = slots.filter(s => s.leaf.levels.has(levels[i]));
+                const table = assembleAtlas(members, levels[i], right, down);
+                // a slot is reused only once the render it last held has been read back
+                if (i >= ATLAS_SLOTS) await pending[i - ATLAS_SLOTS];
+                pending.push(this.atlas.issue(table, camera, i % ATLAS_SLOTS));
             }
+            const rendered = await this.atlas.settle(pending);
+            const images = new Map(levels.map((lod, i) => [lod, rendered[i]]));
 
             for (let k = 0; k < leaves.length; k++) {
                 const reference = images.get(referenceOf[k])!;

--- a/src/lib/writers/write-lod.ts
+++ b/src/lib/writers/write-lod.ts
@@ -1,15 +1,13 @@
 import { basename, dirname, resolve } from 'pathe';
-import { BoundingBox, Mat4, Quat, Vec3 } from 'playcanvas';
+import { BoundingBox, type GraphicsDevice, Mat4, Quat, Vec3 } from 'playcanvas';
 
 import { logWrittenFile } from './utils';
 import { writeSogSource } from './write-sog.js';
 import { type ChunkDataPool, type ChunkSource, type ReadRequest, createChunkDataPool } from '../chunk';
 import { Column, DataTable } from '../data-table';
-import {
-    EPS_COV, det3, ellipsoidArea, quatToRotmat, sigmaFromRotVar, sigmoid, type SplatView
-} from '../decimate/moment-match';
 import { type FileSystem } from '../io/write';
 import { bakeTransform, permuteSource, sortMortonColumns } from '../ops';
+import { type RenderCamera, renderSplats } from '../render';
 import { BTreeNode, BTree } from '../spatial';
 import type { DeviceCreator } from '../types';
 import { logger, Transform } from '../utils';
@@ -173,9 +171,9 @@ const invalidGaussian = (lod: number, row: number, what: string): Error => new E
 /**
  * Reject a batch of gaussians whose geometry is not finite. The bounds pass reads
  * every gaussian's geometric record once, so this covers the whole scene:
- * everything downstream — the error metric above all, whose footprint mass runs
- * through `sigmoid`/`exp` — may then assume finite input rather than each stage
- * carrying its own opinion about invalid data. {@link assertFiniteColor} does the
+ * everything downstream — the error pass above all, which renders every gaussian
+ * — may then assume finite input rather than each stage carrying its own opinion
+ * about invalid data. {@link assertFiniteColor} does the
  * same for the layer this pass does not read.
  *
  * The rules mirror `filterNaNRows`, including its two deliberate exceptions
@@ -313,169 +311,13 @@ const binIndices = (parent: BTreeNode, lodOf: (index: number) => number): Map<nu
     return result;
 };
 
-const distanceToAabbSq = (node: BTreeNode, x: number, y: number, z: number): number => {
-    const { min, max } = node.aabb;
-    const dx = x < min[0] ? min[0] - x : x > max[0] ? x - max[0] : 0;
-    const dy = y < min[1] ? min[1] - y : y > max[1] ? y - max[1] : 0;
-    const dz = z < min[2] ? min[2] - z : z > max[2] ? z - max[2] : 0;
-    return dx * dx + dy * dy + dz * dz;
-};
-
-/**
- * The k nearest candidates of each of several structural LODs to every query, in
- * center space — one traversal per query, serving every LOD.
- *
- * `ranges` holds `[lo, hi)` per LOD in flat analysis index space: LOD is
- * structural, so a level's gaussians are exactly one contiguous index range and
- * the level test is two comparisons rather than a lookup. Sharing the traversal
- * is what makes the error pass affordable — every splat of the reference level is
- * matched against every coarser level, so searching them separately would repeat
- * the same descent once per level.
- *
- * A node is descended while any level can still improve on it, and a leaf's
- * candidates are examined for a level only when that level's own k-th distance
- * says they could, so each level's result is identical to a search of its own.
- * Each node's distance is computed once, by its parent, and passed in.
- *
- * @param root - Root of the tree to search.
- * @param slim - Resident position columns.
- * @param queries - Flat analysis indices to search from.
- * @param ranges - Flat `[lo, hi)` pairs, one per LOD to match against.
- * @param k - Neighbours per query per LOD.
- * @returns Per LOD, `k` flat indices per query, nearest first, `-1` for none.
- */
-const findNearest = (
-    root: BTreeNode, slim: SlimColumns, queries: Uint32Array, ranges: Int32Array, k: number
-): Int32Array[] => {
-    const targets = ranges.length >> 1;
-    const results: Int32Array[] = [];
-    for (let t = 0; t < targets; t++) {
-        const result = new Int32Array(queries.length * k);
-        result.fill(-1);
-        results.push(result);
-    }
-    const distances = new Float64Array(targets * k);
-    const targetK = new Int32Array(targets);
-    for (let t = 0; t < targets; t++) {
-        targetK[t] = Math.min(k, ranges[2 * t + 1] - ranges[2 * t]);
-    }
-
-    const px = slim.x, py = slim.y, pz = slim.z;
-
-    // Per-query state lives out here so the traversal is one function compiled
-    // once, not a fresh closure allocated per query.
-    let x = 0, y = 0, z = 0;
-    let output = 0;
-
-    // the walk can stop where no level can improve: the largest k-th distance
-    let radius = Infinity;
-
-    const visit = (node: BTreeNode, distance: number): void => {
-        if (distance > radius) return;
-
-        const { indices } = node;
-        if (indices) {
-            for (let t = 0; t < targets; t++) {
-                const base = t * k;
-                const worst = base + targetK[t] - 1;
-                if (distance > distances[worst]) continue;
-
-                const lo = ranges[2 * t];
-                const hi = ranges[2 * t + 1];
-                const result = results[t];
-                for (let i = 0; i < indices.length; i++) {
-                    const candidate = indices[i];
-                    if (candidate < lo || candidate >= hi) continue;
-                    const dx = px[candidate] - x;
-                    const dy = py[candidate] - y;
-                    const dz = pz[candidate] - z;
-                    const d = dx * dx + dy * dy + dz * dz;
-                    if (d >= distances[worst]) continue;
-
-                    let insert = targetK[t] - 1;
-                    while (insert > 0 && d < distances[base + insert - 1]) {
-                        distances[base + insert] = distances[base + insert - 1];
-                        result[output + insert] = result[output + insert - 1];
-                        insert--;
-                    }
-                    distances[base + insert] = d;
-                    result[output + insert] = candidate;
-                }
-            }
-
-            radius = 0;
-            for (let t = 0; t < targets; t++) {
-                const d = distances[t * k + targetK[t] - 1];
-                if (d > radius) radius = d;
-            }
-            return;
-        }
-
-        const left = node.left!;
-        const right = node.right!;
-        const dl = distanceToAabbSq(left, x, y, z);
-        const dr = distanceToAabbSq(right, x, y, z);
-        if (dl <= dr) {
-            visit(left, dl);
-            visit(right, dr);
-        } else {
-            visit(right, dr);
-            visit(left, dl);
-        }
-    };
-
-    for (let q = 0; q < queries.length; q++) {
-        distances.fill(Infinity);
-        const g = queries[q];
-        x = px[g]; y = py[g]; z = pz[g];
-        output = q * k;
-        radius = Infinity;
-        visit(root, distanceToAabbSq(root, x, y, z));
-    }
-
-    return results;
-};
-
-const uniqueGlobals = (queries: Uint32Array, neighbourSets: Int32Array[]): Uint32Array => {
-    let capacity = queries.length;
-    for (const neighbours of neighbourSets) capacity += neighbours.length;
-    const combined = new Uint32Array(capacity);
-    combined.set(queries);
-    let count = queries.length;
-    for (const neighbours of neighbourSets) {
-        for (let i = 0; i < neighbours.length; i++) {
-            if (neighbours[i] >= 0) combined[count++] = neighbours[i];
-        }
-    }
-    const sorted = combined.subarray(0, count);
-    sorted.sort();
-    let unique = 0;
-    for (let i = 0; i < sorted.length; i++) {
-        if (i === 0 || sorted[i] !== sorted[i - 1]) sorted[unique++] = sorted[i];
-    }
-    return sorted.slice(0, unique);
-};
-
-const indexOfSorted = (values: Uint32Array, value: number): number => {
-    let lo = 0;
-    let hi = values.length - 1;
-    while (lo <= hi) {
-        const mid = (lo + hi) >>> 1;
-        const candidate = values[mid];
-        if (candidate < value) lo = mid + 1;
-        else if (candidate > value) hi = mid - 1;
-        else return mid;
-    }
-    return -1;
-};
-
 /**
  * Reject a batch of gaussians whose color or stored SH is not finite — the
  * companion to {@link assertFiniteGeometry} for the layer the bounds pass does not
- * read. A single non-finite coefficient makes {@link splatError} return `NaN` for
- * every pair the splat takes part in, and `directional` discards `NaN` matches, so
- * a level would report *less* error the more of it is broken. Coverage is again
- * the whole scene: every gaussian of a leaf is gathered as its own level's query.
+ * read. A non-finite coefficient would paint NaN into the error renders and the
+ * comparison would silently absorb it, so it is refused up front like invalid
+ * geometry. Coverage is again the whole scene: every gaussian of a leaf is
+ * gathered for its own level's render.
  *
  * @param color - Packed color/SH records for the batch.
  * @param count - Gaussians in the batch.
@@ -498,301 +340,225 @@ const assertFiniteColor = (
     }
 };
 
-const gatherView = async (
+const GEOMETRIC_COLUMNS = ['rot_0', 'rot_1', 'rot_2', 'rot_3', 'scale_0', 'scale_1', 'scale_2', 'opacity'];
+
+/**
+ * Gather one structural level of a leaf into a resident {@link DataTable} for the
+ * rasterizer. Positions come from the resident slim columns; rotation, scale,
+ * opacity and color/SH are read from the source by index in pool-sized batches —
+ * the same per-leaf gather the bounds pass does for its layers.
+ *
+ * The table stays in PLY space, tagged as such. The error pass renders scene and
+ * camera in one space and only ever compares renders against each other, so the
+ * space is immaterial as long as it is shared; PLY-space SH is evaluated against
+ * PLY-space view directions, which is self-consistent.
+ *
+ * @param source - The PLY-space scene source.
+ * @param pool - Pool for the temporary per-batch read buffers.
+ * @param slim - Resident position columns.
+ * @param indices - Flat analysis indices of the level's gaussians in this leaf.
+ * @param lod - The structural LOD the indices belong to.
+ * @param base - Flat base of `lod`, converting a flat index to a row local to it.
+ * @returns The level's gaussians as a table in PLY space.
+ */
+const gatherLeafTable = async (
     source: ChunkSource, pool: ChunkDataPool, slim: SlimColumns,
-    globals: Uint32Array, lod: number, base: number
-): Promise<SplatView> => {
+    indices: Uint32Array, lod: number, base: number
+): Promise<DataTable> => {
     const { layouts } = source.meta;
     const colorDim = layouts.color!.stride >> 2;
-    const view: SplatView = {
-        pos: new Float32Array(globals.length * 3),
-        geo: new Float32Array(globals.length * 8),
-        color: new Float32Array(globals.length * colorDim),
-        colorDim
-    };
-    const local = new Uint32Array(globals.length);
-    for (let i = 0; i < globals.length; i++) {
-        const g = globals[i];
-        local[i] = g - base;
-        view.pos[i * 3] = slim.x[g];
-        view.pos[i * 3 + 1] = slim.y[g];
-        view.pos[i * 3 + 2] = slim.z[g];
-    }
+    const n = indices.length;
 
-    for (let off = 0; off < local.length; off += pool.chunkSize) {
-        const count = Math.min(pool.chunkSize, local.length - off);
-        const geo = pool.acquire('geometric', layouts.geometric!, count);
-        const color = pool.acquire('color', layouts.color!, count);
-        await source.read({ indices: local, indexOffset: off, count, lod, geometric: geo, color });
-        const colorBatch = new Float32Array(color.data, 0, count * colorDim);
-        assertFiniteColor(colorBatch, count, colorDim, local, off, lod);
-        view.geo.set(new Float32Array(geo.data, 0, count * 8), off * 8);
-        view.color.set(colorBatch, off * colorDim);
-        geo.release();
-        color.release();
-    }
+    const position = [new Float32Array(n), new Float32Array(n), new Float32Array(n)];
+    const geometric = GEOMETRIC_COLUMNS.map(() => new Float32Array(n));
+    const color = Array.from({ length: colorDim }, () => new Float32Array(n));
 
-    return view;
-};
-
-const concatViews = (views: SplatView[]): SplatView => {
-    const { colorDim } = views[0];
-    let count = 0;
-    for (const v of views) count += v.pos.length / 3;
-    const result: SplatView = {
-        pos: new Float32Array(count * 3),
-        geo: new Float32Array(count * 8),
-        color: new Float32Array(count * colorDim),
-        colorDim
-    };
-    let row = 0;
-    for (const v of views) {
-        result.pos.set(v.pos, row * 3);
-        result.geo.set(v.geo, row * 8);
-        result.color.set(v.color, row * colorDim);
-        row += v.pos.length / 3;
-    }
-    return result;
-};
-
-const PI_1_5 = Math.PI ** 1.5;
-const TWO_PI_1_5 = (2 * Math.PI) ** 1.5;
-
-/**
- * Per-splat terms of the field-L2: the covariance, the footprint mass used to
- * weight it, the gaussian's opacity, sqrt(det sigma), and its self inner product
- * <f, f> = alpha^2 * pi^1.5 * sqrt(det sigma).
- *
- * `sigma` and `mass` are what the decimator's `buildCostCache` computes (same
- * math, same f32 storage, so the same values); the rest of that cache serves the
- * MC-KL edge cost, which this path does not evaluate, so it is not built here.
- */
-type ErrorCache = {
-    sigma: Float32Array;
-    mass: Float32Array;
-    alpha: Float64Array;
-    sqrtDet: Float64Array;
-    self: Float64Array;
-};
-
-const buildErrorCache = (view: SplatView): ErrorCache => {
-    const { geo } = view;
-    const n = geo.length / 8;
-    const sigma = new Float32Array(n * 9);
-    const mass = new Float32Array(n);
-    const alpha = new Float64Array(n);
-    const sqrtDet = new Float64Array(n);
-    const self = new Float64Array(n);
-    const rot = new Float32Array(9);
-
+    const local = new Uint32Array(n);
     for (let i = 0; i < n; i++) {
-        const i8 = 8 * i;
-        const i9 = 9 * i;
-
-        const linAlpha = sigmoid(geo[i8 + 7]);
-        const sx = Math.max(Math.exp(geo[i8 + 4]), 1e-12);
-        const sy = Math.max(Math.exp(geo[i8 + 5]), 1e-12);
-        const sz = Math.max(Math.exp(geo[i8 + 6]), 1e-12);
-
-        let qw = geo[i8], qx = geo[i8 + 1], qy = geo[i8 + 2], qz = geo[i8 + 3];
-        const invq = 1 / Math.max(Math.hypot(qw, qx, qy, qz), 1e-12);
-        qw *= invq; qx *= invq; qy *= invq; qz *= invq;
-
-        quatToRotmat(qw, qx, qy, qz, rot, 0);
-        sigmaFromRotVar(rot, 0, sx * sx + EPS_COV, sy * sy + EPS_COV, sz * sz + EPS_COV, sigma, i9);
-
-        const root = Math.sqrt(Math.max(det3(sigma, i9), 1e-300));
-        alpha[i] = linAlpha;
-        sqrtDet[i] = root;
-        self[i] = linAlpha * linAlpha * PI_1_5 * root;
-        mass[i] = linAlpha * ellipsoidArea(sx, sy, sz) + 1e-12;
+        const g = indices[i];
+        local[i] = g - base;
+        position[0][i] = slim.x[g];
+        position[1][i] = slim.y[g];
+        position[2][i] = slim.z[g];
     }
 
-    return { sigma, mass, alpha, sqrtDet, self };
-};
+    for (let off = 0; off < n; off += pool.chunkSize) {
+        const count = Math.min(pool.chunkSize, n - off);
+        const geo = pool.acquire('geometric', layouts.geometric!, count);
+        const col = pool.acquire('color', layouts.color!, count);
+        await source.read({ indices: local, indexOffset: off, count, lod, geometric: geo, color: col });
 
-const sumScratch = new Float64Array(9);
+        const geoBatch = new Float32Array(geo.data, 0, count * 8);
+        const colorBatch = new Float32Array(col.data, 0, count * colorDim);
+        assertFiniteColor(colorBatch, count, colorDim, local, off, lod);
+        for (let i = 0; i < count; i++) {
+            for (let k = 0; k < 8; k++) geometric[k][off + i] = geoBatch[i * 8 + k];
+            for (let k = 0; k < colorDim; k++) color[k][off + i] = colorBatch[i * colorDim + k];
+        }
+
+        geo.release();
+        col.release();
+    }
+
+    const columns = [
+        new Column('x', position[0]),
+        new Column('y', position[1]),
+        new Column('z', position[2]),
+        ...GEOMETRIC_COLUMNS.map((name, k) => new Column(name, geometric[k])),
+        new Column('f_dc_0', color[0]),
+        new Column('f_dc_1', color[1]),
+        new Column('f_dc_2', color[2])
+    ];
+    for (let k = 3; k < colorDim; k++) columns.push(new Column(`f_rest_${k - 3}`, color[k]));
+
+    return new DataTable(columns, Transform.PLY);
+};
 
 /**
- * Approximation error between two splats: the relative field-L2 of the density
- * each one paints plus the stored-SH L2.
- *
- * Writing f(x) = alpha * exp(-0.5 (x-mu)^T sigma^-1 (x-mu)), every inner product
- * <f_i, f_j> is closed form, so
- *
- *   ||f_i - f_j||^2 / (||f_i||^2 + ||f_j||^2)
- *
- * is exact: zero only for identical splats, monotone in their separation, and
- * bounded by 1 once they no longer overlap. The decimator's edge cost is not
- * usable here — as a one-sample MC estimate of a KL it carries ~1.2 nats of
- * noise, far more than the error a well-decimated leaf actually has, and it is
- * blind to opacity (alpha only sets the merge weights there).
- *
- * Both terms are non-negative, so a pair whose geometric term alone already
- * reaches `cutoff` cannot beat it: `Infinity` is returned without summing the SH
- * coefficients, which is the bulk of the arithmetic at 3 SH bands.
- *
- * @param view - Splat columns.
- * @param cache - Per-splat cache from {@link buildErrorCache}.
- * @param i - First splat (view row).
- * @param j - Second splat (view row).
- * @param cutoff - Error to beat; pass `Infinity` for the unconditional error.
- * @returns The error, zero when the two splats are identical.
+ * Pixels across each error render. This is the metric's one calibration: it fixes
+ * the on-screen size at which a level is judged, since detail finer than a pixel
+ * of the render is invisible to it. 512 across a leaf corresponds to a leaf
+ * spanning roughly a quarter of a 2K-wide viewport — the band in which the
+ * engine's budget allocator is actually trading levels off against each other.
+ * The nearest leaves are bought first whatever their error says, and the far
+ * field sits at its coarsest level regardless, so accuracy elsewhere buys little.
  */
-const splatError = (
-    view: SplatView, cache: ErrorCache, i: number, j: number, cutoff: number
-): number => {
-    const s = sumScratch;
-    const i9 = 9 * i, j9 = 9 * j;
-    for (let a = 0; a < 9; a++) s[a] = cache.sigma[i9 + a] + cache.sigma[j9 + a];
-    const detS = Math.max(det3(s, 0), 1e-300);
+const ERROR_VIEW_SIZE = 512;
 
-    // d^T (sigma_i + sigma_j)^-1 d, via the adjugate (symmetric, so no transpose)
-    const { pos } = view;
-    const dx = pos[3 * i] - pos[3 * j];
-    const dy = pos[3 * i + 1] - pos[3 * j + 1];
-    const dz = pos[3 * i + 2] - pos[3 * j + 2];
-    const ax = (s[4] * s[8] - s[5] * s[7]) * dx + (s[2] * s[7] - s[1] * s[8]) * dy + (s[1] * s[5] - s[2] * s[4]) * dz;
-    const ay = (s[5] * s[6] - s[3] * s[8]) * dx + (s[0] * s[8] - s[2] * s[6]) * dy + (s[2] * s[3] - s[0] * s[5]) * dz;
-    const az = (s[3] * s[7] - s[4] * s[6]) * dx + (s[1] * s[6] - s[0] * s[7]) * dy + (s[0] * s[4] - s[1] * s[3]) * dz;
-    const quad = (dx * ax + dy * ay + dz * az) / detS;
+/**
+ * Camera distance from the leaf centre, in bounding-sphere radii. Near-orthographic
+ * without being so far that the splats' projected footprints are lost to precision.
+ */
+const ERROR_VIEW_DISTANCE = 4;
 
-    const cross = cache.alpha[i] * cache.alpha[j] * TWO_PI_1_5 *
-        cache.sqrtDet[i] * cache.sqrtDet[j] / Math.sqrt(detS) * Math.exp(-0.5 * quad);
-    const total = cache.self[i] + cache.self[j];
-    const geoError = Math.max(0, total - 2 * cross) / Math.max(total, 1e-300);
-    if (geoError >= cutoff) return Infinity;
+/** The six axis-aligned directions the leaf is viewed from. */
+const ERROR_VIEW_DIRECTIONS = [[1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0], [0, 0, 1], [0, 0, -1]];
 
-    const { color, colorDim } = view;
-    let colorError = 0;
-    for (let c = 0; c < colorDim; c++) {
-        const d = color[i * colorDim + c] - color[j * colorDim + c];
-        colorError += d * d;
-    }
+/**
+ * Transparent black: the renderer then reports residual coverage in the alpha
+ * channel and colour premultiplied by it in RGB, so thinning (lost coverage) and
+ * colour drift both register as a difference.
+ */
+const ERROR_BACKGROUND = { r: 0, g: 0, b: 0, a: 0 };
 
-    return geoError + colorError;
+/**
+ * The six views of a leaf: pinhole cameras on each axis, far enough out to frame
+ * the leaf's bounding sphere with a little margin.
+ *
+ * @param bound - The leaf's ellipsoid AABB (the same volume the engine derives its
+ * screen coverage from).
+ * @returns One camera per view direction.
+ */
+const leafCameras = (bound: Aabb): RenderCamera[] => {
+    const { min, max } = bound;
+    const cx = (min[0] + max[0]) / 2;
+    const cy = (min[1] + max[1]) / 2;
+    const cz = (min[2] + max[2]) / 2;
+    const radius = Math.max(Math.hypot(max[0] - min[0], max[1] - min[1], max[2] - min[2]) / 2, 1e-3);
+    const distance = ERROR_VIEW_DISTANCE * radius;
+    const fovY = 2 * Math.atan(1.05 * radius / distance);
+
+    return ERROR_VIEW_DIRECTIONS.map(([dx, dy, dz]) => ({
+        projection: 'pinhole',
+        position: new Vec3(cx + dx * distance, cy + dy * distance, cz + dz * distance),
+        target: new Vec3(cx, cy, cz),
+        // any vector not parallel to the view direction
+        up: dy !== 0 ? new Vec3(0, 0, 1) : new Vec3(0, 1, 0),
+        fovY,
+        width: ERROR_VIEW_SIZE,
+        height: ERROR_VIEW_SIZE,
+        // the leaf occupies [distance - radius, distance + radius] in depth
+        near: radius
+    }));
 };
 
+const sumSquared = (image: Uint8Array): number => {
+    let total = 0;
+    for (let i = 0; i < image.length; i++) {
+        const v = image[i] / 255;
+        total += v * v;
+    }
+    return total;
+};
+
+const sumSquaredDifference = (a: Uint8Array, b: Uint8Array): number => {
+    let total = 0;
+    for (let i = 0; i < a.length; i++) {
+        const d = (a[i] - b[i]) / 255;
+        total += d * d;
+    }
+    return total;
+};
+
+/**
+ * Per-level approximation error of a leaf, measured on rendered images.
+ *
+ * Each level present in the leaf is rendered from the six {@link leafCameras}
+ * views and compared against the finest level present, which is the reference
+ * and carries no error. A level's error is the squared RGBA difference summed
+ * over every pixel of every view, divided by the reference's summed squared RGBA
+ * — a relative image error that is zero for an identical level, grows without
+ * bound as a level departs from the reference, and is dimensionless so leaves of
+ * any physical size compare on one scale.
+ *
+ * Comparing composited images rather than the gaussians themselves is what makes
+ * the number track what the viewer will show: a merge of overlapping splats into
+ * one that paints the same pixels costs nothing, while thinning, blur and colour
+ * drift all register in proportion to how visible they are at the calibrated
+ * size ({@link ERROR_VIEW_SIZE}). Any per-splat comparison saturates once a
+ * splat no longer overlaps its nearest match, which compresses a 128x decimation
+ * and a 2x one into the same narrow band and leaves the engine's allocator
+ * ranking on splat count alone.
+ *
+ * The cost is linear in the leaf's gaussians (each is projected once per view
+ * per level) and each leaf is self-contained, so the pass scales linearly with
+ * the scene and needs no scene-wide search structure.
+ *
+ * The table is kept monotone non-decreasing across levels. The engine ranks
+ * upgrades by error reduction per splat *across* leaves, so a coarser level must
+ * never advertise less error than the finer one it stands in for.
+ *
+ * @param device - Graphics device the renders run on.
+ * @param source - The PLY-space scene source.
+ * @param pool - Pool for the per-batch read buffers.
+ * @param slim - Resident position columns.
+ * @param bound - The leaf's ellipsoid AABB, in PLY space.
+ * @param bins - The leaf's flat analysis indices, by structural LOD.
+ * @param cum - Flat base of each structural LOD.
+ * @param numLods - Number of structural LODs in the source.
+ * @returns One error per structural LOD; zero for the reference and for levels
+ * absent from the leaf.
+ */
 const calcErrors = async (
-    source: ChunkSource, pool: ChunkDataPool, slim: SlimColumns, root: BTreeNode,
-    bins: Map<number, Uint32Array>, cum: number[], numLods: number
+    device: GraphicsDevice, source: ChunkSource, pool: ChunkDataPool, slim: SlimColumns,
+    bound: Aabb, bins: Map<number, Uint32Array>, cum: number[], numLods: number
 ): Promise<number[]> => {
-    // Symmetric Chamfer-style error against the finest representation present in
-    // this leaf, plus the alpha-mass a level fails to carry. Center-space KNN
-    // supplies a small candidate set (including candidates across leaf
-    // boundaries); the final match uses the closed-form {@link splatError}. This
-    // compares arbitrary input LODs, so it does not depend on how those LODs
-    // were produced.
     const errors = new Array(numLods).fill(0);
-    const referenceLod = Math.min(...bins.keys());
-    const referenceQueries = bins.get(referenceLod)!;
-    const k = 4;
+    const levels = [...bins.keys()].sort((a, b) => a - b);
+    if (levels.length < 2) return errors;
 
-    const targetLods = [...bins.keys()].filter(lod => lod !== referenceLod).sort((a, b) => a - b);
-    if (targetLods.length === 0) return errors;
+    const cameras = leafCameras(bound);
 
-    // Forward (reference -> each level) shares one traversal per reference splat;
-    // reverse (each level -> reference) is a separate query set per level.
-    const targetRanges = new Int32Array(targetLods.length * 2);
-    targetLods.forEach((lod, i) => {
-        targetRanges[2 * i] = cum[lod];
-        targetRanges[2 * i + 1] = cum[lod + 1];
-    });
-    const referenceRange = Int32Array.of(cum[referenceLod], cum[referenceLod + 1]);
-
-    const forwards = findNearest(root, slim, referenceQueries, targetRanges, k);
-    const reverses = targetLods.map(lod => findNearest(root, slim, bins.get(lod)!, referenceRange, k)[0]);
-
-    // One gathered section per level, holding that level's own splats plus every
-    // splat another level matched into it, concatenated into a single view. All
-    // levels are handled in one pass so the reference level — the largest, and a
-    // participant in every pair — is read and cached once instead of once per
-    // level pair.
-    const order = [referenceLod, ...targetLods];
-    const globals: Uint32Array[] = new Array(numLods);
-    globals[referenceLod] = uniqueGlobals(referenceQueries, reverses);
-    targetLods.forEach((lod, i) => {
-        globals[lod] = uniqueGlobals(bins.get(lod)!, [forwards[i]]);
-    });
-
-    const offsets = new Int32Array(numLods);
-    const sections: SplatView[] = [];
-    let rows = 0;
-    for (const lod of order) {
-        offsets[lod] = rows;
-        sections.push(await gatherView(source, pool, slim, globals[lod], lod, cum[lod]));
-        rows += globals[lod].length;
+    const referenceLod = levels[0];
+    const referenceTable = await gatherLeafTable(source, pool, slim, bins.get(referenceLod)!, referenceLod, cum[referenceLod]);
+    const referenceImages: Uint8Array[] = [];
+    let energy = 0;
+    for (const camera of cameras) {
+        const image = await renderSplats(device, referenceTable, camera, ERROR_BACKGROUND, { quiet: true });
+        energy += sumSquared(image);
+        referenceImages.push(image);
     }
 
-    const view = concatViews(sections);
-    const cache = buildErrorCache(view);
-
-    // Rows of a level's own splats, in query order. The reference level's are
-    // reused by every pair.
-    const rowsOf = (queries: Uint32Array, lod: number): Int32Array => {
-        const result = new Int32Array(queries.length);
-        const offset = offsets[lod];
-        const g = globals[lod];
-        for (let i = 0; i < queries.length; i++) result[i] = offset + indexOfSorted(g, queries[i]);
-        return result;
-    };
-    const referenceRows = rowsOf(referenceQueries, referenceLod);
-
-    // `mass` (alpha * ellipsoid area) is a splat's share of what the leaf
-    // paints, so it weights both the per-splat mean and the coverage term —
-    // a hair-thin splat and one spanning the whole leaf are not equals.
-    const directional = (
-        queryRows: Int32Array, neighbours: Int32Array, neighbourLod: number
-    ): number => {
-        let total = 0;
-        let weight = 0;
-        const neighbourOffset = offsets[neighbourLod];
-        const neighbourGlobals = globals[neighbourLod];
-        for (let i = 0; i < queryRows.length; i++) {
-            const queryRow = queryRows[i];
-            let best = Infinity;
-            for (let j = 0; j < k; j++) {
-                const neighbour = neighbours[i * k + j];
-                if (neighbour < 0) continue;
-                const neighbourRow = neighbourOffset + indexOfSorted(neighbourGlobals, neighbour);
-                const error = splatError(view, cache, queryRow, neighbourRow, best);
-                if (error < best) best = error;
-            }
-            if (best === Infinity) continue;
-            total += cache.mass[queryRow] * best;
-            weight += cache.mass[queryRow];
-        }
-        return weight > 0 ? total / weight : 0;
-    };
-
-    const massOf = (queryRows: Int32Array): number => {
-        let mass = 0;
-        for (let i = 0; i < queryRows.length; i++) mass += cache.mass[queryRows[i]];
-        return mass;
-    };
-
-    // Nearest-neighbour matching cannot see thinning: drop every second
-    // splat of an overlapping group and each survivor still has a
-    // near-identical partner, while the alpha the group accumulates halves.
-    // Sky gaps are exactly that, so compare the mass the levels carry.
-    const referenceMass = massOf(referenceRows);
-    targetLods.forEach((lod, i) => {
-        const targetRows = rowsOf(bins.get(lod)!, lod);
-        const coverageError = Math.max(0, 1 - massOf(targetRows) / Math.max(referenceMass, 1e-300));
-        const forwardError = directional(referenceRows, forwards[i], lod);
-        const reverseError = directional(targetRows, reverses[i], referenceLod);
-        errors[lod] = 0.5 * (forwardError + reverseError) + coverageError;
-    });
-
-    // Keep the table monotone across levels. This does not keep a finer level on
-    // the engine's Pareto frontier — that domination test accepts an equal error,
-    // so a cheaper coarser level displaces the finer one either way — but the
-    // budget balancer ranks transitions by error reduction per splat *across*
-    // nodes, so a coarser level must never advertise less error than the finer
-    // one it stands in for.
     let previous = 0;
-    for (const lod of [...bins.keys()].sort((a, b) => a - b)) {
-        previous = errors[lod] = Math.max(errors[lod], previous);
+    for (let i = 1; i < levels.length; i++) {
+        const lod = levels[i];
+        const table = await gatherLeafTable(source, pool, slim, bins.get(lod)!, lod, cum[lod]);
+        let difference = 0;
+        for (let v = 0; v < cameras.length; v++) {
+            const image = await renderSplats(device, table, cameras[v], ERROR_BACKGROUND, { quiet: true });
+            difference += sumSquaredDifference(referenceImages[v], image);
+        }
+        previous = errors[lod] = Math.max(energy > 0 ? difference / energy : 0, previous);
     }
 
     return errors;
@@ -853,6 +619,11 @@ type WriteLodSourceOptions = {
     mainSource: ChunkSource;
     envSource: ChunkSource | null;
     iterations: number;
+    /**
+     * Supplies the GPU the per-leaf error tables are rendered on (and that SOG
+     * encoding uses). Without one the manifest declares `lodErrors: false` and a
+     * consumer falls back to deriving errors from splat counts.
+     */
     createDevice?: DeviceCreator;
     chunkCount: number;
     chunkExtent: number;
@@ -887,6 +658,13 @@ const writeLodSource = async (options: WriteLodSourceOptions, fs: FileSystem) =>
 
     // Pool for slim extraction read buffers and the chunk-native SOG encodes.
     const pool = createChunkDataPool();
+
+    // The error tables are rendered, so they need the GPU. Acquired up front: the
+    // partition pass below computes them leaf by leaf.
+    const device = createDevice ? await createDevice() : null;
+    if (!device) {
+        logger.info('No GPU device: LOD error tables are not written; the viewer will derive them from splat counts.');
+    }
 
     const slim = await extractSlim(mainSource, pool);
     const hasEnv = !!envSource && envSource.meta.numGaussians > 0;
@@ -983,8 +761,9 @@ const writeLodSource = async (options: WriteLodSourceOptions, fs: FileSystem) =>
 
         // Bound and approximation errors over the leaf's full structural LOD data.
         const bound = await calcBound(mainSource, pool, bins, cum, n => chunkingBar.tick(n));
-        const errors = await calcErrors(mainSource, pool, slim, bTree!.root, bins, cum, numLods);
+        if (!device) return { bound, lods };
 
+        const errors = await calcErrors(device, mainSource, pool, slim, bound, bins, cum, numLods);
         return { bound, lods, errors };
     };
 
@@ -1024,7 +803,7 @@ const writeLodSource = async (options: WriteLodSourceOptions, fs: FileSystem) =>
         count: counts.reduce((acc, curr) => acc + curr, 0),
         counts,
         lodLevels,
-        lodErrors: true,
+        lodErrors: device !== null,
         ...(hasEnv ? { environment: 'env/meta.json' } : {}),
         filenames,
         tree
@@ -1143,4 +922,4 @@ const writeLodSource = async (options: WriteLodSourceOptions, fs: FileSystem) =>
     writingGroup.end();
 };
 
-export { findNearest, positionsFromSlim, writeLodSource, type WriteLodSourceOptions };
+export { positionsFromSlim, writeLodSource, type WriteLodSourceOptions };

--- a/src/lib/writers/write-lod.ts
+++ b/src/lib/writers/write-lod.ts
@@ -1,10 +1,11 @@
 import { basename, dirname, resolve } from 'pathe';
-import { BoundingBox, Mat4, Quat, Vec3 } from 'playcanvas';
+import { BoundingBox, type GraphicsDevice, Mat4, Quat, Vec3 } from 'playcanvas';
 
 import { ATLAS_MAX_BATCH_GAUSSIANS, ErrorRenderer, type LeafLevels, leafViewSize } from './lod-error';
 import { logWrittenFile } from './utils';
 import { writeSogSource } from './write-sog.js';
-import { type ChunkDataPool, type ChunkSource, type ReadRequest, createChunkDataPool } from '../chunk';
+import { type ChunkDataPool, type ChunkLayer, type ChunkSource, type ReadRequest, createChunkDataPool } from '../chunk';
+import { materializeToDataTable } from '../compat/data-table';
 import { Column, DataTable } from '../data-table';
 import { type FileSystem } from '../io/write';
 import { bakeTransform, permuteSource, sortMortonColumns } from '../ops';
@@ -178,11 +179,10 @@ const invalidGaussian = (lod: number, row: number, what: string): Error => new E
 
 /**
  * Reject a batch of gaussians whose geometry is not finite. The bounds pass reads
- * every gaussian's geometric record once, so this covers the whole scene:
- * everything downstream — the error pass above all, which renders every gaussian
- * — may then assume finite input rather than each stage carrying its own opinion
- * about invalid data. {@link assertFiniteColor} does the same for the layer this
- * pass does not read.
+ * every gaussian's record once, so this covers the whole scene: everything
+ * downstream — the error pass above all, which renders every gaussian — may then
+ * assume finite input rather than each stage carrying its own opinion about
+ * invalid data. {@link assertFiniteColor} does the same for the colour layer.
  *
  * The rules mirror `filterNaNRows`, including its two deliberate exceptions
  * (`scale_*` may be `-Infinity`, `opacity` may be `+Infinity`, both harmless
@@ -225,11 +225,41 @@ const assertFiniteGeometry = (
     }
 };
 
+/**
+ * Reject a batch of gaussians whose color or stored SH is not finite — the
+ * companion to {@link assertFiniteGeometry}, run on the same bounds-pass read so
+ * the whole scene is covered with or without a GPU. A non-finite coefficient would
+ * paint NaN into the error renders, which the comparison would silently absorb,
+ * and would corrupt the SOG colour codebooks, so it is refused up front like
+ * invalid geometry.
+ *
+ * @param color - Packed color/SH records for the batch.
+ * @param count - Gaussians in the batch.
+ * @param colorDim - Floats per gaussian (3 + stored SH).
+ * @param rows - Rows local to `lod`, indexed from `offset`, for error messages.
+ * @param offset - Index of the batch's first row within `rows`.
+ * @param lod - Structural LOD the batch was read from.
+ */
+const assertFiniteColor = (
+    color: Float32Array, count: number, colorDim: number,
+    rows: Uint32Array, offset: number, lod: number
+): void => {
+    for (let i = 0; i < count; i++) {
+        const base = i * colorDim;
+        for (let c = 0; c < colorDim; c++) {
+            if (!isFinite(color[base + c])) {
+                throw invalidGaussian(lod, rows[offset + i], 'a non-finite color or SH coefficient');
+            }
+        }
+    }
+};
+
 // Per-leaf ellipsoid AABB, computed per structural LOD. Positions are resident,
 // but rotation/scale are gathered from the source by index so the geometric layer
 // is never wholly resident — the bounds-pass analog of the per-unit heavy gather.
 // `bins` maps LOD -> flat analysis indices; each is gathered from its own LOD
-// (flat index `g` -> local row `g - cum[lod]`).
+// (flat index `g` -> local row `g - cum[lod]`). The colour layer rides along on
+// the same record read purely to be validated.
 const calcBound = async (
     source: ChunkSource, pool: ChunkDataPool, bins: Map<number, Uint32Array>, cum: number[],
     tick?: (n: number) => void
@@ -239,6 +269,7 @@ const calcBound = async (
 
     const batch = pool.chunkSize;
     const { layouts } = source.meta;
+    const colorDim = layouts.color!.stride >> 2;
 
     for (const [lodValue, flat] of bins) {
         const base = cum[lodValue];
@@ -249,13 +280,15 @@ const calcBound = async (
             const count = Math.min(batch, local.length - off);
             const pos = pool.acquire('position', layouts.position!, count);
             const geo = pool.acquire('geometric', layouts.geometric!, count);
-            await source.read({ indices: local, indexOffset: off, count, lod: lodValue, position: pos, geometric: geo });
+            const color = pool.acquire('color', layouts.color!, count);
+            await source.read({ indices: local, indexOffset: off, count, lod: lodValue, position: pos, geometric: geo, color });
             // position is full-stride packed xyz — read the pool buffer in place
             // rather than copying it out per batch
             const posBatch = new Float32Array(pos.data, 0, count * 3);
             assertFiniteGeometry(
                 posBatch, new Float32Array(geo.data, 0, count * 8), count, local, off, lodValue
             );
+            assertFiniteColor(new Float32Array(color.data, 0, count * colorDim), count, colorDim, local, off, lodValue);
             accumulateBound(
                 min, max,
                 posBatch,
@@ -265,6 +298,7 @@ const calcBound = async (
             );
             pos.release();
             geo.release();
+            color.release();
             tick?.(count);
         }
     }
@@ -319,42 +353,14 @@ const binIndices = (parent: BTreeNode, lodOf: (index: number) => number): Map<nu
     return result;
 };
 
-/**
- * Reject a batch of gaussians whose color or stored SH is not finite — the
- * companion to {@link assertFiniteGeometry} for the layer the bounds pass does not
- * read. A non-finite coefficient would paint NaN into the error renders and the
- * comparison would silently absorb it, so it is refused up front like invalid
- * geometry. Coverage is again the whole scene: every gaussian of a leaf is
- * gathered for its own level's render.
- *
- * @param color - Packed color/SH records for the batch.
- * @param count - Gaussians in the batch.
- * @param colorDim - Floats per gaussian (3 + stored SH).
- * @param rows - Rows local to `lod`, indexed from `offset`, for error messages.
- * @param offset - Index of the batch's first row within `rows`.
- * @param lod - Structural LOD the batch was read from.
- */
-const assertFiniteColor = (
-    color: Float32Array, count: number, colorDim: number,
-    rows: Uint32Array, offset: number, lod: number
-): void => {
-    for (let i = 0; i < count; i++) {
-        const base = i * colorDim;
-        for (let c = 0; c < colorDim; c++) {
-            if (!isFinite(color[base + c])) {
-                throw invalidGaussian(lod, rows[offset + i], 'a non-finite color or SH coefficient');
-            }
-        }
-    }
-};
-
-const GEOMETRIC_COLUMNS = ['rot_0', 'rot_1', 'rot_2', 'rot_3', 'scale_0', 'scale_1', 'scale_2', 'opacity'];
+/** The layers a leaf's render needs from the source; positions are resident. */
+const LEAF_TABLE_LAYERS = new Set<ChunkLayer>(['geometric', 'color']);
 
 /**
  * Gather one structural level of a leaf into a resident {@link DataTable} for the
  * rasterizer. Positions come from the resident slim columns; rotation, scale,
- * opacity and color/SH are read from the source by index in pool-sized batches —
- * the same per-leaf gather the bounds pass does for its layers.
+ * opacity and color/SH are read from the source by index, chunk by chunk, through
+ * the same permuted view the unit writes use.
  *
  * The table stays in PLY space, tagged as such. The error pass renders scene and
  * camera in one space and only ever compares renders against each other, so the
@@ -373,53 +379,24 @@ const gatherLeafTable = async (
     source: ChunkSource, pool: ChunkDataPool, slim: SlimColumns,
     indices: Uint32Array, lod: number, base: number
 ): Promise<DataTable> => {
-    const { layouts } = source.meta;
-    const colorDim = layouts.color!.stride >> 2;
     const n = indices.length;
-
-    const position = [new Float32Array(n), new Float32Array(n), new Float32Array(n)];
-    const geometric = GEOMETRIC_COLUMNS.map(() => new Float32Array(n));
-    const color = Array.from({ length: colorDim }, () => new Float32Array(n));
-
     const local = new Uint32Array(n);
+    const x = new Float32Array(n);
+    const y = new Float32Array(n);
+    const z = new Float32Array(n);
     for (let i = 0; i < n; i++) {
         const g = indices[i];
         local[i] = g - base;
-        position[0][i] = slim.x[g];
-        position[1][i] = slim.y[g];
-        position[2][i] = slim.z[g];
+        x[i] = slim.x[g];
+        y[i] = slim.y[g];
+        z[i] = slim.z[g];
     }
 
-    for (let off = 0; off < n; off += pool.chunkSize) {
-        const count = Math.min(pool.chunkSize, n - off);
-        const geo = pool.acquire('geometric', layouts.geometric!, count);
-        const col = pool.acquire('color', layouts.color!, count);
-        await source.read({ indices: local, indexOffset: off, count, lod, geometric: geo, color: col });
-
-        const geoBatch = new Float32Array(geo.data, 0, count * 8);
-        const colorBatch = new Float32Array(col.data, 0, count * colorDim);
-        assertFiniteColor(colorBatch, count, colorDim, local, off, lod);
-        for (let i = 0; i < count; i++) {
-            for (let k = 0; k < 8; k++) geometric[k][off + i] = geoBatch[i * 8 + k];
-            for (let k = 0; k < colorDim; k++) color[k][off + i] = colorBatch[i * colorDim + k];
-        }
-
-        geo.release();
-        col.release();
-    }
-
-    const columns = [
-        new Column('x', position[0]),
-        new Column('y', position[1]),
-        new Column('z', position[2]),
-        ...GEOMETRIC_COLUMNS.map((name, k) => new Column(name, geometric[k])),
-        new Column('f_dc_0', color[0]),
-        new Column('f_dc_1', color[1]),
-        new Column('f_dc_2', color[2])
-    ];
-    for (let k = 3; k < colorDim; k++) columns.push(new Column(`f_rest_${k - 3}`, color[k]));
-
-    return new DataTable(columns, Transform.PLY);
+    const table = await materializeToDataTable(permuteSource(source, local, { lod }), pool, LEAF_TABLE_LAYERS);
+    table.addColumn(new Column('x', x));
+    table.addColumn(new Column('y', y));
+    table.addColumn(new Column('z', z));
+    return table;
 };
 
 /** A leaf awaiting its error table: the node it fills in and the indices to gather. */
@@ -640,11 +617,19 @@ const writeLodSource = async (options: WriteLodSourceOptions, fs: FileSystem) =>
     const pool = createChunkDataPool();
 
     // The error tables are rendered, so they need the GPU. One renderer serves the
-    // whole pass; the partition below computes the tables leaf by leaf.
-    const device = createDevice ? await createDevice() : null;
+    // whole pass; the partition below queues the leaves for it. A host without a
+    // usable adapter still gets its LODs, without the tables.
+    let device: GraphicsDevice | null = null;
+    if (createDevice) {
+        try {
+            device = await createDevice();
+        } catch (err) {
+            logger.warn(`GPU device unavailable: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
     const renderer = device ? new ErrorRenderer(device, mainSource.meta.shBands) : null;
     if (!renderer) {
-        logger.info('No GPU device: LOD error tables are not written; the viewer will derive them from splat counts.');
+        logger.warn('No GPU device: LOD error tables are not written; the viewer will derive them from splat counts.');
     }
     const leafJobs: LeafJob[] = [];
 
@@ -759,6 +744,11 @@ const writeLodSource = async (options: WriteLodSourceOptions, fs: FileSystem) =>
         chunkingBar.end();
     }
 
+    // The kd-tree is dead once the partition is built (lodFiles and the leaf jobs
+    // hold their own index copies): release its N×4B index buffer and node AABBs
+    // before the error pass and the unit writes, where peak memory lives.
+    bTree = null;
+
     if (renderer) {
         const errorStart = performance.now();
         try {
@@ -774,11 +764,6 @@ const writeLodSource = async (options: WriteLodSourceOptions, fs: FileSystem) =>
         for (const child of node.children ?? []) trimErrors(child);
     };
     trimErrors(tree);
-
-    // The kd-tree is dead once the partition is built (lodFiles holds its own
-    // index copies): release its N×4B index buffer and node AABBs before the
-    // unit writes, where peak memory lives.
-    bTree = null;
 
     // count splats per lod level
     const counts = new Array(lodLevels).fill(0);

--- a/src/lib/writers/write-lod.ts
+++ b/src/lib/writers/write-lod.ts
@@ -1,13 +1,13 @@
 import { basename, dirname, resolve } from 'pathe';
-import { BoundingBox, type GraphicsDevice, Mat4, Quat, Vec3 } from 'playcanvas';
+import { BoundingBox, Mat4, Quat, Vec3 } from 'playcanvas';
 
+import { ATLAS_MAX_BATCH_GAUSSIANS, ErrorRenderer, type LeafLevels, leafViewSize } from './lod-error';
 import { logWrittenFile } from './utils';
 import { writeSogSource } from './write-sog.js';
 import { type ChunkDataPool, type ChunkSource, type ReadRequest, createChunkDataPool } from '../chunk';
 import { Column, DataTable } from '../data-table';
 import { type FileSystem } from '../io/write';
 import { bakeTransform, permuteSource, sortMortonColumns } from '../ops';
-import { type RenderCamera, renderSplats } from '../render';
 import { BTreeNode, BTree } from '../spatial';
 import type { DeviceCreator } from '../types';
 import { logger, Transform } from '../utils';
@@ -173,8 +173,8 @@ const invalidGaussian = (lod: number, row: number, what: string): Error => new E
  * every gaussian's geometric record once, so this covers the whole scene:
  * everything downstream — the error pass above all, which renders every gaussian
  * — may then assume finite input rather than each stage carrying its own opinion
- * about invalid data. {@link assertFiniteColor} does the
- * same for the layer this pass does not read.
+ * about invalid data. {@link assertFiniteColor} does the same for the layer this
+ * pass does not read.
  *
  * The rules mirror `filterNaNRows`, including its two deliberate exceptions
  * (`scale_*` may be `-Infinity`, `opacity` may be `+Infinity`, both harmless
@@ -414,154 +414,114 @@ const gatherLeafTable = async (
     return new DataTable(columns, Transform.PLY);
 };
 
-/**
- * Pixels across each error render. This is the metric's one calibration: it fixes
- * the on-screen size at which a level is judged, since detail finer than a pixel
- * of the render is invisible to it. 512 across a leaf corresponds to a leaf
- * spanning roughly a quarter of a 2K-wide viewport — the band in which the
- * engine's budget allocator is actually trading levels off against each other.
- * The nearest leaves are bought first whatever their error says, and the far
- * field sits at its coarsest level regardless, so accuracy elsewhere buys little.
- */
-const ERROR_VIEW_SIZE = 512;
+/** A leaf awaiting its error table: the node it fills in and the indices to gather. */
+type LeafJob = {
+    node: MetaNode;
+    bins: Map<number, Uint32Array>;
+};
 
 /**
- * Camera distance from the leaf centre, in bounding-sphere radii. Near-orthographic
- * without being so far that the splats' projected footprints are lost to precision.
- */
-const ERROR_VIEW_DISTANCE = 4;
-
-/** The six axis-aligned directions the leaf is viewed from. */
-const ERROR_VIEW_DIRECTIONS = [[1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0], [0, 0, 1], [0, 0, -1]];
-
-/**
- * Transparent black: the renderer then reports residual coverage in the alpha
- * channel and colour premultiplied by it in RGB, so thinning (lost coverage) and
- * colour drift both register as a difference.
- */
-const ERROR_BACKGROUND = { r: 0, g: 0, b: 0, a: 0 };
-
-/**
- * The six views of a leaf: pinhole cameras on each axis, far enough out to frame
- * the leaf's bounding sphere with a little margin.
+ * Make a leaf's raw error table monotone non-decreasing across its levels. The
+ * engine ranks upgrades by error reduction per splat *across* leaves, so a coarser
+ * level must never advertise less error than the finer one it stands in for.
  *
- * @param bound - The leaf's ellipsoid AABB (the same volume the engine derives its
- * screen coverage from).
- * @returns One camera per view direction.
+ * @param raw - Raw error per LOD.
+ * @param levels - The leaf's levels, ascending.
+ * @returns The clamped table, zero for levels absent from the leaf.
  */
-const leafCameras = (bound: Aabb): RenderCamera[] => {
-    const { min, max } = bound;
-    const cx = (min[0] + max[0]) / 2;
-    const cy = (min[1] + max[1]) / 2;
-    const cz = (min[2] + max[2]) / 2;
-    const radius = Math.max(Math.hypot(max[0] - min[0], max[1] - min[1], max[2] - min[2]) / 2, 1e-3);
-    const distance = ERROR_VIEW_DISTANCE * radius;
-    const fovY = 2 * Math.atan(1.05 * radius / distance);
-
-    return ERROR_VIEW_DIRECTIONS.map(([dx, dy, dz]) => ({
-        projection: 'pinhole',
-        position: new Vec3(cx + dx * distance, cy + dy * distance, cz + dz * distance),
-        target: new Vec3(cx, cy, cz),
-        // any vector not parallel to the view direction
-        up: dy !== 0 ? new Vec3(0, 0, 1) : new Vec3(0, 1, 0),
-        fovY,
-        width: ERROR_VIEW_SIZE,
-        height: ERROR_VIEW_SIZE,
-        // the leaf occupies [distance - radius, distance + radius] in depth
-        near: radius
-    }));
-};
-
-const sumSquared = (image: Uint8Array): number => {
-    let total = 0;
-    for (let i = 0; i < image.length; i++) {
-        const v = image[i] / 255;
-        total += v * v;
-    }
-    return total;
-};
-
-const sumSquaredDifference = (a: Uint8Array, b: Uint8Array): number => {
-    let total = 0;
-    for (let i = 0; i < a.length; i++) {
-        const d = (a[i] - b[i]) / 255;
-        total += d * d;
-    }
-    return total;
+const monotoneErrors = (raw: number[], levels: number[]): number[] => {
+    const errors = new Array(raw.length).fill(0);
+    let previous = 0;
+    for (const lod of levels) previous = errors[lod] = Math.max(raw[lod], previous);
+    return errors;
 };
 
 /**
- * Per-level approximation error of a leaf, measured on rendered images.
- *
- * Each level present in the leaf is rendered from the six {@link leafCameras}
- * views and compared against the finest level present, which is the reference
- * and carries no error. A level's error is the squared RGBA difference summed
- * over every pixel of every view, divided by the reference's summed squared RGBA
- * — a relative image error that is zero for an identical level, grows without
- * bound as a level departs from the reference, and is dimensionless so leaves of
- * any physical size compare on one scale.
+ * Fill in every leaf's error table: gather its levels, then measure them with the
+ * {@link ErrorRenderer} — small leaves batched into atlases, the rest alone.
  *
  * Comparing composited images rather than the gaussians themselves is what makes
  * the number track what the viewer will show: a merge of overlapping splats into
  * one that paints the same pixels costs nothing, while thinning, blur and colour
- * drift all register in proportion to how visible they are at the calibrated
- * size ({@link ERROR_VIEW_SIZE}). Any per-splat comparison saturates once a
- * splat no longer overlaps its nearest match, which compresses a 128x decimation
- * and a 2x one into the same narrow band and leaves the engine's allocator
- * ranking on splat count alone.
+ * drift all register in proportion to how visible they are at the judged size
+ * (see {@link leafViewSize}). Any per-splat comparison saturates once a splat no
+ * longer overlaps its nearest match, which compresses a 128x decimation and a 2x
+ * one into the same narrow band and leaves the engine's allocator ranking on
+ * splat count alone.
  *
- * The cost is linear in the leaf's gaussians (each is projected once per view
- * per level) and each leaf is self-contained, so the pass scales linearly with
- * the scene and needs no scene-wide search structure.
+ * Each leaf is self-contained, so the pass needs no scene-wide search structure
+ * and its cost is a fixed price per render times the number of leaves, levels
+ * and views, with batching dividing the render count for small leaves.
  *
- * The table is kept monotone non-decreasing across levels. The engine ranks
- * upgrades by error reduction per splat *across* leaves, so a coarser level must
- * never advertise less error than the finer one it stands in for.
+ * Leaves are visited in partition order so each atlas holds neighbours and the
+ * source gathers stay local. An atlas is flushed when it fills, and every
+ * partially filled one at the end.
  *
- * @param device - Graphics device the renders run on.
+ * @param renderer - The renderer for the pass.
  * @param source - The PLY-space scene source.
  * @param pool - Pool for the per-batch read buffers.
  * @param slim - Resident position columns.
- * @param bound - The leaf's ellipsoid AABB, in PLY space.
- * @param bins - The leaf's flat analysis indices, by structural LOD.
  * @param cum - Flat base of each structural LOD.
  * @param numLods - Number of structural LODs in the source.
- * @returns One error per structural LOD; zero for the reference and for levels
- * absent from the leaf.
+ * @param jobs - The leaves, in partition order.
  */
-const calcErrors = async (
-    device: GraphicsDevice, source: ChunkSource, pool: ChunkDataPool, slim: SlimColumns,
-    bound: Aabb, bins: Map<number, Uint32Array>, cum: number[], numLods: number
-): Promise<number[]> => {
-    const errors = new Array(numLods).fill(0);
-    const levels = [...bins.keys()].sort((a, b) => a - b);
-    if (levels.length < 2) return errors;
+const runErrorPass = async (
+    renderer: ErrorRenderer, source: ChunkSource, pool: ChunkDataPool, slim: SlimColumns,
+    cum: number[], numLods: number, jobs: LeafJob[]
+): Promise<void> => {
+    const bar = logger.bar('lod errors', jobs.length);
+    const atlases = new Map<number, { leaf: LeafLevels; job: LeafJob }[]>();
+    const atlasGaussians = new Map<number, number>();
 
-    const cameras = leafCameras(bound);
+    const assign = (job: LeafJob, levels: number[], raw: number[]) => {
+        job.node.errors = monotoneErrors(raw, levels);
+        bar.tick(1);
+    };
 
-    const referenceLod = levels[0];
-    const referenceTable = await gatherLeafTable(source, pool, slim, bins.get(referenceLod)!, referenceLod, cum[referenceLod]);
-    const referenceImages: Uint8Array[] = [];
-    let energy = 0;
-    for (const camera of cameras) {
-        const image = await renderSplats(device, referenceTable, camera, ERROR_BACKGROUND, { quiet: true });
-        energy += sumSquared(image);
-        referenceImages.push(image);
-    }
+    const flush = async (frame: number) => {
+        const batch = atlases.get(frame);
+        if (!batch?.length) return;
+        atlases.set(frame, []);
+        atlasGaussians.set(frame, 0);
+        const raws = await renderer.atlasErrors(batch.map(b => b.leaf), frame, numLods);
+        batch.forEach((b, i) => assign(b.job, [...b.leaf.levels.keys()].sort((x, y) => x - y), raws[i]));
+    };
 
-    let previous = 0;
-    for (let i = 1; i < levels.length; i++) {
-        const lod = levels[i];
-        const table = await gatherLeafTable(source, pool, slim, bins.get(lod)!, lod, cum[lod]);
-        let difference = 0;
-        for (let v = 0; v < cameras.length; v++) {
-            const image = await renderSplats(device, table, cameras[v], ERROR_BACKGROUND, { quiet: true });
-            difference += sumSquaredDifference(referenceImages[v], image);
+    try {
+        for (const job of jobs) {
+            const levels = [...job.bins.keys()].sort((a, b) => a - b);
+            if (levels.length < 2) {
+                assign(job, levels, new Array(numLods).fill(0));
+                continue;
+            }
+
+            const tables = new Map<number, DataTable>();
+            for (const lod of levels) {
+                tables.set(lod, await gatherLeafTable(source, pool, slim, job.bins.get(lod)!, lod, cum[lod]));
+            }
+            const leaf: LeafLevels = { bound: job.node.bound, levels: tables };
+            const reference = tables.get(levels[0])!;
+            const frame = leafViewSize(leaf.bound, reference);
+
+            if (ErrorRenderer.fitsAtlas(frame, leaf)) {
+                // Batches are keyed by the frame rounded up to a power of two, so a
+                // scene's leaves fall into a few well-filled batches rather than one
+                // per frame size; a leaf is only ever judged at a frame at least its own.
+                const key = 1 << Math.ceil(Math.log2(frame));
+                const batch = atlases.get(key) ?? [];
+                atlases.set(key, batch);
+                batch.push({ leaf, job });
+                const gaussians = (atlasGaussians.get(key) ?? 0) + reference.numRows;
+                atlasGaussians.set(key, gaussians);
+                if (batch.length === ErrorRenderer.atlasCapacity(key) || gaussians >= ATLAS_MAX_BATCH_GAUSSIANS) await flush(key);
+            } else {
+                assign(job, levels, await renderer.leafErrors(leaf, numLods));
+            }
         }
-        previous = errors[lod] = Math.max(energy > 0 ? difference / energy : 0, previous);
+        for (const frame of atlases.keys()) await flush(frame);
+    } finally {
+        bar.end();
     }
-
-    return errors;
 };
 
 /**
@@ -659,12 +619,14 @@ const writeLodSource = async (options: WriteLodSourceOptions, fs: FileSystem) =>
     // Pool for slim extraction read buffers and the chunk-native SOG encodes.
     const pool = createChunkDataPool();
 
-    // The error tables are rendered, so they need the GPU. Acquired up front: the
-    // partition pass below computes them leaf by leaf.
+    // The error tables are rendered, so they need the GPU. One renderer serves the
+    // whole pass; the partition below computes the tables leaf by leaf.
     const device = createDevice ? await createDevice() : null;
-    if (!device) {
+    const renderer = device ? new ErrorRenderer(device, mainSource.meta.shBands) : null;
+    if (!renderer) {
         logger.info('No GPU device: LOD error tables are not written; the viewer will derive them from splat counts.');
     }
+    const leafJobs: LeafJob[] = [];
 
     const slim = await extractSlim(mainSource, pool);
     const hasEnv = !!envSource && envSource.meta.numGaussians > 0;
@@ -759,12 +721,12 @@ const writeLodSource = async (options: WriteLodSourceOptions, fs: FileSystem) =>
             lodLevels = Math.max(lodLevels, lodValue + 1);
         }
 
-        // Bound and approximation errors over the leaf's full structural LOD data.
+        // Bound over the leaf's full structural LOD data; the error table is filled
+        // in by the pass after the partition, which batches leaves.
         const bound = await calcBound(mainSource, pool, bins, cum, n => chunkingBar.tick(n));
-        if (!device) return { bound, lods };
-
-        const errors = await calcErrors(device, mainSource, pool, slim, bound, bins, cum, numLods);
-        return { bound, lods, errors };
+        const leaf: MetaNode = { bound, lods };
+        if (renderer) leafJobs.push({ node: leaf, bins });
+        return leaf;
     };
 
     let tree: MetaNode;
@@ -772,6 +734,16 @@ const writeLodSource = async (options: WriteLodSourceOptions, fs: FileSystem) =>
         tree = await build(bTree.root);
     } finally {
         chunkingBar.end();
+    }
+
+    if (renderer) {
+        const errorStart = performance.now();
+        try {
+            await runErrorPass(renderer, mainSource, pool, slim, cum, numLods, leafJobs);
+        } finally {
+            renderer.destroy();
+        }
+        logger.info(`LOD error pass: ${((performance.now() - errorStart) / 1000).toFixed(1)}s over ${leafJobs.length} leaves`);
     }
 
     const trimErrors = (node: MetaNode): void => {
@@ -803,7 +775,7 @@ const writeLodSource = async (options: WriteLodSourceOptions, fs: FileSystem) =>
         count: counts.reduce((acc, curr) => acc + curr, 0),
         counts,
         lodLevels,
-        lodErrors: device !== null,
+        lodErrors: renderer !== null,
         ...(hasEnv ? { environment: 'env/meta.json' } : {}),
         filenames,
         tree

--- a/src/lib/writers/write-lod.ts
+++ b/src/lib/writers/write-lod.ts
@@ -511,7 +511,7 @@ const runErrorPass = async (
             const reference = tables.get(levels[0])!;
             const frame = leafViewSize(leaf.bound, reference);
 
-            if (ErrorRenderer.fitsAtlas(frame, leaf)) {
+            if (renderer.fitsAtlas(frame, leaf)) {
                 // Batches are keyed by the frame rounded up to a power of two, so a
                 // scene's leaves fall into a few well-filled batches rather than one
                 // per frame size; a leaf is only ever judged at a frame at least its own.
@@ -521,7 +521,7 @@ const runErrorPass = async (
                 batch.push({ leaf, job });
                 const gaussians = (atlasGaussians.get(key) ?? 0) + reference.numRows;
                 atlasGaussians.set(key, gaussians);
-                if (batch.length === ErrorRenderer.atlasCapacity(key) || gaussians >= ATLAS_MAX_BATCH_GAUSSIANS) await flush(key);
+                if (batch.length === renderer.atlasCapacity(key) || gaussians >= ATLAS_MAX_BATCH_GAUSSIANS) await flush(key);
             } else {
                 assign(job, levels, await renderer.leafErrors(leaf, numLods));
             }

--- a/src/lib/writers/write-lod.ts
+++ b/src/lib/writers/write-lod.ts
@@ -565,11 +565,16 @@ type WriteLodSourceOptions = {
     envSource: ChunkSource | null;
     iterations: number;
     /**
-     * Supplies the GPU the per-leaf error tables are rendered on (and that SOG
-     * encoding uses). Without one the manifest declares `lodErrors: false` and a
-     * consumer falls back to deriving errors from splat counts.
+     * Supplies the GPU that SOG encoding uses and, with `lodErrors`, that the
+     * per-leaf error tables are rendered on.
      */
     createDevice?: DeviceCreator;
+    /**
+     * Render and write the per-leaf error tables. Default false: the manifest then
+     * declares `lodErrors: false` and a consumer derives errors from splat counts.
+     * Needs `createDevice`.
+     */
+    lodErrors?: boolean;
     chunkCount: number;
     chunkExtent: number;
     /**
@@ -602,7 +607,7 @@ type WriteLodSourceOptions = {
  * @ignore
  */
 const writeLodSource = async (options: WriteLodSourceOptions, fs: FileSystem) => {
-    const { filename, envSource, iterations, createDevice, chunkCount, chunkExtent, chunkMin = 8 } = options;
+    const { filename, envSource, iterations, createDevice, chunkCount, chunkExtent, chunkMin = 8, lodErrors = false } = options;
 
     // Bake the pending coordinate-space transform to PLY once, up front, so the
     // partition/bounds passes (extractSlim, calcBound, morton) and the per-unit
@@ -616,11 +621,11 @@ const writeLodSource = async (options: WriteLodSourceOptions, fs: FileSystem) =>
     // Pool for slim extraction read buffers and the chunk-native SOG encodes.
     const pool = createChunkDataPool();
 
-    // The error tables are rendered, so they need the GPU. One renderer serves the
-    // whole pass; the partition below queues the leaves for it. A host without a
-    // usable adapter still gets its LODs, without the tables.
+    // The error tables are opt-in and rendered, so they need the GPU. One renderer
+    // serves the whole pass; the partition below queues the leaves for it. A host
+    // without a usable adapter still gets its LODs, without the tables.
     let device: GraphicsDevice | null = null;
-    if (createDevice) {
+    if (lodErrors && createDevice) {
         try {
             device = await createDevice();
         } catch (err) {
@@ -628,7 +633,7 @@ const writeLodSource = async (options: WriteLodSourceOptions, fs: FileSystem) =>
         }
     }
     const renderer = device ? new ErrorRenderer(device, mainSource.meta.shBands) : null;
-    if (!renderer) {
+    if (lodErrors && !renderer) {
         logger.warn('No GPU device: LOD error tables are not written; the viewer will derive them from splat counts.');
     }
     const leafJobs: LeafJob[] = [];

--- a/test/write-lod.test.mjs
+++ b/test/write-lod.test.mjs
@@ -139,12 +139,29 @@ const writeErrors = async (levels) => {
     return meta.tree.errors;
 };
 
-const makeShTable = (restValue) => {
+// A one-splat table with `count` SH coefficients (9, 24 or 45 for bands 1 to 3),
+// all `restValue` except those in `overrides`.
+const makeShTable = (restValue, count = 9, overrides = {}) => {
     const table = makeTable(1);
-    for (let i = 0; i < 9; i++) {
-        table.addColumn(new Column(`f_rest_${i}`, new Float32Array([restValue])));
+    for (let i = 0; i < count; i++) {
+        table.addColumn(new Column(`f_rest_${i}`, new Float32Array([overrides[i] ?? restValue])));
     }
     return table;
+};
+
+// The error table of a two-level scene whose levels are the given one-splat tables.
+const writeTableErrors = async (tables) => {
+    const fs = new MemoryFileSystem();
+    await writeLodSource({
+        filename: '/scene/lod-meta.json',
+        mainSource: stackLods(tables.map(table => dataTableToChunkSource(table, 1 << 20))),
+        envSource: null,
+        iterations: 1,
+        chunkCount: 1,
+        chunkExtent: 16,
+        createDevice: async () => device
+    }, fs);
+    return JSON.parse(new TextDecoder().decode(fs.results.get('/scene/lod-meta.json'))).tree.errors;
 };
 
 // Build a structural multi-LOD source from per-level row counts (each level a
@@ -293,22 +310,15 @@ describe('writeLodSource: lod-meta.json contract', function () {
 
     it('includes stored spherical harmonics in the LOD error', async function (t) {
         if (!device) return t.skip('no WebGPU adapter available');
-        const fs = new MemoryFileSystem();
-        await writeLodSource({
-            filename: '/scene/lod-meta.json',
-            mainSource: stackLods([
-                dataTableToChunkSource(makeShTable(0), 1 << 20),
-                dataTableToChunkSource(makeShTable(2), 1 << 20)
-            ]),
-            envSource: null,
-            iterations: 1,
-            chunkCount: 1,
-            chunkExtent: 16,
-            createDevice: async () => device
-        }, fs);
+        const errors = await writeTableErrors([makeShTable(0), makeShTable(2)]);
+        assert.ok(errors[1] > 0);
+    });
 
-        const meta = JSON.parse(new TextDecoder().decode(fs.results.get('/scene/lod-meta.json')));
-        assert.ok(meta.tree.errors[1] > 0);
+    it('sees colour held in SH coefficients that vanish on the coordinate axes', async function (t) {
+        if (!device) return t.skip('no WebGPU adapter available');
+        // f_rest_3 is the red channel's xy term, zero in any view along an axis
+        const errors = await writeTableErrors([makeShTable(0, 45), makeShTable(0, 45, { 3: 2 })]);
+        assert.ok(errors[1] > 0, `expected a non-zero error, got ${errors[1]}`);
     });
 
     it('reports no error for a level identical to the finest', async function (t) {
@@ -329,6 +339,13 @@ describe('writeLodSource: lod-meta.json contract', function () {
         if (!device) return t.skip('no WebGPU adapter available');
         const errors = await writeErrors([[{ opacity: 2 }], [{ opacity: -2 }]]);
         assert.ok(errors[1] > 0, `expected a non-zero error, got ${errors[1]}`);
+    });
+
+    it('scores a level that draws where the reference renders nothing', async function (t) {
+        if (!device) return t.skip('no WebGPU adapter available');
+        // opacity logit -10 is under the rasterizer's alpha floor, so the reference is transparent
+        const errors = await writeErrors([[{ opacity: -10 }], [{ opacity: 5 }]]);
+        assert.ok(errors[1] > 0 && Number.isFinite(errors[1]), `expected a positive finite error, got ${errors[1]}`);
     });
 
     it('penalises thinning even when the survivors are identical', async function (t) {

--- a/test/write-lod.test.mjs
+++ b/test/write-lod.test.mjs
@@ -358,7 +358,8 @@ describe('writeLodSource: lod-meta.json contract', function () {
 
     // Non-finite input is rejected up front rather than tolerated: a NaN anywhere
     // in a gaussian would paint NaN into the error renders, and the comparison
-    // would quietly absorb it.
+    // would quietly absorb it. The check runs on the bounds pass, so it holds with
+    // or without a GPU.
     const rejects = [
         ['a NaN scale', { scale: NaN }, /non-finite scale/],
         ['a NaN opacity', { opacity: NaN }, /non-finite opacity/],
@@ -369,8 +370,7 @@ describe('writeLodSource: lod-meta.json contract', function () {
     ];
 
     for (const [label, splat, expected] of rejects) {
-        it(`refuses to write LODs for input with ${label}`, async function (t) {
-            if (!device) return t.skip('no WebGPU adapter available');
+        it(`refuses to write LODs for input with ${label}`, async function () {
             await assert.rejects(() => writeErrors([[{}, splat], [{}]]), (err) => {
                 assert.match(err.message, expected);
                 assert.match(err.message, /--filter-nan/);
@@ -379,15 +379,27 @@ describe('writeLodSource: lod-meta.json contract', function () {
         });
     }
 
-    it('accepts the non-finite values --filter-nan deliberately keeps', async function (t) {
-        if (!device) return t.skip('no WebGPU adapter available');
+    it('accepts the non-finite values --filter-nan deliberately keeps', async function () {
         // a flat splat (scale -Inf) and a fully opaque one (opacity +Inf) survive
         // filterNaN, so the writer must not reject them
         const errors = await writeErrors([[{}, { scale: -Infinity }, { opacity: Infinity }], [{}]]);
-        assert.ok(
-            errors.every(error => Number.isFinite(error) && error >= 0),
-            `expected finite non-negative errors, got ${errors}`
-        );
+        if (device) {
+            assert.ok(
+                errors.every(error => Number.isFinite(error) && error >= 0),
+                `expected finite non-negative errors, got ${errors}`
+            );
+        }
+    });
+
+    it('measures small leaves through the atlas', async function (t) {
+        if (!device) return t.skip('no WebGPU adapter available');
+        // a grid of small splats: every splat is far below half the leaf's bounding
+        // radius, so the leaf is batched into an atlas rather than rendered alone.
+        // Three levels, so the atlas renderer's second slot is reused within a view.
+        const grid = Array.from({ length: 64 }, (_, i) => ({ x: (i % 8) * 0.25, y: Math.floor(i / 8) * 0.25 }));
+        const errors = await writeErrors([grid, grid, grid.filter((_, i) => i % 2 === 0)]);
+        assert.strictEqual(errors[1], 0, `expected no error for an identical level, got ${errors[1]}`);
+        assert.ok(errors[2] > 0 && Number.isFinite(errors[2]), `expected a positive finite error for thinning, got ${errors[2]}`);
     });
 
     it('keeps the error table monotone across levels', async function (t) {

--- a/test/write-lod.test.mjs
+++ b/test/write-lod.test.mjs
@@ -29,9 +29,9 @@ import { encodePlyBinary } from './helpers/test-utils.mjs';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 WebPCodec.wasmUrl = join(__dirname, '..', 'lib', 'webp.wasm');
 
-// The per-leaf error tables are rendered on the GPU; tests that read them skip
-// when no adapter is available, and the header tests assert the declaration
-// matches whether a device was supplied.
+// The per-leaf error tables are opt-in and rendered on the GPU; tests that read
+// them request them and skip when no adapter is available, and the header tests
+// assert the declaration matches whether a device was supplied.
 let device = null;
 
 before(async () => {
@@ -47,7 +47,7 @@ after(() => {
     device?.destroy?.();
 });
 
-const deviceOptions = () => (device ? { createDevice: async () => device } : {});
+const deviceOptions = () => (device ? { createDevice: async () => device, lodErrors: true } : { lodErrors: true });
 
 // Minimal seekable ReadSource over a buffer, for the disk-PLY writeLodSource path.
 class BufferReadSource {
@@ -159,7 +159,8 @@ const writeTableErrors = async (tables) => {
         iterations: 1,
         chunkCount: 1,
         chunkExtent: 16,
-        createDevice: async () => device
+        createDevice: async () => device,
+        lodErrors: true
     }, fs);
     return JSON.parse(new TextDecoder().decode(fs.results.get('/scene/lod-meta.json'))).tree.errors;
 };
@@ -301,11 +302,28 @@ describe('writeLodSource: lod-meta.json contract', function () {
             envSource: null,
             iterations: 1,
             chunkCount: 1,
-            chunkExtent: 16
+            chunkExtent: 16,
+            lodErrors: true
         }, fs);
         const meta = JSON.parse(new TextDecoder().decode(fs.results.get('/scene/lod-meta.json')));
         assert.strictEqual(meta.lodErrors, false);
         assert.ok(!('errors' in meta.tree), 'no per-leaf error table without a GPU');
+    });
+
+    it('omits error tables by default', async function () {
+        const fs = new MemoryFileSystem();
+        await writeLodSource({
+            filename: '/scene/lod-meta.json',
+            mainSource: makeSource([3, 2]),
+            envSource: null,
+            iterations: 1,
+            chunkCount: 1,
+            chunkExtent: 16,
+            ...(device ? { createDevice: async () => device } : {})
+        }, fs);
+        const meta = JSON.parse(new TextDecoder().decode(fs.results.get('/scene/lod-meta.json')));
+        assert.strictEqual(meta.lodErrors, false);
+        assert.ok(!('errors' in meta.tree), 'no per-leaf error table unless requested');
     });
 
     it('includes stored spherical harmonics in the LOD error', async function (t) {

--- a/test/write-lod.test.mjs
+++ b/test/write-lod.test.mjs
@@ -8,7 +8,7 @@
 
 import assert from 'node:assert';
 import { dirname, join } from 'node:path';
-import { describe, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import {
@@ -21,13 +21,33 @@ import { bakeTransform, mapSource, stackLods } from '../src/lib/ops/index.js';
 import { readPly } from '../src/lib/readers/read-ply.js';
 import { collectFilesByLod, readLodEnvironmentSource } from '../src/lib/readers/read-lod.js';
 import { createChunkDataPool } from '../src/lib/chunk/index.js';
-import { findNearest, positionsFromSlim, writeLodSource } from '../src/lib/writers/write-lod.js';
+import { positionsFromSlim, writeLodSource } from '../src/lib/writers/write-lod.js';
 import { version } from '../src/lib/version.js';
 
 import { encodePlyBinary } from './helpers/test-utils.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 WebPCodec.wasmUrl = join(__dirname, '..', 'lib', 'webp.wasm');
+
+// The per-leaf error tables are rendered on the GPU; tests that read them skip
+// when no adapter is available, and the header tests assert the declaration
+// matches whether a device was supplied.
+let device = null;
+
+before(async () => {
+    try {
+        const { createDevice } = await import('../src/cli/node-device.js');
+        device = await createDevice();
+    } catch {
+        device = null;
+    }
+});
+
+after(() => {
+    device?.destroy?.();
+});
+
+const deviceOptions = () => (device ? { createDevice: async () => device } : {});
 
 // Minimal seekable ReadSource over a buffer, for the disk-PLY writeLodSource path.
 class BufferReadSource {
@@ -112,7 +132,8 @@ const writeErrors = async (levels) => {
         envSource: null,
         iterations: 1,
         chunkCount: 1,
-        chunkExtent: 16
+        chunkExtent: 16,
+        ...deviceOptions()
     }, fs);
     const meta = JSON.parse(new TextDecoder().decode(fs.results.get('/scene/lod-meta.json')));
     return meta.tree.errors;
@@ -151,7 +172,8 @@ const writeScene = async (levelCounts, envRows) => {
         envSource: envRows > 0 ? dataTableToChunkSource(makeTable(envRows), 1 << 20) : null,
         iterations: 1,
         chunkCount: 1,
-        chunkExtent: 16
+        chunkExtent: 16,
+        ...deviceOptions()
     }, fs);
     const meta = JSON.parse(new TextDecoder().decode(fs.results.get('/scene/lod-meta.json')));
     return { fs, meta };
@@ -176,7 +198,7 @@ describe('writeLodSource: lod-meta.json contract', function () {
         assert.strictEqual(meta.count, 5);
         assert.deepStrictEqual(meta.counts, [3, 2]);
         assert.strictEqual(meta.lodLevels, 2);
-        assert.strictEqual(meta.lodErrors, true, 'error tables are declared in the header');
+        assert.strictEqual(meta.lodErrors, device !== null, 'error tables are declared exactly when a GPU rendered them');
         assert.ok(!('environment' in meta), 'environment omitted when there are no environment splats');
         assert.deepStrictEqual([...meta.filenames].sort(), ['0_0/meta.json', '1_0/meta.json']);
 
@@ -191,9 +213,13 @@ describe('writeLodSource: lod-meta.json contract', function () {
             { offset: meta.tree.lods['1'].offset, count: meta.tree.lods['1'].count },
             { offset: 0, count: 2 }
         );
-        assert.strictEqual(meta.tree.errors.length, 2);
-        assert.strictEqual(meta.tree.errors[0], 0);
-        assert.ok(Number.isFinite(meta.tree.errors[1]) && meta.tree.errors[1] >= 0);
+        if (device) {
+            assert.strictEqual(meta.tree.errors.length, 2);
+            assert.strictEqual(meta.tree.errors[0], 0);
+            assert.ok(Number.isFinite(meta.tree.errors[1]) && meta.tree.errors[1] >= 0);
+        } else {
+            assert.ok(!('errors' in meta.tree), 'no per-leaf error table without a GPU');
+        }
 
         assert.ok(fs.results.has('/scene/0_0/meta.json'));
         assert.ok(fs.results.has('/scene/1_0/meta.json'));
@@ -202,43 +228,27 @@ describe('writeLodSource: lod-meta.json contract', function () {
     it('matches errors to lodLevels when trailing structural LODs are empty', async function () {
         const { meta } = await writeScene([1, 0], 0);
         assert.strictEqual(meta.lodLevels, 1);
-        assert.deepStrictEqual(meta.tree.errors, [0]);
+        if (device) assert.deepStrictEqual(meta.tree.errors, [0]);
         assert.doesNotThrow(() => collectFilesByLod(meta, '/scene/lod-meta.json'));
     });
 
-    it('prunes KNN traversal when a target LOD contains fewer than k splats', function () {
-        let farLeafVisits = 0;
-        const nearLeaf = {
-            count: 2,
-            aabb: { min: [0, 0, 0], max: [0, 0, 0] },
-            indices: Uint32Array.of(0, 2)
-        };
-        const farLeaf = {
-            count: 1,
-            aabb: { min: [1000, 0, 0], max: [1000, 0, 0] },
-            get indices() {
-                farLeafVisits++;
-                return Uint32Array.of(1);
-            }
-        };
-        const root = {
-            count: 3,
-            aabb: { min: [0, 0, 0], max: [1000, 0, 0] },
-            left: nearLeaf,
-            right: farLeaf
-        };
-        const slim = {
-            x: Float32Array.of(0, 1000, 0),
-            y: new Float32Array(3),
-            z: new Float32Array(3)
-        };
-
-        const [result] = findNearest(root, slim, Uint32Array.of(0), Int32Array.of(2, 3), 4);
-        assert.deepStrictEqual(result, Int32Array.of(2, -1, -1, -1));
-        assert.strictEqual(farLeafVisits, 0);
+    it('omits error tables when no GPU device is supplied', async function () {
+        const fs = new MemoryFileSystem();
+        await writeLodSource({
+            filename: '/scene/lod-meta.json',
+            mainSource: makeSource([3, 2]),
+            envSource: null,
+            iterations: 1,
+            chunkCount: 1,
+            chunkExtent: 16
+        }, fs);
+        const meta = JSON.parse(new TextDecoder().decode(fs.results.get('/scene/lod-meta.json')));
+        assert.strictEqual(meta.lodErrors, false);
+        assert.ok(!('errors' in meta.tree), 'no per-leaf error table without a GPU');
     });
 
-    it('includes stored spherical harmonics in the LOD error', async function () {
+    it('includes stored spherical harmonics in the LOD error', async function (t) {
+        if (!device) return t.skip('no WebGPU adapter available');
         const fs = new MemoryFileSystem();
         await writeLodSource({
             filename: '/scene/lod-meta.json',
@@ -249,54 +259,57 @@ describe('writeLodSource: lod-meta.json contract', function () {
             envSource: null,
             iterations: 1,
             chunkCount: 1,
-            chunkExtent: 16
+            chunkExtent: 16,
+            createDevice: async () => device
         }, fs);
 
         const meta = JSON.parse(new TextDecoder().decode(fs.results.get('/scene/lod-meta.json')));
         assert.ok(meta.tree.errors[1] > 0);
     });
 
-    it('reports no error for a level identical to the finest', async function () {
+    it('reports no error for a level identical to the finest', async function (t) {
+        if (!device) return t.skip('no WebGPU adapter available');
         assert.deepStrictEqual(await writeErrors([[{}], [{}]]), [0, 0]);
     });
 
-    it('resolves a sub-sigma displacement', async function () {
-        // half a sigma apart: 1 - exp(-d^2/4) = 0.0606 for the relative field-L2
+    it('grows with displacement', async function (t) {
+        if (!device) return t.skip('no WebGPU adapter available');
         const sigma = Math.exp(-3);
-        const errors = await writeErrors([[{}], [{ x: 0.5 * sigma }]]);
-        assert.ok(errors[1] > 0.05 && errors[1] < 0.07, `expected ~0.0606, got ${errors[1]}`);
+        const small = (await writeErrors([[{}], [{ x: 0.5 * sigma }]]))[1];
+        const large = (await writeErrors([[{}], [{ x: 4 * sigma }]]))[1];
+        assert.ok(small > 0, `expected a non-zero error for a half-sigma shift, got ${small}`);
+        assert.ok(large > small, `expected a larger error for a larger shift, got ${small} then ${large}`);
     });
 
-    it('penalises an opacity drop at identical geometry', async function () {
+    it('penalises an opacity drop at identical geometry', async function (t) {
+        if (!device) return t.skip('no WebGPU adapter available');
         const errors = await writeErrors([[{ opacity: 2 }], [{ opacity: -2 }]]);
-        assert.ok(errors[1] > 0.5, `expected a large error, got ${errors[1]}`);
+        assert.ok(errors[1] > 0, `expected a non-zero error, got ${errors[1]}`);
     });
 
-    it('penalises thinning even when the survivors are identical', async function () {
-        // two coincident splats decimated to one: every nearest-neighbour match
-        // is exact, but the level carries half the alpha mass
+    it('penalises thinning even when the survivors are identical', async function (t) {
+        if (!device) return t.skip('no WebGPU adapter available');
+        // two coincident splats decimated to one: the survivor is exact, but the
+        // level paints less coverage
         const errors = await writeErrors([[{}, {}], [{}]]);
-        assert.ok(Math.abs(errors[1] - 0.5) < 1e-6, `expected 0.5, got ${errors[1]}`);
+        assert.ok(errors[1] > 0, `expected a non-zero error, got ${errors[1]}`);
     });
 
-    // Non-finite geometry is rejected up front rather than tolerated: a NaN scale
-    // or opacity would otherwise poison that splat's footprint mass, and the error
-    // table would quietly claim a coarse level costs nothing.
+    // Non-finite input is rejected up front rather than tolerated: a NaN anywhere
+    // in a gaussian would paint NaN into the error renders, and the comparison
+    // would quietly absorb it.
     const rejects = [
         ['a NaN scale', { scale: NaN }, /non-finite scale/],
         ['a NaN opacity', { opacity: NaN }, /non-finite opacity/],
         ['a NaN position', { x: NaN }, /non-finite position/],
         ['a NaN rotation', { rot_0: NaN }, /non-finite rotation/],
         ['a zero-norm rotation', { rot_0: 0 }, /zero-norm rotation/],
-        // a NaN colour makes splatError NaN for every pair the splat is in, and
-        // directional discards NaN matches — so the more of a level is broken, the
-        // less error it reports. Left unchecked, two displaced levels whose colours
-        // are NaN report error 0 and the engine drops the finer one.
         ['a NaN color', { f_dc: NaN }, /non-finite color or SH/]
     ];
 
     for (const [label, splat, expected] of rejects) {
-        it(`refuses to write LODs for input with ${label}`, async function () {
+        it(`refuses to write LODs for input with ${label}`, async function (t) {
+            if (!device) return t.skip('no WebGPU adapter available');
             await assert.rejects(() => writeErrors([[{}, splat], [{}]]), (err) => {
                 assert.match(err.message, expected);
                 assert.match(err.message, /--filter-nan/);
@@ -305,7 +318,8 @@ describe('writeLodSource: lod-meta.json contract', function () {
         });
     }
 
-    it('accepts the non-finite values --filter-nan deliberately keeps', async function () {
+    it('accepts the non-finite values --filter-nan deliberately keeps', async function (t) {
+        if (!device) return t.skip('no WebGPU adapter available');
         // a flat splat (scale -Inf) and a fully opaque one (opacity +Inf) survive
         // filterNaN, so the writer must not reject them
         const errors = await writeErrors([[{}, { scale: -Infinity }, { opacity: Infinity }], [{}]]);
@@ -315,7 +329,8 @@ describe('writeLodSource: lod-meta.json contract', function () {
         );
     });
 
-    it('keeps the error table monotone across levels', async function () {
+    it('keeps the error table monotone across levels', async function (t) {
+        if (!device) return t.skip('no WebGPU adapter available');
         // level 2 matches a level-0 splat exactly while level 1 sits between
         // both, so the raw errors would rank the coarser level as the better one
         const errors = await writeErrors([[{ x: 0 }, { x: 1 }], [{ x: 0.5 }], [{ x: 0 }]]);


### PR DESCRIPTION
Fixes: #310

Replaces the per-leaf LOD error metric in the LOD writer with a rendered one. Each level of a leaf is drawn from six fixed directions against a transparent background and scored as the summed squared RGBA difference from the finest level, relative to that level's own energy. Comparing composited images means a merge that paints the same pixels costs nothing while thinning, blur and colour drift register in proportion to how visible they are, which the previous nearest-neighbour field-L2 metric could not express once splats stopped overlapping their matches.

Small leaves are batched: each is normalised to unit radius and packed into its own cell of a large atlas rendered once per level per view, so the pass is priced by GPU round trips rather than by leaf count. Leaves with large splats, many gaussians or a big frame are still rendered alone.

The rasterizer gains what a long-lived instance serving tens of thousands of renders needs: a `setView` to change camera per render, multiple in-flight running-state/output slots, an optional `radiusFade` off switch so a splat that legitimately fills a leaf's frame keeps full alpha, a GPU clear-state shader replacing the CPU upload, and a sort key width derived from the radix sort's reported pass width. The chunk-cap arithmetic is shared with the image writer via `rasterChunkCap`.

Error tables now require a GPU. Without a device the writer warns, skips the pass and writes `lodErrors: false` so the viewer derives errors from splat counts. Colour finiteness is checked in the bounds pass so validation holds either way. The old KNN and closed-form error code is removed.

Tests create a device up front, skip error-value tests without an adapter, and replace the previous exact numeric expectations with ordinal checks. New tests cover the no-GPU path, SH terms that vanish on the coordinate axes, a transparent reference and the atlas path.